### PR TITLE
Add public BragStack share page API

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.auth_routes import router as auth_router
-from app.routes import router as entries_router
+from app.routes import public_router, router as entries_router
 
 app = FastAPI(
     title="BragStack API",
@@ -15,6 +15,7 @@ app.add_middleware(
     allow_origins=[
         "http://localhost:5173",
         "http://127.0.0.1:5173",
+        "https://congenial-space-orbit-g5pwgj56pg73w7vg-5173.app.github.dev",
     ],
     allow_credentials=True,
     allow_methods=["*"],
@@ -23,6 +24,7 @@ app.add_middleware(
 
 app.include_router(auth_router)
 app.include_router(entries_router)
+app.include_router(public_router)
 
 
 @app.get("/")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -16,6 +16,7 @@ class BragEntryCreate(BaseModel):
     impact: str = Field(..., examples=["Found incorrect hostname and restored connectivity."])
     lesson: Optional[str] = Field(None, examples=["Docker Compose DNS uses service names."])
     tags: list[str] = Field(default_factory=list, examples=[["Docker", "Networking", "Compose"]])
+    is_public: bool = Field(default=False, examples=[True])
 
 
 class BragEntryResponse(BaseModel):
@@ -24,10 +25,13 @@ class BragEntryResponse(BaseModel):
     id: str
     title: str
     category: str
+    entry_date: str
+    entry_type: str
     situation: str
     action: str
     impact: str
     lesson: Optional[str]
     tags: list[str]
+    is_public: bool = False
     resume_bullet: str
     created_at: datetime

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -8,6 +8,7 @@ from app.database import entries_collection
 from app.models import BragEntryCreate
 
 router = APIRouter(prefix="/entries", tags=["entries"])
+public_router = APIRouter(prefix="/public", tags=["public"])
 
 
 def get_user_id(current_user: dict) -> str:
@@ -395,3 +396,124 @@ def delete_entry(
         raise HTTPException(status_code=404, detail="Entry not found")
 
     return {"message": "Entry deleted"}
+
+@public_router.get("/brag")
+def get_public_brag_entries():
+    """Return public brag entries for the shareable interviewer page.
+
+    Returns:
+        A dictionary containing the total number of public entries, the entries,
+        and a status message.
+    """
+    entries = [
+        serialize_entry(entry)
+        for entry in entries_collection.find({"is_public": True}).sort("created_at", -1)
+    ]
+
+    return {
+        "total_entries": len(entries),
+        "entries": entries,
+        "message": (
+            "No public entries yet."
+            if not entries
+            else "Public brag entries loaded successfully."
+        ),
+    }
+
+
+@public_router.get("/brag/reports/weekly")
+def get_public_weekly_report():
+    """Generate a public report from public brag entries.
+
+    Returns:
+        A dictionary containing public entry counts, category totals, tag totals,
+        resume bullets, and a status message.
+    """
+    entries = list(entries_collection.find({"is_public": True}).sort("created_at", -1))
+
+    categories = {}
+    tags = {}
+    resume_bullets = []
+
+    for entry in entries:
+        category = entry.get("category", "Uncategorized")
+        categories[category] = categories.get(category, 0) + 1
+
+        for tag in entry.get("tags", []):
+            tags[tag] = tags.get(tag, 0) + 1
+
+        if entry.get("resume_bullet"):
+            resume_bullets.append(entry["resume_bullet"])
+
+    return {
+        "period": "public_entries",
+        "total_entries": len(entries),
+        "categories": categories,
+        "top_tags": tags,
+        "resume_bullets": resume_bullets,
+        "message": (
+            "No public entries yet."
+            if not entries
+            else "Public report generated successfully."
+        ),
+    }
+
+
+@public_router.get("/brag/tags/summary")
+def get_public_tags_summary():
+    """Generate a tag summary from public brag entries.
+
+    Returns:
+        A dictionary containing public tag counts and a status message.
+    """
+    entries = entries_collection.find({"is_public": True})
+
+    tag_counts = {}
+
+    for entry in entries:
+        for tag in entry.get("tags", []):
+            tag_counts[tag] = tag_counts.get(tag, 0) + 1
+
+    sorted_tag_counts = dict(
+        sorted(tag_counts.items(), key=lambda item: item[1], reverse=True)
+    )
+
+    return {
+        "total_unique_tags": len(sorted_tag_counts),
+        "tags": sorted_tag_counts,
+        "message": (
+            "No public tags found yet."
+            if not sorted_tag_counts
+            else "Public tag summary generated successfully."
+        ),
+    }
+
+
+@public_router.get("/brag/categories/summary")
+def get_public_categories_summary():
+    """Generate a category summary from public brag entries.
+
+    Returns:
+        A dictionary containing public category counts and a status message.
+    """
+    entries = entries_collection.find({"is_public": True})
+
+    category_counts = {}
+
+    for entry in entries:
+        category = entry.get("category", "Uncategorized")
+        category_counts[category] = category_counts.get(category, 0) + 1
+
+    sorted_category_counts = dict(
+        sorted(category_counts.items(), key=lambda item: item[1], reverse=True)
+    )
+
+    return {
+        "total_unique_categories": len(sorted_category_counts),
+        "categories": sorted_category_counts,
+        "message": (
+            "No public categories found yet."
+            if not sorted_category_counts
+            else "Public category summary generated successfully."
+        ),
+    }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -15,6 +15,10 @@ import {
   loginUser,
   registerUser,
   updateEntry,
+  getPublicEntries,
+  getPublicWeeklyReport,
+  getPublicTagsSummary,
+  getPublicCategoriesSummary,
 } from "./api";
 import "./App.css";
 

--- a/frontend/src/PublicBragPage.jsx
+++ b/frontend/src/PublicBragPage.jsx
@@ -1,10 +1,10 @@
 import { useEffect, useMemo, useState } from "react";
 import { ExternalLink, Code2, Search } from "lucide-react";
 import {
-  getCategoriesSummary,
-  getEntries,
-  getTagsSummary,
-  getWeeklyReport,
+  getPublicCategoriesSummary,
+  getPublicEntries,
+  getPublicTagsSummary,
+  getPublicWeeklyReport,
 } from "./api";
 
 import "./PublicBragPage.css";
@@ -52,26 +52,26 @@ function PublicBragPage() {
   const [isOffline, setIsOffline] = useState(false);
 
   useEffect(() => {
-    async function loadPublicPage() {
-      try {
-        const [entriesData, weeklyData, tagsData, categoriesData] =
-          await Promise.all([
-            getEntries(),
-            getWeeklyReport(),
-            getTagsSummary(),
-            getCategoriesSummary(),
-          ]);
+  async function loadPublicPage() {
+    try {
+      const [entriesData, weeklyData, tagsData, categoriesData] =
+        await Promise.all([
+          getPublicEntries(),
+          getPublicWeeklyReport(),
+          getPublicTagsSummary(),
+          getPublicCategoriesSummary(),
+        ]);
 
-        setEntries(entriesData?.entries ?? []);
-        setWeeklyReport(weeklyData);
-        setTagsSummary(tagsData);
-        setCategoriesSummary(categoriesData);
-        setIsOffline(false);
-      } catch (err) {
-        console.error("PublicBragPage failed to load:", err);
-        setIsOffline(true);
-      }
+      setEntries(entriesData.entries || []);
+      setWeeklyReport(weeklyData);
+      setTagsSummary(tagsData);
+      setCategoriesSummary(categoriesData);
+      setIsPreviewMode(false);
+    } catch (err) {
+      console.error("Failed to load public BragStack page:", err);
+      setIsPreviewMode(true);
     }
+  }
 
     loadPublicPage();
   }, []);

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -76,3 +76,23 @@ export async function deleteEntry(entryId) {
   const response = await api.delete(`/entries/${entryId}`);
   return response.data;
 }
+
+export async function getPublicEntries() {
+  const response = await api.get("/public/brag");
+  return response.data;
+}
+
+export async function getPublicWeeklyReport() {
+  const response = await api.get("/public/brag/reports/weekly");
+  return response.data;
+}
+
+export async function getPublicTagsSummary() {
+  const response = await api.get("/public/brag/tags/summary");
+  return response.data;
+}
+
+export async function getPublicCategoriesSummary() {
+  const response = await api.get("/public/brag/categories/summary");
+  return response.data;
+}


### PR DESCRIPTION
## Summary

- Added public backend endpoints for the shareable BragStack interviewer page
- Added `is_public` support to brag entries so selected entries can be shown publicly
- Updated the public BragStack frontend page to use public read-only API calls instead of private authenticated dashboard endpoints
- Updated CORS configuration so the Codespaces frontend can call the Codespaces backend

## Testing

- Verified `/public/brag` returns public entries without authentication
- Verified the `/brag` frontend page loads live public BragStack data
- Confirmed the page no longer falls back to preview mode after public API/CORS fixes