### PR TITLE
Add slug-based public brag endpoints

### DIFF
--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -75,10 +75,11 @@ def serialize_user(user: dict) -> dict:
         A dictionary containing safe user fields.
     """
     return {
-        "id": str(user["_id"]),
-        "name": user.get("name", ""),
-        "email": user.get("email", ""),
-        "created_at": user.get("created_at"),
+    "id": str(user["_id"]),
+    "name": user.get("name", ""),
+    "email": user.get("email", ""),
+    "public_slug": user.get("public_slug", ""),
+    "created_at": user.get("created_at"),
     }
 
 

--- a/backend/app/auth_routes.py
+++ b/backend/app/auth_routes.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timezone
+import re
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.security import OAuth2PasswordRequestForm
@@ -41,6 +42,23 @@ class LoginRequest(BaseModel):
     email: EmailStr
     password: str
 
+def slugify(value: str) -> str:
+    """Convert a display name into a URL-safe slug."""
+    slug = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+    return slug or "user"
+
+
+def generate_unique_public_slug(name: str) -> str:
+    """Generate a unique public profile slug for a new user."""
+    base_slug = slugify(name)
+    slug = base_slug
+    counter = 2
+
+    while users_collection.find_one({"public_slug": slug}):
+        slug = f"{base_slug}-{counter}"
+        counter += 1
+
+    return slug
 
 @router.post("/register")
 def register_user(payload: RegisterRequest):
@@ -66,11 +84,12 @@ def register_user(payload: RegisterRequest):
         )
 
     user_doc = {
-        "name": payload.name.strip(),
-        "email": normalized_email,
-        "hashed_password": hash_password(payload.password),
-        "created_at": datetime.now(timezone.utc).isoformat(),
-    }
+    "name": payload.name.strip(),
+    "email": normalized_email,
+    "public_slug": generate_unique_public_slug(payload.name),
+    "hashed_password": hash_password(payload.password),
+    "created_at": datetime.now(timezone.utc).isoformat(),
+}
 
     result = users_collection.insert_one(user_doc)
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.auth_routes import router as auth_router
+from app.public_slug_routes import router as public_slug_router
 from app.routes import public_router, router as entries_router
 
 app = FastAPI(
@@ -25,6 +26,7 @@ app.add_middleware(
 app.include_router(auth_router)
 app.include_router(entries_router)
 app.include_router(public_router)
+app.include_router(public_slug_router)
 
 
 @app.get("/")

--- a/backend/app/public_slug_routes.py
+++ b/backend/app/public_slug_routes.py
@@ -1,0 +1,153 @@
+from datetime import datetime, timedelta, timezone
+
+from fastapi import APIRouter, HTTPException
+
+from app.database import entries_collection, users_collection
+
+
+router = APIRouter(prefix="/public", tags=["public"])
+
+
+def normalize_slug(slug: str) -> str:
+    """Normalize a public profile slug for lookup."""
+    return slug.strip().lower()
+
+
+def serialize_entry(entry: dict) -> dict:
+    """Convert a MongoDB brag entry document into an API response dictionary."""
+    return {
+        "id": str(entry["_id"]),
+        "title": entry.get("title", ""),
+        "description": entry.get("description", ""),
+        "category": entry.get("category", ""),
+        "tags": entry.get("tags", []),
+        "resume_bullet": entry.get("resume_bullet", ""),
+        "is_public": entry.get("is_public", False),
+        "created_at": entry.get("created_at"),
+        "updated_at": entry.get("updated_at"),
+    }
+
+
+def get_user_by_public_slug(slug: str) -> dict:
+    """Find a user by their public slug."""
+    normalized_slug = normalize_slug(slug)
+
+    user = users_collection.find_one(
+        {
+            "$or": [
+                {"public_slug": normalized_slug},
+                {"slug": normalized_slug},
+                {"username": normalized_slug},
+            ]
+        }
+    )
+
+    if user is None:
+        raise HTTPException(status_code=404, detail="Public profile not found")
+
+    return user
+
+
+def get_public_entry_query(slug: str) -> dict:
+    """Build the base public-entry query for a slug."""
+    user = get_user_by_public_slug(slug)
+
+    return {
+        "user_id": str(user["_id"]),
+        "is_public": True,
+    }
+
+
+@router.get("/brag/{slug}")
+def get_public_brag_entries_by_slug(slug: str):
+    """Return public brag entries for a specific user's public profile."""
+    query = get_public_entry_query(slug)
+
+    entries = [
+        serialize_entry(entry)
+        for entry in entries_collection.find(query).sort("created_at", -1)
+    ]
+
+    return {
+        "slug": normalize_slug(slug),
+        "total_entries": len(entries),
+        "entries": entries,
+        "message": (
+            "No public entries yet."
+            if not entries
+            else "Public brag entries loaded successfully."
+        ),
+    }
+
+
+@router.get("/brag/{slug}/reports/weekly")
+def get_public_weekly_report_by_slug(slug: str):
+    """Generate a weekly public report for a specific user's public profile."""
+    query = get_public_entry_query(slug)
+
+    week_start = datetime.now(timezone.utc) - timedelta(days=7)
+    query["created_at"] = {"$gte": week_start.isoformat()}
+
+    entries = list(entries_collection.find(query).sort("created_at", -1))
+
+    categories = {}
+    tags = {}
+    resume_bullets = []
+
+    for entry in entries:
+        category = entry.get("category", "Uncategorized")
+        categories[category] = categories.get(category, 0) + 1
+
+        for tag in entry.get("tags", []):
+            tags[tag] = tags.get(tag, 0) + 1
+
+        if entry.get("resume_bullet"):
+            resume_bullets.append(entry["resume_bullet"])
+
+    sorted_tags = dict(sorted(tags.items(), key=lambda item: item[1], reverse=True))
+    sorted_categories = dict(
+        sorted(categories.items(), key=lambda item: item[1], reverse=True)
+    )
+
+    return {
+        "slug": normalize_slug(slug),
+        "period": "last_7_days",
+        "total_entries": len(entries),
+        "categories": sorted_categories,
+        "top_tags": sorted_tags,
+        "resume_bullets": resume_bullets,
+        "message": (
+            "No public entries found for this week."
+            if not entries
+            else "Public weekly report generated successfully."
+        ),
+    }
+
+
+@router.get("/brag/{slug}/tags/summary")
+def get_public_tags_summary_by_slug(slug: str):
+    """Generate a public tag summary for a specific user's public profile."""
+    query = get_public_entry_query(slug)
+
+    entries = entries_collection.find(query)
+
+    tag_counts = {}
+
+    for entry in entries:
+        for tag in entry.get("tags", []):
+            tag_counts[tag] = tag_counts.get(tag, 0) + 1
+
+    sorted_tag_counts = dict(
+        sorted(tag_counts.items(), key=lambda item: item[1], reverse=True)
+    )
+
+    return {
+        "slug": normalize_slug(slug),
+        "total_unique_tags": len(sorted_tag_counts),
+        "tags": sorted_tag_counts,
+        "message": (
+            "No public tags found yet."
+            if not sorted_tag_counts
+            else "Public tag summary generated successfully."
+        ),
+    }

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,3 +9,4 @@ python-multipart
 email-validator
 pytest
 httpx
+mongomock

--- a/backend/tests/test_public_routes.py
+++ b/backend/tests/test_public_routes.py
@@ -1,9 +1,32 @@
+from datetime import datetime, timezone
+from uuid import uuid4
+
+import mongomock
+import pytest
 from fastapi.testclient import TestClient
 
+import app.public_slug_routes as public_slug_routes
+import app.routes as routes
 from app.main import app
 
 
 client = TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def use_mock_database(monkeypatch):
+    """Use an in-memory MongoDB replacement for public route tests."""
+    mock_client = mongomock.MongoClient()
+    mock_db = mock_client["bragstack_test"]
+
+    mock_entries_collection = mock_db["entries"]
+    mock_users_collection = mock_db["users"]
+
+    monkeypatch.setattr(routes, "entries_collection", mock_entries_collection)
+    monkeypatch.setattr(public_slug_routes, "entries_collection", mock_entries_collection)
+    monkeypatch.setattr(public_slug_routes, "users_collection", mock_users_collection)
+
+    yield
 
 
 def test_root_returns_health_message():
@@ -26,3 +49,178 @@ def test_public_brag_route_returns_public_payload():
     assert "entries" in data
     assert "message" in data
     assert isinstance(data["entries"], list)
+
+
+def test_public_brag_slug_route_returns_only_that_users_public_entries():
+    """Verify slug public brag route only returns public entries for that user."""
+    slug = f"test-user-{uuid4().hex[:8]}"
+
+    user_result = public_slug_routes.users_collection.insert_one(
+        {
+            "name": "Test User",
+            "email": f"{slug}@example.com",
+            "public_slug": slug,
+            "hashed_password": "unused",
+            "created_at": datetime.now(timezone.utc),
+        }
+    )
+
+    other_user_result = public_slug_routes.users_collection.insert_one(
+        {
+            "name": "Other User",
+            "email": f"other-{slug}@example.com",
+            "public_slug": f"other-{slug}",
+            "hashed_password": "unused",
+            "created_at": datetime.now(timezone.utc),
+        }
+    )
+
+    public_slug_routes.entries_collection.insert_many(
+        [
+            {
+                "user_id": str(user_result.inserted_id),
+                "title": "Visible win",
+                "description": "This should show up.",
+                "category": "Support",
+                "tags": ["docker", "customer"],
+                "resume_bullet": "Resolved a customer Docker issue.",
+                "is_public": True,
+                "created_at": datetime.now(timezone.utc),
+                "updated_at": datetime.now(timezone.utc),
+            },
+            {
+                "user_id": str(user_result.inserted_id),
+                "title": "Private win",
+                "description": "This should not show up.",
+                "category": "Private",
+                "tags": ["secret"],
+                "resume_bullet": "",
+                "is_public": False,
+                "created_at": datetime.now(timezone.utc),
+                "updated_at": datetime.now(timezone.utc),
+            },
+            {
+                "user_id": str(other_user_result.inserted_id),
+                "title": "Other user win",
+                "description": "This should not show up.",
+                "category": "Other",
+                "tags": ["other"],
+                "resume_bullet": "",
+                "is_public": True,
+                "created_at": datetime.now(timezone.utc),
+                "updated_at": datetime.now(timezone.utc),
+            },
+        ]
+    )
+
+    response = client.get(f"/public/brag/{slug}")
+
+    assert response.status_code == 200
+
+    data = response.json()
+
+    assert data["slug"] == slug
+    assert data["total_entries"] == 1
+    assert data["entries"][0]["title"] == "Visible win"
+
+
+def test_public_weekly_report_slug_route_returns_summary():
+    """Verify slug public weekly report returns summary data for that user."""
+    slug = f"weekly-user-{uuid4().hex[:8]}"
+
+    user_result = public_slug_routes.users_collection.insert_one(
+        {
+            "name": "Weekly User",
+            "email": f"{slug}@example.com",
+            "public_slug": slug,
+            "hashed_password": "unused",
+            "created_at": datetime.now(timezone.utc),
+        }
+    )
+
+    public_slug_routes.entries_collection.insert_one(
+        {
+            "user_id": str(user_result.inserted_id),
+            "title": "Weekly win",
+            "description": "This should appear in weekly summary.",
+            "category": "Engineering",
+            "tags": ["python", "api"],
+            "resume_bullet": "Built a public API endpoint.",
+            "is_public": True,
+            "created_at": datetime.now(timezone.utc).isoformat(),
+            "updated_at": datetime.now(timezone.utc).isoformat(),
+        }
+    )
+
+    response = client.get(f"/public/brag/{slug}/reports/weekly")
+
+    assert response.status_code == 200
+
+    data = response.json()
+
+    assert data["slug"] == slug
+    assert data["period"] == "last_7_days"
+    assert data["total_entries"] == 1
+    assert data["categories"] == {"Engineering": 1}
+    assert data["top_tags"] == {"python": 1, "api": 1}
+    assert data["resume_bullets"] == ["Built a public API endpoint."]
+
+
+def test_public_tags_summary_slug_route_returns_tags():
+    """Verify slug public tags summary returns tag counts for that user."""
+    slug = f"tags-user-{uuid4().hex[:8]}"
+
+    user_result = public_slug_routes.users_collection.insert_one(
+        {
+            "name": "Tags User",
+            "email": f"{slug}@example.com",
+            "public_slug": slug,
+            "hashed_password": "unused",
+            "created_at": datetime.now(timezone.utc),
+        }
+    )
+
+    public_slug_routes.entries_collection.insert_many(
+        [
+            {
+                "user_id": str(user_result.inserted_id),
+                "title": "Tag win one",
+                "description": "First tag win.",
+                "category": "Support",
+                "tags": ["docker", "api"],
+                "resume_bullet": "",
+                "is_public": True,
+                "created_at": datetime.now(timezone.utc),
+                "updated_at": datetime.now(timezone.utc),
+            },
+            {
+                "user_id": str(user_result.inserted_id),
+                "title": "Tag win two",
+                "description": "Second tag win.",
+                "category": "Support",
+                "tags": ["docker"],
+                "resume_bullet": "",
+                "is_public": True,
+                "created_at": datetime.now(timezone.utc),
+                "updated_at": datetime.now(timezone.utc),
+            },
+        ]
+    )
+
+    response = client.get(f"/public/brag/{slug}/tags/summary")
+
+    assert response.status_code == 200
+
+    data = response.json()
+
+    assert data["slug"] == slug
+    assert data["total_unique_tags"] == 2
+    assert data["tags"] == {"docker": 2, "api": 1}
+
+
+def test_public_brag_slug_route_returns_404_for_missing_profile():
+    """Verify unknown public profile slugs return 404."""
+    response = client.get("/public/brag/profile-that-does-not-exist")
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Public profile not found"


### PR DESCRIPTION
## Summary
- Adds slug-based public brag profile endpoints
- Adds weekly report endpoint by public slug
- Adds tags summary endpoint by public slug
- Adds backend tests for public slug routes

## Test
- `pytest`