### PR TITLE
Feature/impact receipts v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,37 +1,275 @@
 # BragStack
 
-BragStack is a SaaS-style career proof tracker that helps technical workers log wins, track skills, generate resume-ready bullets, and summarize weekly progress.
+> **Don’t just claim your impact. Stack the proof.**
 
-It is built with FastAPI, MongoDB, Docker, and Docker Compose, with Kubernetes support planned as the project grows.
+BragStack is a career-proof platform that helps people document their work, preserve evidence of their contributions, and turn real accomplishments into useful career materials.
+
+Users can record wins throughout the year, organize measurable impact, publish selected accomplishments, and maintain a portable professional record.
+
+BragStack is evolving around a core concept called **Impact Receipts**: structured, evidence-backed records showing what someone contributed, what changed, and why it mattered.
+
+---
 
 ## Why BragStack?
 
-Technical workers often solve meaningful problems every day but forget the details when it is time to update a resume, prepare for interviews, ask for a raise, or explain their impact.
+Important work is often forgotten, overlooked, or difficult to reconstruct later.
 
-BragStack helps users turn daily work into career evidence.
+People regularly struggle to remember specific examples when preparing for:
+
+- Promotions
+- Performance reviews
+- Interviews
+- One-on-one meetings
+- Client reports
+- Résumé updates
+- Portfolio updates
+- Career transitions
+
+BragStack helps users capture accomplishments while the details are still fresh.
+
+Every win can be documented. Significant wins can become **Impact Receipts**.
+
+---
+
+## Who BragStack Is For
+
+### Promotions
+
+Walk into promotion conversations with organized proof of impact, growth, ownership, and added responsibilities.
+
+### Interviews
+
+Turn real accomplishments into confident interview stories instead of trying to remember examples under pressure.
+
+### Performance Reviews
+
+Build a review throughout the year instead of reconstructing twelve months of work the night before.
+
+### One-on-One Meetings
+
+Bring wins, blockers, lessons, and progress into conversations with managers.
+
+### Trainers and Clients
+
+Document milestones, completed goals, progress, and measurable results over time.
+
+### Freelancers and Consultants
+
+Turn completed projects into client updates, case studies, testimonials, and proof of value.
+
+### Students and Career Changers
+
+Track projects, certifications, new skills, and portfolio evidence while developing a career.
+
+### Creators and Founders
+
+Capture launches, experiments, customer wins, audience growth, partnerships, and business milestones.
+
+---
 
 ## Current Features
 
-- Create brag entries
-- List all brag entries
-- View a single brag entry
-- Update brag entries
-- Delete brag entries
-- Generate resume-style bullets
-- Generate weekly progress reports
-- Track categories and skill tags
-- Run locally with Docker Compose
-- Store data in MongoDB
+### Accounts and Profiles
 
-## Tech Stack
+- User registration and login
+- JWT-based authentication
+- User-owned private data
+- Editable professional profiles
+- Professional headline and biography
+- Location
+- GitHub, portfolio, and résumé links
+- Unique public profile URLs
+
+### Accomplishment Tracking
+
+- Create brag entries
+- Edit existing entries
+- Delete entries
+- Categorize accomplishments
+- Add entry dates and entry types
+- Record situation, action, impact, and lessons
+- Add skill tags
+- Mark entries as public or private
+- Generate résumé-style accomplishment bullets
+
+### Reports and Summaries
+
+- Weekly accomplishment reports
+- Skill-tag summaries
+- Category summaries
+- Recent accomplishment dashboard
+
+### Public Career Proof
+
+- Public BragStack profiles
+- Public-only accomplishment filtering
+- Shareable profile URLs
+- Public and private visibility controls
+
+### Product Experience
+
+- Marketing landing page
+- Responsive React interface
+- Docker Compose development environment
+- FastAPI interactive API documentation
+
+---
+
+## Impact Receipts
+
+Impact Receipts are the planned core feature of BragStack.
+
+An Impact Receipt is a structured record of a meaningful contribution.
+
+```text
+IMPACT RECEIPT
+
+Accomplishment:
+Prevented a recurring Docker DNS outage
+
+My contribution:
+Identified the networking regression and created the fix
+
+Result:
+Reduced repeat escalations by 35%
+
+Evidence:
+✓ Support incident
+✓ Pull request
+✓ Internal documentation
+✓ Customer feedback
+
+Skills demonstrated:
+Docker Networking · Troubleshooting · Incident Leadership
+
+Credit:
+Tee — Root-cause analysis
+Jordan — Testing
+Maria — Deployment
+
+Confirmed by:
+✓ Collaborator
+✓ Manager
+```
+
+Impact Receipts will help users document:
+
+- What happened
+- What they personally contributed
+- What changed because of the work
+- Which skills were demonstrated
+- What evidence supports the claim
+- Who else contributed
+- Who confirmed the contribution
+
+---
+
+## Impact Receipt Trust Signals
+
+Impact Receipts will support progressive trust signals.
+
+| Trust signal | Meaning |
+|---|---|
+| Self-documented | Entered by the owner |
+| Evidence-linked | Includes tickets, documents, pull requests, feedback, or other evidence |
+| Collaborator-confirmed | A teammate or collaborator confirms the contribution |
+| Stakeholder-verified | A manager, client, instructor, trainer, or other stakeholder verifies the claim |
+| Organization-issued | An organization formally recognizes the accomplishment |
+
+These signals will remain separate so BragStack can clearly communicate what has and has not been verified.
+
+---
+
+## Shared Credit
+
+Real work is collaborative.
+
+BragStack will allow multiple contributors to receive accurate credit for different parts of the same outcome.
+
+```text
+Project outcome:
+Successful production recovery
+
+Tee:
+Diagnosed the production failures
+
+Jordan:
+Implemented and tested the backend fix
+
+Maria:
+Coordinated the customer rollout
+
+Alex:
+Documented the recovery process
+```
+
+Each contributor can receive a related Impact Receipt without claiming the entire project.
+
+---
+
+## Product Model
+
+BragStack follows a simple product flow:
+
+```text
+Brag Entry
+    ↓
+Impact Receipt
+    ↓
+Career Output
+```
+
+### Brag Entry
+
+A fast way to record everyday wins, progress, lessons, and responsibilities.
+
+### Impact Receipt
+
+A significant accomplishment enhanced with evidence, contribution details, shared credit, and verification.
+
+### Career Output
+
+Impact Receipts can later power:
+
+- Promotion packets
+- Performance-review summaries
+- Interview stories
+- Résumé bullets
+- Client reports
+- Case studies
+- Public proof cards
+- Embedded portfolios
+- Team impact dashboards
+
+---
+
+## Technology Stack
+
+### Frontend
+
+- React
+- Vite
+- Axios
+- Lucide React
+- CSS
+
+### Backend
 
 - Python
 - FastAPI
-- MongoDB
+- Pydantic
 - PyMongo
+- JWT authentication
+
+### Data and Infrastructure
+
+- MongoDB
 - Docker
 - Docker Compose
+- GitHub Actions
 - Swagger / OpenAPI
+
+---
 
 ## Project Structure
 
@@ -42,131 +280,231 @@ bragstack/
 │   │   ├── main.py
 │   │   ├── database.py
 │   │   ├── models.py
-│   │   └── routes.py
+│   │   ├── routes.py
+│   │   ├── auth.py
+│   │   ├── auth_routes.py
+│   │   └── public_slug_routes.py
+│   ├── tests/
 │   ├── Dockerfile
 │   └── requirements.txt
+├── frontend/
+│   ├── src/
+│   │   ├── App.jsx
+│   │   ├── App.css
+│   │   ├── api.js
+│   │   ├── AuthPage.jsx
+│   │   ├── LandingPage.jsx
+│   │   └── PublicBragPage.jsx
+│   ├── Dockerfile
+│   └── package.json
 ├── docker-compose.yml
 ├── README.md
 └── .gitignore
 ```
 
-## API Endpoints
+---
 
-| Method | Endpoint | Description |
-|---|---|---|
-| `GET` | `/` | Health check |
-| `POST` | `/entries` | Create a brag entry |
-| `GET` | `/entries` | List all brag entries |
-| `GET` | `/entries/{entry_id}` | View one brag entry |
-| `PUT` | `/entries/{entry_id}` | Update a brag entry |
-| `DELETE` | `/entries/{entry_id}` | Delete a brag entry |
-| `GET` | `/entries/reports/weekly` | Generate a weekly progress report |
+## Run BragStack Locally
 
-## Example Brag Entry
-
-```json
-{
-  "title": "Debugged Docker Compose networking issue",
-  "category": "Docker",
-  "situation": "A service could not connect to MongoDB inside a Docker Compose environment.",
-  "action": "checked container logs, inspected the Compose network, and verified the MongoDB service hostname",
-  "impact": "identified that the app was using localhost instead of the Compose service name",
-  "lesson": "Inside Docker Compose, containers should use service names for DNS resolution.",
-  "tags": ["Docker", "Compose", "Networking", "MongoDB"]
-}
-```
-
-## Example Generated Resume Bullet
-
-```text
-Resolved docker issue involving Docker, Compose, Networking, MongoDB by checked container logs, inspected the Compose network, and verified the MongoDB service hostname Result: identified that the app was using localhost instead of the Compose service name
-```
-
-## Run Locally with Docker Compose
-
-Make sure Docker Desktop is running.
+Make sure Docker is installed and running.
 
 From the project root:
 
 ```bash
-docker compose up --build
+docker compose up -d --build
 ```
 
-Then open the API docs:
+Check the containers:
+
+```bash
+docker compose ps
+```
+
+Open the frontend:
+
+```text
+http://localhost:5173
+```
+
+Open the API documentation:
 
 ```text
 http://localhost:8000/docs
 ```
 
-## Stop the App
+---
+
+## Development Commands
+
+### Build the Frontend
+
+```bash
+docker compose exec frontend npm run build
+```
+
+### Run Backend Tests
+
+```bash
+docker compose exec api pytest
+```
+
+### Restart the API
+
+```bash
+docker compose restart api
+```
+
+### Stop BragStack
 
 ```bash
 docker compose down
 ```
 
-To remove MongoDB data too:
+### Remove Containers and Local MongoDB Data
 
 ```bash
 docker compose down -v
 ```
 
-## Environment Variables
+---
 
-The backend uses the following environment variable:
+## API Highlights
 
-| Variable | Description | Default |
+### Authentication and Profiles
+
+| Method | Endpoint | Description |
 |---|---|---|
-| `MONGO_URL` | MongoDB connection string | `mongodb://localhost:27017` |
+| `POST` | `/auth/register` | Register a user |
+| `POST` | `/auth/login` | Log in |
+| `GET` | `/auth/me` | Get the authenticated user |
+| `PATCH` | `/auth/me/profile` | Update the authenticated user’s profile |
 
-In Docker Compose, this is set to:
+### Accomplishments
 
-```text
-mongodb://mongo:27017
-```
+| Method | Endpoint | Description |
+|---|---|---|
+| `POST` | `/entries` | Create an accomplishment |
+| `GET` | `/entries` | List the authenticated user’s accomplishments |
+| `GET` | `/entries/{entry_id}` | View one accomplishment |
+| `PUT` | `/entries/{entry_id}` | Update an accomplishment |
+| `DELETE` | `/entries/{entry_id}` | Delete an accomplishment |
+| `GET` | `/entries/reports/weekly` | Generate a weekly report |
+| `GET` | `/entries/tags/summary` | Summarize skill tags |
+| `GET` | `/entries/categories/summary` | Summarize categories |
 
-## DevOps Concepts Demonstrated
+### Public Profiles
 
-This project demonstrates:
+| Method | Endpoint | Description |
+|---|---|---|
+| `GET` | `/public/brag/{slug}` | View public accomplishments |
+| `GET` | `/public/brag/{slug}/profile` | View public profile information |
+| `GET` | `/public/brag/{slug}/reports/weekly` | View the public weekly report |
+| `GET` | `/public/brag/{slug}/tags/summary` | View public skill summaries |
+| `GET` | `/public/brag/{slug}/categories/summary` | View public category summaries |
 
-- Building a FastAPI backend
-- Connecting FastAPI to MongoDB
-- Creating REST API endpoints
-- Using Dockerfiles to containerize an application
-- Running a multi-container environment with Docker Compose
-- Connecting services through Docker Compose networking
-- Persisting MongoDB data with Docker volumes
-- Testing API behavior through Swagger/OpenAPI
-- Using timezone-aware UTC datetime values
-- Structuring a backend project for future SaaS growth
+---
+
+## Current Development Milestone
+
+The current milestone is **Impact Receipts V1**.
+
+Planned V1 work:
+
+- [ ] Complete editable-profile persistence testing
+- [ ] Display saved profile information on public profiles
+- [ ] Remove remaining hardcoded public-profile information
+- [ ] Create the first Impact Receipt backend model
+- [ ] Convert an existing brag entry into an Impact Receipt
+- [ ] Add a **Create Impact Receipt** action to entries
+- [ ] Display the first Impact Receipt card
+- [ ] Add receipt visibility controls
+- [ ] Add receipt creation and update timestamps
+
+---
 
 ## Roadmap
 
-Planned features:
+### Impact Receipts V1
 
-- React or Next.js frontend
-- User authentication
-- Skill/tag summary dashboard
-- Monthly reports
-- STAR interview story generator
-- AI-assisted resume bullet generation
-- Export entries to Markdown or PDF
-- Kubernetes manifests
-- GitHub Actions CI workflow
-- Deployment to a cloud environment
+- Structured accomplishment records
+- Individual contribution details
+- Results and measurable impact
+- Skills backed by accomplishments
+- Public and private receipt cards
 
-## Future Kubernetes Goals
+### Evidence
 
-BragStack will eventually include Kubernetes manifests for:
+- Evidence links
+- GitHub pull requests
+- Jira and Zendesk tickets
+- Documentation
+- Customer feedback
+- File attachments
 
-- Backend Deployment
-- Backend Service
-- MongoDB Deployment
-- MongoDB Service
-- ConfigMap
-- Secret
-- Ingress
-- Health checks
+### Shared Credit and Confirmation
+
+- Contributor invitations
+- Individual contribution roles
+- Collaborator confirmation
+- Stakeholder verification
+- Verification history
+- Revocation and correction workflows
+
+### Career Outputs
+
+- Review Packet Generator
+- Promotion packets
+- Interview-story generation
+- Résumé exports
+- Client impact reports
+- Markdown and PDF exports
+
+### Teams and Organizations
+
+- Organizations
+- Teams
+- Invitations
+- Member roles
+- Manager workflows
+- Team impact dashboards
+- Custom review templates
+
+### Integrations and Enterprise
+
+- GitHub integration
+- Jira integration
+- Zendesk integration
+- Slack integration
+- Compact iframe embeds
+- SSO
+- Audit logs
+- Enterprise permissions
+- Verifiable credentials
+
+---
+
+## Product Principles
+
+BragStack is being designed around several principles:
+
+1. **Employees control their career proof.**
+2. **Sensitive workplace evidence should remain private by default.**
+3. **Imported activity should require user approval.**
+4. **Shared work should receive shared credit.**
+5. **Verification should clearly state what was confirmed.**
+6. **BragStack should support existing HR systems instead of forcing companies to replace them.**
+7. **The product should reveal overlooked work without becoming workplace surveillance.**
+
+---
+
+## Vision
+
+BragStack is where work becomes portable, shared-credit, verifiable career proof.
+
+The long-term goal is to give every person a living record of their contributions while helping organizations recognize impact that traditional performance systems often miss.
+
+---
 
 ## Author
 
-Built by Tee as a portfolio SaaS project to showcase backend development, Docker, MongoDB, and future Kubernetes/DevOps skills.
+Built by Tee as a SaaS product focused on career proof, workplace impact, backend development, Docker, MongoDB, and modern product engineering.

--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -79,8 +79,14 @@ def serialize_user(user: dict) -> dict:
     "name": user.get("name", ""),
     "email": user.get("email", ""),
     "public_slug": user.get("public_slug", ""),
+    "headline": user.get("headline", ""),
+    "bio": user.get("bio", ""),
+    "location": user.get("location", ""),
+    "github_url": user.get("github_url", ""),
+    "portfolio_url": user.get("portfolio_url", ""),
+    "resume_url": user.get("resume_url", ""),
     "created_at": user.get("created_at"),
-    }
+}
 
 
 async def get_current_user(token: str = Depends(oauth2_scheme)) -> dict:

--- a/backend/app/auth_routes.py
+++ b/backend/app/auth_routes.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timezone
 import re
+import secrets
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.security import OAuth2PasswordRequestForm
@@ -42,6 +43,17 @@ class LoginRequest(BaseModel):
     email: EmailStr
     password: str
 
+class ProfileUpdateRequest(BaseModel):
+    """Editable public profile information."""
+
+    name: str = Field(..., min_length=1, max_length=80)
+    headline: str = Field(default="", max_length=120)
+    bio: str = Field(default="", max_length=500)
+    location: str = Field(default="", max_length=100)
+    github_url: str = Field(default="", max_length=300)
+    portfolio_url: str = Field(default="", max_length=300)
+    resume_url: str = Field(default="", max_length=300)
+
 def slugify(value: str) -> str:
     """Convert a display name into a URL-safe slug."""
     slug = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
@@ -49,16 +61,16 @@ def slugify(value: str) -> str:
 
 
 def generate_unique_public_slug(name: str) -> str:
-    """Generate a unique public profile slug for a new user."""
+    """Generate a stable, unique public profile slug."""
+
     base_slug = slugify(name)
-    slug = base_slug
-    counter = 2
 
-    while users_collection.find_one({"public_slug": slug}):
-        slug = f"{base_slug}-{counter}"
-        counter += 1
+    while True:
+        random_suffix = secrets.token_hex(3)
+        slug = f"{base_slug}-{random_suffix}"
 
-    return slug
+        if not users_collection.find_one({"public_slug": slug}):
+            return slug
 
 @router.post("/register")
 def register_user(payload: RegisterRequest):
@@ -138,12 +150,60 @@ def login_user(form_data: OAuth2PasswordRequestForm = Depends()):
 
 @router.get("/me")
 def get_me(current_user: dict = Depends(get_current_user)):
-    """Return the currently authenticated user.
+    """Return the currently authenticated user."""
 
-    Args:
-        current_user: The authenticated user injected by the auth dependency.
+    current_slug = current_user.get("public_slug", "")
+    basic_name_slug = slugify(current_user.get("name", "user"))
 
-    Returns:
-        A serialized user dictionary.
-    """
+    if not current_slug or current_slug == basic_name_slug:
+        public_slug = generate_unique_public_slug(
+            current_user.get("name", "user")
+        )
+
+        users_collection.update_one(
+            {"_id": current_user["_id"]},
+            {"$set": {"public_slug": public_slug}},
+        )
+
+        current_user["public_slug"] = public_slug
+
     return serialize_user(current_user)
+
+@router.patch("/me/profile")
+def update_profile(
+    payload: ProfileUpdateRequest,
+    current_user: dict = Depends(get_current_user),
+):
+    """Update the authenticated user's public profile."""
+
+    updates = {
+        "name": payload.name.strip(),
+        "headline": payload.headline.strip(),
+        "bio": payload.bio.strip(),
+        "location": payload.location.strip(),
+        "github_url": payload.github_url.strip(),
+        "portfolio_url": payload.portfolio_url.strip(),
+        "resume_url": payload.resume_url.strip(),
+    }
+
+    url_fields = ("github_url", "portfolio_url", "resume_url")
+
+    for field_name in url_fields:
+        value = updates[field_name]
+
+        if value and not value.startswith(("http://", "https://")):
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=f"{field_name} must start with http:// or https://",
+            )
+
+    users_collection.update_one(
+        {"_id": current_user["_id"]},
+        {"$set": updates},
+    )
+
+    updated_user = users_collection.find_one(
+        {"_id": current_user["_id"]}
+    )
+
+    return serialize_user(updated_user)

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -8,3 +8,4 @@ db = client["bragstack"]
 
 entries_collection = db["entries"]
 users_collection = db["users"]
+impact_receipts_collection = db["impact_receipts"]

--- a/backend/app/impact_receipt_routes.py
+++ b/backend/app/impact_receipt_routes.py
@@ -1,0 +1,246 @@
+from datetime import datetime, timezone
+
+from bson import ObjectId
+from fastapi import APIRouter, Depends, HTTPException, status, Query
+
+from app.auth import get_current_user
+from app.database import (
+    entries_collection,
+    impact_receipts_collection,
+)
+from app.models import (
+    ImpactReceiptFromEntryCreate,
+    ImpactReceiptResponse,
+)
+
+
+router = APIRouter(
+    prefix="/impact-receipts",
+    tags=["impact-receipts"],
+)
+
+
+def clean_string_list(values: list[str]) -> list[str]:
+    """Trim values, remove blanks, and prevent duplicates."""
+
+    cleaned_values = []
+    seen_values = set()
+
+    for value in values:
+        cleaned_value = value.strip()
+
+        if cleaned_value and cleaned_value not in seen_values:
+            cleaned_values.append(cleaned_value)
+            seen_values.add(cleaned_value)
+
+    return cleaned_values
+
+
+def build_trust_signals(evidence: list[dict]) -> list[str]:
+    """Build honest trust signals for a newly created receipt."""
+
+    trust_signals = ["self-documented"]
+
+    if evidence:
+        trust_signals.append("evidence-linked")
+
+    return trust_signals
+
+
+def serialize_impact_receipt(receipt: dict) -> dict:
+    """Convert a MongoDB Impact Receipt into an API response."""
+
+    return {
+        "id": str(receipt["_id"]),
+        "source_entry_id": receipt["source_entry_id"],
+        "accomplishment": receipt["accomplishment"],
+        "contribution": receipt["contribution"],
+        "result": receipt["result"],
+        "evidence": receipt.get("evidence", []),
+        "skills": receipt.get("skills", []),
+        "credit": receipt.get("credit", []),
+        "confirmations": receipt.get("confirmations", []),
+        "trust_signals": receipt.get(
+            "trust_signals",
+            ["self-documented"],
+        ),
+        "is_public": receipt.get("is_public", False),
+        "schema_version": receipt.get("schema_version", 1),
+        "created_at": receipt["created_at"],
+        "updated_at": receipt["updated_at"],
+    }
+
+
+@router.post(
+    "/from-entry/{entry_id}",
+    response_model=ImpactReceiptResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+def create_impact_receipt_from_entry(
+    entry_id: str,
+    payload: ImpactReceiptFromEntryCreate,
+    current_user: dict = Depends(get_current_user),
+):
+    """Convert an owned brag entry into an Impact Receipt."""
+
+    if not ObjectId.is_valid(entry_id):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid entry ID",
+        )
+
+    user_id = str(current_user["_id"])
+
+    entry = entries_collection.find_one(
+        {
+            "_id": ObjectId(entry_id),
+            "user_id": user_id,
+        }
+    )
+
+    if entry is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Entry not found",
+        )
+
+    existing_receipt = impact_receipts_collection.find_one(
+        {
+            "user_id": user_id,
+            "source_entry_id": entry_id,
+        }
+    )
+
+    if existing_receipt is not None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "code": "impact_receipt_already_exists",
+                "message": (
+                    "This brag entry already has an Impact Receipt."
+                ),
+                "receipt_id": str(existing_receipt["_id"]),
+            },
+        )
+
+    accomplishment = str(
+        entry.get("title", "")
+    ).strip()
+
+    contribution = (
+        payload.contribution.strip()
+        if payload.contribution
+        else str(entry.get("action", "")).strip()
+    )
+
+    result = (
+        payload.result.strip()
+        if payload.result
+        else str(entry.get("impact", "")).strip()
+    )
+
+    if not accomplishment:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="The source entry must have a title.",
+        )
+
+    if not contribution:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=(
+                "The source entry must have an action or a custom "
+                "contribution."
+            ),
+        )
+
+    if not result:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=(
+                "The source entry must have an impact or a custom result."
+            ),
+        )
+
+    evidence = [
+        evidence_item.model_dump()
+        for evidence_item in payload.evidence
+    ]
+
+    credit = [
+        credit_item.model_dump()
+        for credit_item in payload.credit
+    ]
+
+    skills = clean_string_list(
+        payload.skills or entry.get("tags", [])
+    )
+
+    now = datetime.now(timezone.utc)
+
+    receipt_document = {
+        "user_id": user_id,
+        "source_entry_id": entry_id,
+        "accomplishment": accomplishment,
+        "contribution": contribution,
+        "result": result,
+        "evidence": evidence,
+        "skills": skills,
+        "credit": credit,
+        "confirmations": [],
+        "trust_signals": build_trust_signals(evidence),
+        "is_public": payload.is_public,
+        "schema_version": 1,
+        "created_at": now,
+        "updated_at": now,
+    }
+
+    result = impact_receipts_collection.insert_one(
+        receipt_document
+    )
+
+    created_receipt = impact_receipts_collection.find_one(
+        {"_id": result.inserted_id}
+    )
+
+    return serialize_impact_receipt(created_receipt)
+
+@router.get("")
+def list_impact_receipts(
+    limit: int = Query(default=20, ge=1, le=100),
+    skip: int = Query(default=0, ge=0),
+    current_user: dict = Depends(get_current_user),
+):
+    """List Impact Receipts owned by the authenticated user."""
+
+    user_id = str(current_user["_id"])
+
+    query = {
+        "user_id": user_id,
+    }
+
+    total_receipts = (
+        impact_receipts_collection.count_documents(query)
+    )
+
+    cursor = (
+        impact_receipts_collection
+        .find(query)
+        .sort("created_at", -1)
+        .skip(skip)
+        .limit(limit)
+    )
+
+    receipts = [
+        serialize_impact_receipt(receipt)
+        for receipt in cursor
+    ]
+
+    return {
+        "total_receipts": total_receipts,
+        "returned_receipts": len(receipts),
+        "limit": limit,
+        "skip": skip,
+        "has_more": skip + limit < total_receipts,
+        "receipts": receipts,
+    }

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,6 +4,8 @@ from fastapi.middleware.cors import CORSMiddleware
 from app.auth_routes import router as auth_router
 from app.public_slug_routes import router as public_slug_router
 from app.routes import public_router, router as entries_router
+from app.impact_receipt_routes import router as impact_receipts_router
+
 
 app = FastAPI(
     title="BragStack API",
@@ -27,6 +29,7 @@ app.include_router(auth_router)
 app.include_router(entries_router)
 app.include_router(public_router)
 app.include_router(public_slug_router)
+app.include_router(impact_receipts_router)
 
 
 @app.get("/")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Optional
+from typing import Optional, Literal
 
 from pydantic import BaseModel, Field
 
@@ -35,3 +35,263 @@ class BragEntryResponse(BaseModel):
     is_public: bool = False
     resume_bullet: str
     created_at: datetime
+
+
+class BragEntryCreate(BaseModel):
+    """Request model for creating a brag entry."""
+
+    title: str = Field(
+        ...,
+        examples=["Debugged Docker networking issue"],
+    )
+    category: str = Field(
+        ...,
+        examples=["Docker"],
+    )
+    entry_date: str = Field(
+        ...,
+        examples=["2026-05-27"],
+    )
+    entry_type: str = Field(
+        ...,
+        examples=["Current Job"],
+    )
+    situation: str = Field(
+        ...,
+        examples=[
+            "Customer container could not connect to MongoDB."
+        ],
+    )
+    action: str = Field(
+        ...,
+        examples=[
+            "Checked logs, inspected networks, and verified "
+            "Compose service names."
+        ],
+    )
+    impact: str = Field(
+        ...,
+        examples=[
+            "Found the incorrect hostname and restored connectivity."
+        ],
+    )
+    lesson: Optional[str] = Field(
+        None,
+        examples=["Docker Compose DNS uses service names."],
+    )
+    tags: list[str] = Field(
+        default_factory=list,
+        examples=[["Docker", "Networking", "Compose"]],
+    )
+    is_public: bool = Field(
+        default=False,
+        examples=[True],
+    )
+
+
+class BragEntryResponse(BaseModel):
+    """Response model for a brag entry."""
+
+    id: str
+    title: str
+    category: str
+    entry_date: str
+    entry_type: str
+    situation: str
+    action: str
+    impact: str
+    lesson: Optional[str]
+    tags: list[str]
+    is_public: bool = False
+    resume_bullet: str
+    created_at: datetime
+
+
+EvidenceType = Literal[
+    "support-incident",
+    "pull-request",
+    "ticket",
+    "documentation",
+    "customer-feedback",
+    "project-link",
+    "attachment",
+    "other",
+]
+
+ConfirmationType = Literal[
+    "collaborator",
+    "stakeholder",
+    "organization",
+]
+
+ConfirmationStatus = Literal[
+    "pending",
+    "confirmed",
+    "declined",
+    "revoked",
+]
+
+TrustSignal = Literal[
+    "self-documented",
+    "evidence-linked",
+    "collaborator-confirmed",
+    "stakeholder-verified",
+    "organization-issued",
+]
+
+
+class ImpactEvidence(BaseModel):
+    """One piece of evidence supporting an Impact Receipt."""
+
+    evidence_type: EvidenceType = "other"
+
+    title: str = Field(
+        ...,
+        min_length=1,
+        max_length=120,
+        examples=["Docker DNS incident INC-1042"],
+    )
+
+    reference: Optional[str] = Field(
+        default=None,
+        max_length=500,
+        examples=["INC-1042"],
+    )
+
+    description: Optional[str] = Field(
+        default=None,
+        max_length=500,
+        examples=[
+            "Incident showing the original failure and resolution."
+        ],
+    )
+
+    is_public: bool = Field(
+        default=False,
+        description=(
+            "Evidence is private unless the owner explicitly "
+            "makes it public."
+        ),
+    )
+
+
+class ImpactCredit(BaseModel):
+    """Credit for another person who contributed to the outcome."""
+
+    name: str = Field(
+        ...,
+        min_length=1,
+        max_length=100,
+        examples=["Jordan"],
+    )
+
+    contribution: str = Field(
+        ...,
+        min_length=1,
+        max_length=300,
+        examples=["Tested the networking fix before deployment."],
+    )
+
+
+class ImpactConfirmation(BaseModel):
+    """Confirmation from a collaborator or stakeholder."""
+
+    name: str
+    role: Optional[str] = None
+    confirmation_type: ConfirmationType
+    status: ConfirmationStatus = "pending"
+    requested_at: Optional[datetime] = None
+    confirmed_at: Optional[datetime] = None
+
+
+class ImpactReceiptFromEntryCreate(BaseModel):
+    """Request used to turn an existing brag entry into a receipt."""
+
+    contribution: Optional[str] = Field(
+        default=None,
+        max_length=2000,
+        description=(
+            "The owner's specific contribution. Defaults to the "
+            "source entry action."
+        ),
+    )
+
+    result: Optional[str] = Field(
+        default=None,
+        max_length=2000,
+        description=(
+            "What changed because of the work. Defaults to the "
+            "source entry impact."
+        ),
+    )
+
+    evidence: list[ImpactEvidence] = Field(
+        default_factory=list,
+    )
+
+    skills: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Skills demonstrated by this specific accomplishment."
+        ),
+    )
+
+    credit: list[ImpactCredit] = Field(
+        default_factory=list,
+        description=(
+            "Other contributors and the work they performed."
+        ),
+    )
+
+    is_public: bool = False
+
+
+class ImpactReceiptUpdate(BaseModel):
+    """Owner-editable Impact Receipt fields."""
+
+    accomplishment: Optional[str] = Field(
+        default=None,
+        min_length=1,
+        max_length=300,
+    )
+
+    contribution: Optional[str] = Field(
+        default=None,
+        min_length=1,
+        max_length=2000,
+    )
+
+    result: Optional[str] = Field(
+        default=None,
+        min_length=1,
+        max_length=2000,
+    )
+
+    evidence: Optional[list[ImpactEvidence]] = None
+    skills: Optional[list[str]] = None
+    credit: Optional[list[ImpactCredit]] = None
+    is_public: Optional[bool] = None
+
+
+class ImpactReceiptResponse(BaseModel):
+    """Complete Impact Receipt returned by the API."""
+
+    id: str
+    source_entry_id: str
+
+    accomplishment: str
+    contribution: str
+    result: str
+
+    evidence: list[ImpactEvidence]
+    skills: list[str]
+    credit: list[ImpactCredit]
+
+    confirmations: list[ImpactConfirmation]
+    trust_signals: list[TrustSignal]
+
+    is_public: bool = False
+    schema_version: int = 1
+
+    created_at: datetime
+    updated_at: datetime

--- a/backend/app/public_slug_routes.py
+++ b/backend/app/public_slug_routes.py
@@ -12,6 +12,27 @@ def normalize_slug(slug: str) -> str:
     """Normalize a public profile slug for lookup."""
     return slug.strip().lower()
 
+def parse_datetime(value):
+    """Convert MongoDB datetime or ISO datetime text into UTC datetime."""
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            return value.replace(tzinfo=timezone.utc)
+
+        return value.astimezone(timezone.utc)
+
+    if isinstance(value, str):
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=timezone.utc)
+
+            return parsed.astimezone(timezone.utc)
+        except ValueError:
+            return None
+
+    return None
+
 
 def serialize_entry(entry: dict) -> dict:
     """Convert a MongoDB brag entry into a safe public response."""
@@ -116,8 +137,19 @@ def get_public_weekly_report_by_slug(slug: str):
     query = get_public_entry_query(slug)
 
     week_start = datetime.now(timezone.utc) - timedelta(days=7)
-    query["created_at"] = {"$gte": week_start}
-    entries = list(entries_collection.find(query).sort("created_at", -1))
+    entries = []
+
+    for entry in entries_collection.find(query):
+        created_at = parse_datetime(entry.get("created_at"))
+
+        if created_at is not None and created_at >= week_start:
+            entries.append(entry)
+
+    entries.sort(
+        key=lambda entry: parse_datetime(entry.get("created_at"))
+        or datetime.min.replace(tzinfo=timezone.utc),
+        reverse=True,
+    )
 
     categories = {}
     tags = {}

--- a/backend/app/public_slug_routes.py
+++ b/backend/app/public_slug_routes.py
@@ -14,17 +14,38 @@ def normalize_slug(slug: str) -> str:
 
 
 def serialize_entry(entry: dict) -> dict:
-    """Convert a MongoDB brag entry document into an API response dictionary."""
+    """Convert a MongoDB brag entry into a safe public response."""
+
     return {
         "id": str(entry["_id"]),
         "title": entry.get("title", ""),
         "description": entry.get("description", ""),
         "category": entry.get("category", ""),
+        "entry_type": entry.get("entry_type", ""),
+        "entry_date": entry.get("entry_date", ""),
+        "situation": entry.get("situation", ""),
+        "action": entry.get("action", ""),
+        "impact": entry.get("impact", ""),
+        "lesson": entry.get("lesson", ""),
         "tags": entry.get("tags", []),
         "resume_bullet": entry.get("resume_bullet", ""),
         "is_public": entry.get("is_public", False),
         "created_at": entry.get("created_at"),
         "updated_at": entry.get("updated_at"),
+    }
+
+def serialize_public_profile(user: dict) -> dict:
+    """Return profile fields that are safe for public display."""
+
+    return {
+        "name": user.get("name", ""),
+        "public_slug": user.get("public_slug", ""),
+        "headline": user.get("headline", ""),
+        "bio": user.get("bio", ""),
+        "location": user.get("location", ""),
+        "github_url": user.get("github_url", ""),
+        "portfolio_url": user.get("portfolio_url", ""),
+        "resume_url": user.get("resume_url", ""),
     }
 
 
@@ -79,6 +100,15 @@ def get_public_brag_entries_by_slug(slug: str):
         ),
     }
 
+@router.get("/brag/{slug}/profile")
+def get_public_profile_by_slug(slug: str):
+    """Return the owner information for a public BragStack."""
+
+    user = get_user_by_public_slug(slug)
+
+    return {
+        "profile": serialize_public_profile(user),
+    }
 
 @router.get("/brag/{slug}/reports/weekly")
 def get_public_weekly_report_by_slug(slug: str):
@@ -86,8 +116,7 @@ def get_public_weekly_report_by_slug(slug: str):
     query = get_public_entry_query(slug)
 
     week_start = datetime.now(timezone.utc) - timedelta(days=7)
-    query["created_at"] = {"$gte": week_start.isoformat()}
-
+    query["created_at"] = {"$gte": week_start}
     entries = list(entries_collection.find(query).sort("created_at", -1))
 
     categories = {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,8 +19,8 @@ services:
     ports:
       - "5173:5173"
     environment:
-      VITE_API_BASE_URL: http://localhost:8000
-      VITE_API_URL: http://localhost:8000
+      VITE_API_BASE_URL: https://super-fishstick-wgjqr7g4p9c5gxq-8000.app.github.dev
+      VITE_API_URL: https://super-fishstick-wgjqr7g4p9c5gxq-8000.app.github.dev
     depends_on:
       - api
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,13 @@ services:
       - "8000:8000"
     environment:
       MONGO_URL: mongodb://mongo:27017
+      WATCHFILES_FORCE_POLLING: "true"
+    command: >
+      uvicorn app.main:app
+      --host 0.0.0.0
+      --port 8000
+      --reload
+      --reload-dir /app/app
     depends_on:
       - mongo
     volumes:
@@ -19,8 +26,8 @@ services:
     ports:
       - "5173:5173"
     environment:
-      VITE_API_BASE_URL: https://super-fishstick-wgjqr7g4p9c5gxq-8000.app.github.dev
-      VITE_API_URL: https://super-fishstick-wgjqr7g4p9c5gxq-8000.app.github.dev
+      VITE_API_BASE_URL: http://localhost:8000
+      VITE_API_URL: http://localhost:8000
     depends_on:
       - api
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,8 +19,8 @@ services:
     ports:
       - "5173:5173"
     environment:
-      VITE_API_BASE_URL: https://congenial-space-orbit-g5pwgj56pg73w7vg-8000.app.github.dev
-      VITE_API_URL: https://congenial-space-orbit-g5pwgj56pg73w7vg-8000.app.github.dev
+      VITE_API_BASE_URL: http://localhost:8000
+      VITE_API_URL: http://localhost:8000
     depends_on:
       - api
     volumes:

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -852,3 +852,317 @@ a {
   background: rgba(127, 29, 29, 0.16);
   font-weight: 700;
 }
+
+.impact-section {
+  margin-top: 2rem;
+  padding: 1.5rem;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: 24px;
+  background:
+    radial-gradient(
+      circle at top right,
+      rgba(139, 92, 246, 0.12),
+      transparent 34%
+    ),
+    rgba(15, 23, 42, 0.74);
+}
+
+.impact-section-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1.25rem;
+}
+
+.impact-section-header h2 {
+  margin: 0.25rem 0;
+}
+
+.impact-section-header > div > p:last-child {
+  max-width: 700px;
+  margin: 0;
+  color: #94a3b8;
+  line-height: 1.6;
+}
+
+.impact-count {
+  padding: 0.5rem 0.8rem;
+  border: 1px solid rgba(167, 139, 250, 0.3);
+  border-radius: 999px;
+  color: #ddd6fe;
+  background: rgba(109, 40, 217, 0.12);
+  font-size: 0.78rem;
+  font-weight: 800;
+  white-space: nowrap;
+}
+
+.impact-receipt-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.impact-receipt-card {
+  padding: 1.35rem;
+  border: 1px solid rgba(167, 139, 250, 0.24);
+  border-radius: 20px;
+  background:
+    linear-gradient(
+      145deg,
+      rgba(30, 41, 59, 0.92),
+      rgba(15, 23, 42, 0.92)
+    );
+  box-shadow: 0 18px 45px rgba(2, 6, 23, 0.2);
+}
+
+.impact-receipt-top {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.14);
+}
+
+.impact-receipt-top h3 {
+  margin: 0.3rem 0 0;
+  color: #f8fafc;
+  font-size: 1.25rem;
+}
+
+.impact-receipt-detail {
+  margin-top: 1rem;
+}
+
+.impact-receipt-detail > span {
+  display: block;
+  margin-bottom: 0.45rem;
+  color: #a5b4fc;
+  font-size: 0.72rem;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.impact-receipt-detail p {
+  margin: 0;
+  color: #cbd5e1;
+  line-height: 1.65;
+}
+
+.impact-receipt-detail.result {
+  padding: 0.9rem 1rem;
+  border-left: 3px solid rgba(52, 211, 153, 0.75);
+  border-radius: 0 12px 12px 0;
+  background: rgba(16, 185, 129, 0.07);
+}
+
+.impact-evidence-list,
+.impact-credit-list {
+  display: grid;
+  gap: 0.65rem;
+}
+
+.impact-evidence-item {
+  padding: 0.8rem;
+  border: 1px solid rgba(148, 163, 184, 0.14);
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.56);
+}
+
+.impact-evidence-item strong {
+  display: block;
+  color: #f8fafc;
+}
+
+.impact-evidence-item small {
+  display: block;
+  margin-top: 0.2rem;
+  color: #a5b4fc;
+  font-weight: 800;
+}
+
+.impact-evidence-item p {
+  margin-top: 0.4rem;
+  color: #94a3b8;
+}
+
+.impact-receipt-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-top: 1.2rem;
+  padding-top: 1rem;
+  border-top: 1px solid rgba(148, 163, 184, 0.14);
+}
+
+.trust-signal-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.trust-signal-list span {
+  padding: 0.35rem 0.6rem;
+  border: 1px solid rgba(96, 165, 250, 0.28);
+  border-radius: 999px;
+  color: #bfdbfe;
+  background: rgba(37, 99, 235, 0.1);
+  font-size: 0.7rem;
+  font-weight: 800;
+}
+
+.impact-receipt-footer small {
+  color: #94a3b8;
+  white-space: nowrap;
+}
+
+.impact-empty-state {
+  padding: 2rem;
+  border: 1px dashed rgba(167, 139, 250, 0.3);
+  border-radius: 18px;
+  text-align: center;
+  background: rgba(15, 23, 42, 0.4);
+}
+
+.impact-empty-state h3 {
+  margin-top: 0;
+}
+
+.impact-empty-state p {
+  margin-bottom: 0;
+  color: #94a3b8;
+}
+
+@media (max-width: 700px) {
+  .impact-section-header,
+  .impact-receipt-top,
+  .impact-receipt-footer {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .impact-count {
+    align-self: flex-start;
+  }
+}
+/* Impact Receipts V1 finishing styles */
+
+.receipt-feedback {
+  margin: 0 0 1rem;
+  padding: 0.8rem 1rem;
+  border-radius: 12px;
+  font-weight: 800;
+}
+
+.receipt-feedback.success {
+  color: #bbf7d0;
+  border: 1px solid rgba(34, 197, 94, 0.3);
+  background: rgba(34, 197, 94, 0.1);
+}
+
+.receipt-feedback.error {
+  color: #fecaca;
+  border: 1px solid rgba(248, 113, 113, 0.3);
+  background: rgba(127, 29, 29, 0.16);
+}
+
+.impact-receipt-card.compact {
+  padding: 1.2rem;
+}
+
+.impact-result-preview {
+  margin-top: 1rem;
+  padding: 0.85rem 1rem;
+  border-left: 3px solid rgba(52, 211, 153, 0.75);
+  border-radius: 0 12px 12px 0;
+  background: rgba(16, 185, 129, 0.07);
+}
+
+.impact-result-preview > span {
+  display: block;
+  margin-bottom: 0.35rem;
+  color: #a5b4fc;
+  font-size: 0.7rem;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.impact-result-preview p {
+  margin: 0;
+  color: #dbe4f0;
+  line-height: 1.55;
+}
+
+.receipt-summary-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+  margin: 0.9rem 0;
+  color: #94a3b8;
+  font-size: 0.78rem;
+  font-weight: 800;
+}
+
+.receipt-summary-row span:not(:last-child)::after {
+  content: " •";
+  margin-left: 0.65rem;
+  color: #64748b;
+}
+
+.receipt-details {
+  margin-top: 1rem;
+  border-top: 1px solid rgba(148, 163, 184, 0.14);
+}
+
+.receipt-details summary {
+  padding-top: 1rem;
+  color: #bfdbfe;
+  font-size: 0.82rem;
+  font-weight: 900;
+  cursor: pointer;
+  user-select: none;
+}
+
+.receipt-details summary:hover {
+  color: #f8fafc;
+}
+
+.receipt-details-content {
+  padding-top: 0.25rem;
+}
+
+.entry-receipt-action {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 1rem;
+  padding-top: 1rem;
+  border-top: 1px solid rgba(148, 163, 184, 0.14);
+}
+
+.receipt-button {
+  padding: 0.65rem 0.9rem;
+  font-size: 0.78rem;
+}
+
+.receipt-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+@media (max-width: 700px) {
+  .entry-receipt-action {
+    justify-content: stretch;
+  }
+
+  .receipt-button {
+    width: 100%;
+  }
+
+  .receipt-summary-row span:not(:last-child)::after {
+    content: "";
+    margin: 0;
+  }
+}

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -739,3 +739,32 @@ a {
     font-size: clamp(2.6rem, 16vw, 4rem);
   }
 }
+
+.entry-form .visibility-toggle {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem 1.1rem;
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  border-radius: 14px;
+  background: rgba(15, 23, 42, 0.55);
+  cursor: pointer;
+}
+
+.entry-form .visibility-toggle span {
+  font-weight: 700;
+  line-height: 1.4;
+}
+
+.entry-form .visibility-toggle input[type="checkbox"] {
+  width: 20px;
+  height: 20px;
+  min-width: 20px;
+  margin: 0;
+  padding: 0;
+  flex: 0 0 auto;
+  accent-color: #8b5cf6;
+  cursor: pointer;
+}

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -791,3 +791,64 @@ a {
   background: rgba(148, 163, 184, 0.1);
   border: 1px solid rgba(148, 163, 184, 0.25);
 }
+
+.profile-card-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.profile-card-heading .mini-label {
+  margin: 0;
+}
+
+.profile-edit-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.45rem 0.7rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 999px;
+  color: #cbd5e1;
+  background: rgba(15, 23, 42, 0.55);
+  font: inherit;
+  font-size: 0.72rem;
+  font-weight: 800;
+  cursor: pointer;
+}
+
+.profile-edit-button:hover {
+  color: #f8fafc;
+  border-color: rgba(166, 220, 255, 0.45);
+}
+
+.profile-headline {
+  color: #d8e1ee;
+  font-weight: 700;
+}
+
+.profile-bio {
+  color: #aebbd0;
+  line-height: 1.6;
+}
+
+.profile-location {
+  color: #9ed8ff;
+  font-size: 0.82rem;
+  font-weight: 800;
+}
+
+.profile-modal-card {
+  max-width: 680px;
+}
+
+.profile-form-error {
+  margin: 0;
+  padding: 0.8rem 1rem;
+  border: 1px solid rgba(248, 113, 113, 0.3);
+  border-radius: 12px;
+  color: #fecaca;
+  background: rgba(127, 29, 29, 0.16);
+  font-weight: 700;
+}

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -75,11 +75,9 @@ a {
   position: absolute;
   inset: 0;
   pointer-events: none;
-  background: linear-gradient(
-    135deg,
-    rgba(255, 255, 255, 0.08),
-    transparent 38%
-  );
+  background: linear-gradient(135deg,
+      rgba(255, 255, 255, 0.08),
+      transparent 38%);
 }
 
 .hero-copy {
@@ -682,6 +680,7 @@ a {
 }
 
 @media (max-width: 940px) {
+
   .hero,
   .stats-grid,
   .dashboard-grid {
@@ -767,4 +766,28 @@ a {
   flex: 0 0 auto;
   accent-color: #8b5cf6;
   cursor: pointer;
+}
+
+.visibility-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.35rem 0.65rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 800;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.visibility-badge.public {
+  color: #bbf7d0;
+  background: rgba(34, 197, 94, 0.14);
+  border: 1px solid rgba(34, 197, 94, 0.35);
+}
+
+.visibility-badge.private {
+  color: #cbd5e1;
+  background: rgba(148, 163, 184, 0.1);
+  border: 1px solid rgba(148, 163, 184, 0.25);
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -39,6 +39,7 @@ const EMPTY_FORM = {
   impact: "",
   lesson: "",
   tags: "",
+  is_public: false,
 };
 
 function App() {
@@ -52,7 +53,7 @@ function App() {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [editingEntryId, setEditingEntryId] = useState(null);
   const [formData, setFormData] = useState(EMPTY_FORM);
-  
+
   const path = window.location.pathname;
   const isPublicPage = path.startsWith("/brag");
   const isLoginPage = path === "/login";
@@ -131,6 +132,7 @@ function App() {
       impact: entry.impact ?? "",
       lesson: entry.lesson ?? "",
       tags: entry.tags?.join(", ") ?? "",
+      is_public: entry.is_public ?? false,
     });
 
     setIsModalOpen(true);
@@ -147,11 +149,11 @@ function App() {
   }
 
   function handleInputChange(event) {
-    const { name, value } = event.target;
+    const { name, value, type, checked } = event.target;
 
     setFormData((current) => ({
       ...current,
-      [name]: value,
+      [name]: type === "checkbox" ? checked : value,
     }));
   }
 
@@ -566,6 +568,17 @@ function App() {
                   value={formData.tags}
                   onChange={handleInputChange}
                   placeholder="Docker, FastAPI, MongoDB"
+                />
+              </label>
+
+              <label className="visibility-toggle">
+                <span>Show this entry on my public BragStack</span>
+
+                <input
+                  type="checkbox"
+                  name="is_public"
+                  checked={formData.is_public}
+                  onChange={handleInputChange}
                 />
               </label>
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,3 +1,6 @@
+
+
+
 import { useEffect, useState } from "react";
 import { Pencil, Plus, Trash2, X } from "lucide-react";
 
@@ -7,16 +10,18 @@ import LandingPage from "./LandingPage";
 
 import {
   createEntry,
+  createImpactReceiptFromEntry,
   deleteEntry,
   getCategoriesSummary,
   getCurrentUser,
   getEntries,
+  getImpactReceipts,
   getTagsSummary,
   getWeeklyReport,
   loginUser,
   registerUser,
-  updateEntry,
   updateCurrentUserProfile,
+  updateEntry,
 } from "./api";
 import "./App.css";
 
@@ -30,6 +35,11 @@ const ENTRY_TYPES = [
 ];
 
 const getTodayDate = () => new Date().toISOString().slice(0, 10);
+
+const formatLabel = (value = "") =>
+  value
+    .replace(/-/g, " ")
+    .replace(/\b\w/g, (character) => character.toUpperCase());
 
 const EMPTY_FORM = {
   title: "",
@@ -57,6 +67,10 @@ const EMPTY_PROFILE_FORM = {
 function App() {
   const [currentUser, setCurrentUser] = useState(null);
   const [entries, setEntries] = useState([]);
+  const [impactReceipts, setImpactReceipts] = useState([]);
+  const [creatingReceiptEntryId, setCreatingReceiptEntryId] = useState(null);
+  const [receiptNotice, setReceiptNotice] = useState("");
+  const [receiptError, setReceiptError] = useState("");
   const [weeklyReport, setWeeklyReport] = useState(null);
   const [tagsSummary, setTagsSummary] = useState(null);
   const [categoriesSummary, setCategoriesSummary] = useState(null);
@@ -78,17 +92,25 @@ function App() {
 
   async function loadDashboard() {
     try {
-      const [userData, entriesData, weeklyData, tagsData, categoriesData] =
-        await Promise.all([
-          getCurrentUser(),
-          getEntries(),
-          getWeeklyReport(),
-          getTagsSummary(),
-          getCategoriesSummary(),
-        ]);
+      const [
+        userData,
+        entriesData,
+        receiptsData,
+        weeklyData,
+        tagsData,
+        categoriesData,
+      ] = await Promise.all([
+        getCurrentUser(),
+        getEntries(),
+        getImpactReceipts(),
+        getWeeklyReport(),
+        getTagsSummary(),
+        getCategoriesSummary(),
+      ]);
 
       setCurrentUser(userData);
       setEntries(entriesData.entries ?? []);
+      setImpactReceipts(receiptsData.receipts ?? []);
       setWeeklyReport(weeklyData);
       setTagsSummary(tagsData);
       setCategoriesSummary(categoriesData);
@@ -141,8 +163,7 @@ function App() {
     setProfileError("");
 
     try {
-      const updatedUser =
-        await updateCurrentUserProfile(profileForm);
+      const updatedUser = await updateCurrentUserProfile(profileForm);
 
       setCurrentUser(updatedUser);
       closeProfileModal();
@@ -151,7 +172,7 @@ function App() {
 
       setProfileError(
         error.response?.data?.detail ??
-        "Your profile could not be saved."
+          "Your profile could not be saved."
       );
     } finally {
       setIsSavingProfile(false);
@@ -161,7 +182,12 @@ function App() {
   useEffect(() => {
     const token = localStorage.getItem("bragstack_token");
 
-    if (isLandingPage || isPublicPage || isLoginPage || isRegisterPage) {
+    if (
+      isLandingPage ||
+      isPublicPage ||
+      isLoginPage ||
+      isRegisterPage
+    ) {
       return;
     }
 
@@ -175,7 +201,12 @@ function App() {
     }, 0);
 
     return () => window.clearTimeout(timeoutId);
-  }, [isLandingPage, isPublicPage, isLoginPage, isRegisterPage]);
+  }, [
+    isLandingPage,
+    isPublicPage,
+    isLoginPage,
+    isRegisterPage,
+  ]);
 
   function openCreateModal() {
     setEditingEntryId(null);
@@ -270,8 +301,40 @@ function App() {
     }
   }
 
-  const topTags = tagsSummary?.tags ? Object.entries(tagsSummary.tags) : [];
+  async function handleCreateImpactReceipt(entryId) {
+    setCreatingReceiptEntryId(entryId);
+    setReceiptNotice("");
+    setReceiptError("");
 
+    try {
+      await createImpactReceiptFromEntry(entryId, {
+        contribution: null,
+        result: null,
+        evidence: [],
+        skills: [],
+        credit: [],
+        is_public: false,
+      });
+
+      await loadDashboard();
+      setReceiptNotice("Impact Receipt created successfully.");
+    } catch (error) {
+      console.error(error);
+
+      if (error.response?.status === 409) {
+        setReceiptError(
+          "This entry already has an Impact Receipt."
+        );
+      } else {
+        setReceiptError(
+          error.response?.data?.detail ??
+            "The Impact Receipt could not be created."
+        );
+      }
+    } finally {
+      setCreatingReceiptEntryId(null);
+    }
+  }
 
   async function handleLogin(credentials) {
     const data = await loginUser(credentials);
@@ -285,6 +348,14 @@ function App() {
     window.location.href = "/app";
   }
 
+  const topTags = tagsSummary?.tags
+    ? Object.entries(tagsSummary.tags)
+    : [];
+
+  const receiptSourceEntryIds = new Set(
+    impactReceipts.map((receipt) => receipt.source_entry_id)
+  );
+
   if (isPublicPage) {
     return <PublicBragPage />;
   }
@@ -297,9 +368,13 @@ function App() {
     return <AuthPage mode="login" onLogin={handleLogin} />;
   }
 
-
   if (isRegisterPage) {
-    return <AuthPage mode="register" onRegister={handleRegister} />;
+    return (
+      <AuthPage
+        mode="register"
+        onRegister={handleRegister}
+      />
+    );
   }
 
   const token = localStorage.getItem("bragstack_token");
@@ -320,14 +395,16 @@ function App() {
           </h1>
 
           <p>
-            Track technical wins, skill growth, resume bullets, and project
-            evidence in one clean portfolio-ready space.
+            Track technical wins, skill growth, resume bullets,
+            and project evidence in one clean portfolio-ready
+            space.
           </p>
 
           <div className="hero-actions">
             <a className="btn primary" href="#entries">
               View proof
             </a>
+
             <a
               className="btn secondary"
               href="http://localhost:8000/docs"
@@ -424,8 +501,10 @@ function App() {
 
       {isOffline && (
         <section className="notice">
-          <strong>Preview mode</strong>
-          <span>Please contact support.</span>
+          <strong>Connection problem</strong>
+          <span>
+            BragStack could not load all dashboard data.
+          </span>
         </section>
       )}
 
@@ -438,15 +517,221 @@ function App() {
 
         <article className="stat-card">
           <p>Unique Tags</p>
-          <strong>{tagsSummary?.total_unique_tags ?? 0}</strong>
+          <strong>
+            {tagsSummary?.total_unique_tags ?? 0}
+          </strong>
           <span>Skills tracked across entries</span>
         </article>
 
         <article className="stat-card">
           <p>Categories</p>
-          <strong>{categoriesSummary?.total_unique_categories ?? 0}</strong>
+          <strong>
+            {categoriesSummary?.total_unique_categories ?? 0}
+          </strong>
           <span>Career areas documented</span>
         </article>
+      </section>
+
+      <section
+        className="impact-section"
+        id="impact-receipts"
+      >
+        <div className="impact-section-header">
+          <div>
+            <p className="mini-label">
+              Evidence-Backed Proof
+            </p>
+            <h2>Impact Receipts</h2>
+            <p>
+              Structured proof of what you contributed, what changed,
+              and what evidence supports it.
+            </p>
+          </div>
+
+          <span className="impact-count">
+            {impactReceipts.length}{" "}
+            {impactReceipts.length === 1
+              ? "receipt"
+              : "receipts"}
+          </span>
+        </div>
+
+        {receiptNotice && (
+          <p className="receipt-feedback success">
+            {receiptNotice}
+          </p>
+        )}
+
+        {receiptError && (
+          <p className="receipt-feedback error">
+            {receiptError}
+          </p>
+        )}
+
+        {impactReceipts.length === 0 ? (
+          <div className="impact-empty-state">
+            <h3>No Impact Receipts yet.</h3>
+            <p>
+              Use the Create Impact Receipt button on a meaningful
+              entry below.
+            </p>
+          </div>
+        ) : (
+          <div className="impact-receipt-grid">
+            {impactReceipts.map((receipt) => (
+              <article
+                className="impact-receipt-card compact"
+                key={receipt.id}
+              >
+                <div className="impact-receipt-top">
+                  <div>
+                    <p className="mini-label">
+                      Impact Receipt
+                    </p>
+                    <h3>{receipt.accomplishment}</h3>
+                  </div>
+
+                  <span
+                    className={`visibility-badge ${
+                      receipt.is_public
+                        ? "public"
+                        : "private"
+                    }`}
+                  >
+                    {receipt.is_public
+                      ? "Public"
+                      : "Private"}
+                  </span>
+                </div>
+
+                <div className="impact-result-preview">
+                  <span>Result</span>
+                  <p>{receipt.result}</p>
+                </div>
+
+                <div className="receipt-summary-row">
+                  <span>
+                    {receipt.evidence?.length ?? 0} evidence
+                  </span>
+                  <span>
+                    {receipt.credit?.length ?? 0} contributors
+                  </span>
+                  <span>
+                    {receipt.confirmations?.filter(
+                      (confirmation) =>
+                        confirmation.status === "confirmed"
+                    ).length ?? 0}{" "}
+                    confirmed
+                  </span>
+                </div>
+
+                <div className="trust-signal-list">
+                  {receipt.trust_signals?.map((signal) => (
+                    <span key={signal}>
+                      {formatLabel(signal)}
+                    </span>
+                  ))}
+                </div>
+
+                <details className="receipt-details">
+                  <summary>View receipt details</summary>
+
+                  <div className="receipt-details-content">
+                    <div className="impact-receipt-detail">
+                      <span>My contribution</span>
+                      <p>{receipt.contribution}</p>
+                    </div>
+
+                    {receipt.skills?.length > 0 && (
+                      <div className="impact-receipt-detail">
+                        <span>Skills demonstrated</span>
+
+                        <div className="tags">
+                          {receipt.skills.map((skill) => (
+                            <span key={skill}>{skill}</span>
+                          ))}
+                        </div>
+                      </div>
+                    )}
+
+                    {receipt.evidence?.length > 0 && (
+                      <div className="impact-receipt-detail">
+                        <span>Evidence</span>
+
+                        <div className="impact-evidence-list">
+                          {receipt.evidence.map(
+                            (evidenceItem, index) => (
+                              <div
+                                className="impact-evidence-item"
+                                key={`${evidenceItem.title}-${index}`}
+                              >
+                                <strong>
+                                  {evidenceItem.title}
+                                </strong>
+
+                                <small>
+                                  {formatLabel(
+                                    evidenceItem.evidence_type
+                                  )}
+                                </small>
+
+                                {evidenceItem.reference && (
+                                  <p>
+                                    {evidenceItem.reference}
+                                  </p>
+                                )}
+
+                                {evidenceItem.description && (
+                                  <p>
+                                    {evidenceItem.description}
+                                  </p>
+                                )}
+
+                                <span
+                                  className={`visibility-badge ${
+                                    evidenceItem.is_public
+                                      ? "public"
+                                      : "private"
+                                  }`}
+                                >
+                                  {evidenceItem.is_public
+                                    ? "Public evidence"
+                                    : "Private evidence"}
+                                </span>
+                              </div>
+                            )
+                          )}
+                        </div>
+                      </div>
+                    )}
+
+                    {receipt.credit?.length > 0 && (
+                      <div className="impact-receipt-detail">
+                        <span>Shared credit</span>
+
+                        <div className="impact-credit-list">
+                          {receipt.credit.map(
+                            (creditItem, index) => (
+                              <p
+                                key={`${creditItem.name}-${index}`}
+                              >
+                                <strong>
+                                  {creditItem.name}
+                                </strong>
+                                {" — "}
+                                {creditItem.contribution}
+                              </p>
+                            )
+                          )}
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                </details>
+              </article>
+            ))}
+          </div>
+        )}
       </section>
 
       <section className="toolbar">
@@ -467,7 +752,11 @@ function App() {
             Logout
           </button>
 
-          <button className="btn primary icon-btn" onClick={openCreateModal}>
+          <button
+            className="btn primary icon-btn"
+            type="button"
+            onClick={openCreateModal}
+          >
             <Plus size={18} />
             New Entry
           </button>
@@ -487,47 +776,75 @@ function App() {
             <div className="empty-state">
               <h3>No entries loaded yet.</h3>
               <p>
-                Once your backend is connected, your technical wins will appear
-                here as resume-ready proof.
+                Add a brag entry to begin building your
+                evidence-backed career record.
               </p>
             </div>
           ) : (
             <div className="entry-list">
-              {entries.map((entry) => (
-                <article className="entry-card" key={entry.id}>
+              {entries.map((entry) => {
+                const hasReceipt = receiptSourceEntryIds.has(
+                  entry.id
+                );
+                const isCreatingReceipt =
+                  creatingReceiptEntryId === entry.id;
+
+                return (
+                  <article
+                    className="entry-card"
+                    key={entry.id}
+                  >
                   <div className="entry-top">
                     <div>
                       <p className="mini-label">
                         {entry.category}
-                        {entry.entry_type ? ` • ${entry.entry_type}` : ""}
-                        {entry.entry_date ? ` • ${entry.entry_date}` : ""}
+                        {entry.entry_type
+                          ? ` • ${entry.entry_type}`
+                          : ""}
+                        {entry.entry_date
+                          ? ` • ${entry.entry_date}`
+                          : ""}
                       </p>
+
                       <h3>{entry.title}</h3>
                     </div>
 
                     <div className="entry-actions">
                       <span
-                        className={`visibility-badge ${entry.is_public ? "public" : "private"
-                          }`}
+                        className={`visibility-badge ${
+                          entry.is_public
+                            ? "public"
+                            : "private"
+                        }`}
                       >
-                        {entry.is_public ? "Public" : "Private"}
+                        {entry.is_public
+                          ? "Public"
+                          : "Private"}
                       </span>
 
                       <button
                         type="button"
                         className="icon-action"
-                        onClick={() => openEditModal(entry)}
+                        onClick={() =>
+                          openEditModal(entry)
+                        }
                         aria-label="Edit entry"
                         title="Edit entry"
                       >
-                        <Pencil size={17} strokeWidth={2.4} />
+                        <Pencil
+                          size={17}
+                          strokeWidth={2.4}
+                        />
                       </button>
 
                       <button
                         type="button"
                         className="icon-action danger"
-                        onClick={() => handleDeleteEntry(entry.id)}
+                        onClick={() =>
+                          handleDeleteEntry(entry.id)
+                        }
                         aria-label="Delete entry"
+                        title="Delete entry"
                       >
                         <Trash2 size={16} />
                       </button>
@@ -541,8 +858,26 @@ function App() {
                       <span key={tag}>{tag}</span>
                     ))}
                   </div>
+
+                  <div className="entry-receipt-action">
+                    <button
+                      type="button"
+                      className="btn secondary receipt-button"
+                      disabled={hasReceipt || isCreatingReceipt}
+                      onClick={() =>
+                        handleCreateImpactReceipt(entry.id)
+                      }
+                    >
+                      {isCreatingReceipt
+                        ? "Creating receipt..."
+                        : hasReceipt
+                          ? "Impact Receipt created"
+                          : "Create Impact Receipt"}
+                    </button>
+                  </div>
                 </article>
-              ))}
+                );
+              })}
             </div>
           )}
         </article>
@@ -553,7 +888,10 @@ function App() {
 
           {topTags.length === 0 ? (
             <div className="empty-state small">
-              <p>Your top skills will show here after entries load.</p>
+              <p>
+                Your top skills will show here after entries
+                load.
+              </p>
             </div>
           ) : (
             <div className="skill-list">
@@ -569,319 +907,326 @@ function App() {
       </section>
 
       {isProfileModalOpen && (
-  <div
-    className="modal-backdrop"
-    onClick={closeProfileModal}
-  >
-    <div
-      className="modal-card profile-modal-card"
-      onClick={(event) => event.stopPropagation()}
-    >
-      <div className="modal-header">
-        <div>
-          <p className="mini-label">Profile Settings</p>
-          <h2>Edit your public profile</h2>
-        </div>
-
-        <button
-          type="button"
-          className="modal-close"
+        <div
+          className="modal-backdrop"
           onClick={closeProfileModal}
-          aria-label="Close profile editor"
         >
-          <X size={18} />
-        </button>
-      </div>
-
-      <form
-        className="entry-form"
-        onSubmit={handleProfileSubmit}
-      >
-        <label>
-          Display name
-          <input
-            name="name"
-            value={profileForm.name}
-            onChange={handleProfileInputChange}
-            placeholder="Tee"
-            maxLength={80}
-            required
-          />
-        </label>
-
-        <label>
-          Professional headline
-          <input
-            name="headline"
-            value={profileForm.headline}
-            onChange={handleProfileInputChange}
-            placeholder="Docker support engineer and backend developer"
-            maxLength={120}
-          />
-        </label>
-
-        <label>
-          About you
-          <textarea
-            name="bio"
-            value={profileForm.bio}
-            onChange={handleProfileInputChange}
-            placeholder="Share a short professional introduction."
-            maxLength={500}
-          />
-        </label>
-
-        <label>
-          Location
-          <input
-            name="location"
-            value={profileForm.location}
-            onChange={handleProfileInputChange}
-            placeholder="Atlanta, Georgia"
-            maxLength={100}
-          />
-        </label>
-
-        <label>
-          GitHub URL
-          <input
-            type="url"
-            name="github_url"
-            value={profileForm.github_url}
-            onChange={handleProfileInputChange}
-            placeholder="https://github.com/username"
-          />
-        </label>
-
-        <label>
-          Portfolio URL
-          <input
-            type="url"
-            name="portfolio_url"
-            value={profileForm.portfolio_url}
-            onChange={handleProfileInputChange}
-            placeholder="https://yourportfolio.com"
-          />
-        </label>
-
-        <label>
-          Résumé URL
-          <input
-            type="url"
-            name="resume_url"
-            value={profileForm.resume_url}
-            onChange={handleProfileInputChange}
-            placeholder="https://example.com/resume"
-          />
-        </label>
-
-        {profileError && (
-          <p className="profile-form-error">
-            {profileError}
-          </p>
-        )}
-
-        <div className="modal-footer">
-          <button
-            type="button"
-            className="btn secondary"
-            onClick={closeProfileModal}
+          <div
+            className="modal-card profile-modal-card"
+            onClick={(event) => event.stopPropagation()}
           >
-            Cancel
-          </button>
+            <div className="modal-header">
+              <div>
+                <p className="mini-label">
+                  Profile Settings
+                </p>
+                <h2>Edit your public profile</h2>
+              </div>
 
-          <button
-            type="submit"
-            className="btn primary form-button"
-            disabled={isSavingProfile}
-          >
-            {isSavingProfile
-              ? "Saving..."
-              : "Save profile"}
-          </button>
-        </div>
-      </form>
-    </div>
-  </div>
-)}
+              <button
+                type="button"
+                className="modal-close"
+                onClick={closeProfileModal}
+                aria-label="Close profile editor"
+              >
+                <X size={18} />
+              </button>
+            </div>
 
-{isModalOpen && (
-  <div className="modal-backdrop" onClick={closeModal}>
-    <div
-      className="modal-card"
-      onClick={(event) => event.stopPropagation()}
-    >
-      <div className="modal-header">
-        <div>
-          <p className="mini-label">
-            {editingEntryId ? "Edit Proof" : "Create Proof"}
-          </p>
-
-          <h2>
-            {editingEntryId
-              ? "Update brag entry"
-              : "Add a new brag entry"}
-          </h2>
-        </div>
-
-        <button
-          type="button"
-          className="modal-close"
-          onClick={closeModal}
-          aria-label="Close modal"
-        >
-          <X size={18} />
-        </button>
-      </div>
-
-      <form
-        className="entry-form"
-        onSubmit={handleCreateEntry}
-      >
-        <div className="form-row">
-          <label>
-            Title
-            <input
-              name="title"
-              value={formData.title}
-              onChange={handleInputChange}
-              placeholder="Debugged Docker networking issue"
-              required
-            />
-          </label>
-
-          <label>
-            Category
-            <input
-              name="category"
-              value={formData.category}
-              onChange={handleInputChange}
-              placeholder="Docker"
-              required
-            />
-          </label>
-        </div>
-
-        <div className="form-row">
-          <label>
-            Entry Date
-            <input
-              type="date"
-              name="entry_date"
-              value={formData.entry_date}
-              onChange={handleInputChange}
-              required
-            />
-          </label>
-
-          <label>
-            Entry Type
-            <select
-              name="entry_type"
-              value={formData.entry_type}
-              onChange={handleInputChange}
-              required
+            <form
+              className="entry-form"
+              onSubmit={handleProfileSubmit}
             >
-              {ENTRY_TYPES.map((type) => (
-                <option key={type} value={type}>
-                  {type}
-                </option>
-              ))}
-            </select>
-          </label>
+              <label>
+                Display name
+                <input
+                  name="name"
+                  value={profileForm.name}
+                  onChange={handleProfileInputChange}
+                  placeholder="Tee"
+                  maxLength={80}
+                  required
+                />
+              </label>
+
+              <label>
+                Professional headline
+                <input
+                  name="headline"
+                  value={profileForm.headline}
+                  onChange={handleProfileInputChange}
+                  placeholder="Docker support engineer and backend developer"
+                  maxLength={120}
+                />
+              </label>
+
+              <label>
+                About you
+                <textarea
+                  name="bio"
+                  value={profileForm.bio}
+                  onChange={handleProfileInputChange}
+                  placeholder="Share a short professional introduction."
+                  maxLength={500}
+                />
+              </label>
+
+              <label>
+                Location
+                <input
+                  name="location"
+                  value={profileForm.location}
+                  onChange={handleProfileInputChange}
+                  placeholder="Atlanta, Georgia"
+                  maxLength={100}
+                />
+              </label>
+
+              <label>
+                GitHub URL
+                <input
+                  type="url"
+                  name="github_url"
+                  value={profileForm.github_url}
+                  onChange={handleProfileInputChange}
+                  placeholder="https://github.com/username"
+                />
+              </label>
+
+              <label>
+                Portfolio URL
+                <input
+                  type="url"
+                  name="portfolio_url"
+                  value={profileForm.portfolio_url}
+                  onChange={handleProfileInputChange}
+                  placeholder="https://yourportfolio.com"
+                />
+              </label>
+
+              <label>
+                Résumé URL
+                <input
+                  type="url"
+                  name="resume_url"
+                  value={profileForm.resume_url}
+                  onChange={handleProfileInputChange}
+                  placeholder="https://example.com/resume"
+                />
+              </label>
+
+              {profileError && (
+                <p className="profile-form-error">
+                  {profileError}
+                </p>
+              )}
+
+              <div className="modal-footer">
+                <button
+                  type="button"
+                  className="btn secondary"
+                  onClick={closeProfileModal}
+                >
+                  Cancel
+                </button>
+
+                <button
+                  type="submit"
+                  className="btn primary form-button"
+                  disabled={isSavingProfile}
+                >
+                  {isSavingProfile
+                    ? "Saving..."
+                    : "Save profile"}
+                </button>
+              </div>
+            </form>
+          </div>
         </div>
+      )}
 
-        <label>
-          Situation
-          <textarea
-            name="situation"
-            value={formData.situation}
-            onChange={handleInputChange}
-            placeholder="What was happening?"
-            required
-          />
-        </label>
-
-        <label>
-          Action
-          <textarea
-            name="action"
-            value={formData.action}
-            onChange={handleInputChange}
-            placeholder="What did you do?"
-            required
-          />
-        </label>
-
-        <label>
-          Impact
-          <textarea
-            name="impact"
-            value={formData.impact}
-            onChange={handleInputChange}
-            placeholder="What changed because of your work?"
-            required
-          />
-        </label>
-
-        <label>
-          Lesson
-          <input
-            name="lesson"
-            value={formData.lesson}
-            onChange={handleInputChange}
-            placeholder="What did you learn?"
-          />
-        </label>
-
-        <label>
-          Tags
-          <input
-            name="tags"
-            value={formData.tags}
-            onChange={handleInputChange}
-            placeholder="Docker, FastAPI, MongoDB"
-          />
-        </label>
-
-        <label className="visibility-toggle">
-          <span>
-            Show this entry on my public BragStack
-          </span>
-
-          <input
-            type="checkbox"
-            name="is_public"
-            checked={formData.is_public}
-            onChange={handleInputChange}
-          />
-        </label>
-
-        <div className="modal-footer">
-          <button
-            type="button"
-            className="btn secondary"
-            onClick={closeModal}
+      {isModalOpen && (
+        <div
+          className="modal-backdrop"
+          onClick={closeModal}
+        >
+          <div
+            className="modal-card"
+            onClick={(event) => event.stopPropagation()}
           >
-            Cancel
-          </button>
+            <div className="modal-header">
+              <div>
+                <p className="mini-label">
+                  {editingEntryId
+                    ? "Edit Proof"
+                    : "Create Proof"}
+                </p>
 
-          <button
-            className="btn primary form-button"
-            type="submit"
-            disabled={isSubmitting}
-          >
-            {isSubmitting
-              ? "Saving..."
-              : editingEntryId
-                ? "Update entry"
-                : "Save brag entry"}
-          </button>
+                <h2>
+                  {editingEntryId
+                    ? "Update brag entry"
+                    : "Add a new brag entry"}
+                </h2>
+              </div>
+
+              <button
+                type="button"
+                className="modal-close"
+                onClick={closeModal}
+                aria-label="Close modal"
+              >
+                <X size={18} />
+              </button>
+            </div>
+
+            <form
+              className="entry-form"
+              onSubmit={handleCreateEntry}
+            >
+              <div className="form-row">
+                <label>
+                  Title
+                  <input
+                    name="title"
+                    value={formData.title}
+                    onChange={handleInputChange}
+                    placeholder="Debugged Docker networking issue"
+                    required
+                  />
+                </label>
+
+                <label>
+                  Category
+                  <input
+                    name="category"
+                    value={formData.category}
+                    onChange={handleInputChange}
+                    placeholder="Docker"
+                    required
+                  />
+                </label>
+              </div>
+
+              <div className="form-row">
+                <label>
+                  Entry Date
+                  <input
+                    type="date"
+                    name="entry_date"
+                    value={formData.entry_date}
+                    onChange={handleInputChange}
+                    required
+                  />
+                </label>
+
+                <label>
+                  Entry Type
+                  <select
+                    name="entry_type"
+                    value={formData.entry_type}
+                    onChange={handleInputChange}
+                    required
+                  >
+                    {ENTRY_TYPES.map((type) => (
+                      <option key={type} value={type}>
+                        {type}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              </div>
+
+              <label>
+                Situation
+                <textarea
+                  name="situation"
+                  value={formData.situation}
+                  onChange={handleInputChange}
+                  placeholder="What was happening?"
+                  required
+                />
+              </label>
+
+              <label>
+                Action
+                <textarea
+                  name="action"
+                  value={formData.action}
+                  onChange={handleInputChange}
+                  placeholder="What did you do?"
+                  required
+                />
+              </label>
+
+              <label>
+                Impact
+                <textarea
+                  name="impact"
+                  value={formData.impact}
+                  onChange={handleInputChange}
+                  placeholder="What changed because of your work?"
+                  required
+                />
+              </label>
+
+              <label>
+                Lesson
+                <input
+                  name="lesson"
+                  value={formData.lesson}
+                  onChange={handleInputChange}
+                  placeholder="What did you learn?"
+                />
+              </label>
+
+              <label>
+                Tags
+                <input
+                  name="tags"
+                  value={formData.tags}
+                  onChange={handleInputChange}
+                  placeholder="Docker, FastAPI, MongoDB"
+                />
+              </label>
+
+              <label className="visibility-toggle">
+                <span>
+                  Show this entry on my public BragStack
+                </span>
+
+                <input
+                  type="checkbox"
+                  name="is_public"
+                  checked={formData.is_public}
+                  onChange={handleInputChange}
+                />
+              </label>
+
+              <div className="modal-footer">
+                <button
+                  type="button"
+                  className="btn secondary"
+                  onClick={closeModal}
+                >
+                  Cancel
+                </button>
+
+                <button
+                  className="btn primary form-button"
+                  type="submit"
+                  disabled={isSubmitting}
+                >
+                  {isSubmitting
+                    ? "Saving..."
+                    : editingEntryId
+                      ? "Update entry"
+                      : "Save brag entry"}
+                </button>
+              </div>
+            </form>
+          </div>
         </div>
-      </form>
-    </div>
-  </div>
-)}
+      )}
     </main>
   );
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -16,6 +16,7 @@ import {
   loginUser,
   registerUser,
   updateEntry,
+  updateCurrentUserProfile,
 } from "./api";
 import "./App.css";
 
@@ -43,6 +44,16 @@ const EMPTY_FORM = {
   is_public: false,
 };
 
+const EMPTY_PROFILE_FORM = {
+  name: "",
+  headline: "",
+  bio: "",
+  location: "",
+  github_url: "",
+  portfolio_url: "",
+  resume_url: "",
+};
+
 function App() {
   const [currentUser, setCurrentUser] = useState(null);
   const [entries, setEntries] = useState([]);
@@ -54,6 +65,10 @@ function App() {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [editingEntryId, setEditingEntryId] = useState(null);
   const [formData, setFormData] = useState(EMPTY_FORM);
+  const [isProfileModalOpen, setIsProfileModalOpen] = useState(false);
+  const [isSavingProfile, setIsSavingProfile] = useState(false);
+  const [profileError, setProfileError] = useState("");
+  const [profileForm, setProfileForm] = useState(EMPTY_PROFILE_FORM);
 
   const path = window.location.pathname;
   const isLandingPage = path === "/";
@@ -91,6 +106,58 @@ function App() {
     }
   }
 
+  function openProfileModal() {
+    setProfileForm({
+      name: currentUser?.name ?? "",
+      headline: currentUser?.headline ?? "",
+      bio: currentUser?.bio ?? "",
+      location: currentUser?.location ?? "",
+      github_url: currentUser?.github_url ?? "",
+      portfolio_url: currentUser?.portfolio_url ?? "",
+      resume_url: currentUser?.resume_url ?? "",
+    });
+
+    setProfileError("");
+    setIsProfileModalOpen(true);
+  }
+
+  function closeProfileModal() {
+    setIsProfileModalOpen(false);
+    setProfileError("");
+  }
+
+  function handleProfileInputChange(event) {
+    const { name, value } = event.target;
+
+    setProfileForm((current) => ({
+      ...current,
+      [name]: value,
+    }));
+  }
+
+  async function handleProfileSubmit(event) {
+    event.preventDefault();
+    setIsSavingProfile(true);
+    setProfileError("");
+
+    try {
+      const updatedUser =
+        await updateCurrentUserProfile(profileForm);
+
+      setCurrentUser(updatedUser);
+      closeProfileModal();
+    } catch (error) {
+      console.error(error);
+
+      setProfileError(
+        error.response?.data?.detail ??
+        "Your profile could not be saved."
+      );
+    } finally {
+      setIsSavingProfile(false);
+    }
+  }
+
   useEffect(() => {
     const token = localStorage.getItem("bragstack_token");
 
@@ -108,7 +175,7 @@ function App() {
     }, 0);
 
     return () => window.clearTimeout(timeoutId);
-  }, [isLandingPage,isPublicPage, isLoginPage, isRegisterPage]);
+  }, [isLandingPage, isPublicPage, isLoginPage, isRegisterPage]);
 
   function openCreateModal() {
     setEditingEntryId(null);
@@ -273,33 +340,84 @@ function App() {
         </div>
 
         <aside className="profile-card">
-          <p className="mini-label">Public Proof Card</p>
+          <div className="profile-card-heading">
+            <p className="mini-label">Public Proof Card</p>
 
-          <div className="avatar">T</div>
+            <button
+              type="button"
+              className="profile-edit-button"
+              onClick={openProfileModal}
+            >
+              <Pencil size={15} />
+              Edit profile
+            </button>
+          </div>
+
+          <div className="avatar">
+            {currentUser?.name?.charAt(0).toUpperCase() || "B"}
+          </div>
 
           <h2>
-            {currentUser?.name ? `${currentUser.name}'s BragStack` : "Your BragStack"}
+            {currentUser?.name
+              ? `${currentUser.name}'s BragStack`
+              : "Your BragStack"}
           </h2>
-          <p>
-            Docker support engineer, backend builder, and SaaS
-            founder-in-progress.
+
+          <p className="profile-headline">
+            {currentUser?.headline ||
+              "Add a professional headline to introduce yourself."}
           </p>
 
+          {currentUser?.bio && (
+            <p className="profile-bio">{currentUser.bio}</p>
+          )}
+
+          {currentUser?.location && (
+            <p className="profile-location">
+              {currentUser.location}
+            </p>
+          )}
+
           <div className="proof-links">
-            <a href="#" aria-label="Resume link">
-              Resume <span>Coming soon</span>
-            </a>
-            <a href="#" aria-label="Portfolio link">
-              Portfolio <span>Coming soon</span>
-            </a>
-            <a
-              href="https://github.com/mergemaven11/bragstack"
-              target="_blank"
-              rel="noreferrer"
-              aria-label="GitHub link"
-            >
-              GitHub <span>Repo</span>
-            </a>
+            {currentUser?.public_slug && (
+              <a
+                href={`/brag/${currentUser.public_slug}`}
+                target="_blank"
+                rel="noreferrer"
+              >
+                Public BragStack <span>View profile</span>
+              </a>
+            )}
+
+            {currentUser?.resume_url && (
+              <a
+                href={currentUser.resume_url}
+                target="_blank"
+                rel="noreferrer"
+              >
+                Résumé <span>Open</span>
+              </a>
+            )}
+
+            {currentUser?.portfolio_url && (
+              <a
+                href={currentUser.portfolio_url}
+                target="_blank"
+                rel="noreferrer"
+              >
+                Portfolio <span>Visit</span>
+              </a>
+            )}
+
+            {currentUser?.github_url && (
+              <a
+                href={currentUser.github_url}
+                target="_blank"
+                rel="noreferrer"
+              >
+                GitHub <span>Profile</span>
+              </a>
+            )}
           </div>
         </aside>
       </section>
@@ -450,176 +568,320 @@ function App() {
         </aside>
       </section>
 
-      {isModalOpen && (
-        <div className="modal-backdrop" onClick={closeModal}>
-          <div
-            className="modal-card"
-            onClick={(event) => event.stopPropagation()}
-          >
-            <div className="modal-header">
-              <div>
-                <p className="mini-label">
-                  {editingEntryId ? "Edit Proof" : "Create Proof"}
-                </p>
-                <h2>
-                  {editingEntryId
-                    ? "Update brag entry"
-                    : "Add a new brag entry"}
-                </h2>
-              </div>
-
-              <button
-                className="modal-close"
-                onClick={closeModal}
-                aria-label="Close modal"
-              >
-                <X size={18} />
-              </button>
-            </div>
-
-            <form className="entry-form" onSubmit={handleCreateEntry}>
-              <div className="form-row">
-                <label>
-                  Title
-                  <input
-                    name="title"
-                    value={formData.title}
-                    onChange={handleInputChange}
-                    placeholder="Debugged Docker networking issue"
-                    required
-                  />
-                </label>
-
-                <label>
-                  Category
-                  <input
-                    name="category"
-                    value={formData.category}
-                    onChange={handleInputChange}
-                    placeholder="Docker"
-                    required
-                  />
-                </label>
-              </div>
-
-              <div className="form-row">
-                <label>
-                  Entry Date
-                  <input
-                    type="date"
-                    name="entry_date"
-                    value={formData.entry_date}
-                    onChange={handleInputChange}
-                    required
-                  />
-                </label>
-
-                <label>
-                  Entry Type
-                  <select
-                    name="entry_type"
-                    value={formData.entry_type}
-                    onChange={handleInputChange}
-                    required
-                  >
-                    {ENTRY_TYPES.map((type) => (
-                      <option key={type} value={type}>
-                        {type}
-                      </option>
-                    ))}
-                  </select>
-                </label>
-              </div>
-
-              <label>
-                Situation
-                <textarea
-                  name="situation"
-                  value={formData.situation}
-                  onChange={handleInputChange}
-                  placeholder="What was happening?"
-                  required
-                />
-              </label>
-
-              <label>
-                Action
-                <textarea
-                  name="action"
-                  value={formData.action}
-                  onChange={handleInputChange}
-                  placeholder="What did you do?"
-                  required
-                />
-              </label>
-
-              <label>
-                Impact
-                <textarea
-                  name="impact"
-                  value={formData.impact}
-                  onChange={handleInputChange}
-                  placeholder="What changed because of your work?"
-                  required
-                />
-              </label>
-
-              <label>
-                Lesson
-                <input
-                  name="lesson"
-                  value={formData.lesson}
-                  onChange={handleInputChange}
-                  placeholder="What did you learn?"
-                />
-              </label>
-
-              <label>
-                Tags
-                <input
-                  name="tags"
-                  value={formData.tags}
-                  onChange={handleInputChange}
-                  placeholder="Docker, FastAPI, MongoDB"
-                />
-              </label>
-
-              <label className="visibility-toggle">
-                <span>Show this entry on my public BragStack</span>
-
-                <input
-                  type="checkbox"
-                  name="is_public"
-                  checked={formData.is_public}
-                  onChange={handleInputChange}
-                />
-              </label>
-
-              <div className="modal-footer">
-                <button
-                  type="button"
-                  className="btn secondary"
-                  onClick={closeModal}
-                >
-                  Cancel
-                </button>
-
-                <button
-                  className="btn primary form-button"
-                  type="submit"
-                  disabled={isSubmitting}
-                >
-                  {isSubmitting
-                    ? "Saving..."
-                    : editingEntryId
-                      ? "Update entry"
-                      : "Save brag entry"}
-                </button>
-              </div>
-            </form>
-          </div>
+      {isProfileModalOpen && (
+  <div
+    className="modal-backdrop"
+    onClick={closeProfileModal}
+  >
+    <div
+      className="modal-card profile-modal-card"
+      onClick={(event) => event.stopPropagation()}
+    >
+      <div className="modal-header">
+        <div>
+          <p className="mini-label">Profile Settings</p>
+          <h2>Edit your public profile</h2>
         </div>
-      )}
+
+        <button
+          type="button"
+          className="modal-close"
+          onClick={closeProfileModal}
+          aria-label="Close profile editor"
+        >
+          <X size={18} />
+        </button>
+      </div>
+
+      <form
+        className="entry-form"
+        onSubmit={handleProfileSubmit}
+      >
+        <label>
+          Display name
+          <input
+            name="name"
+            value={profileForm.name}
+            onChange={handleProfileInputChange}
+            placeholder="Tee"
+            maxLength={80}
+            required
+          />
+        </label>
+
+        <label>
+          Professional headline
+          <input
+            name="headline"
+            value={profileForm.headline}
+            onChange={handleProfileInputChange}
+            placeholder="Docker support engineer and backend developer"
+            maxLength={120}
+          />
+        </label>
+
+        <label>
+          About you
+          <textarea
+            name="bio"
+            value={profileForm.bio}
+            onChange={handleProfileInputChange}
+            placeholder="Share a short professional introduction."
+            maxLength={500}
+          />
+        </label>
+
+        <label>
+          Location
+          <input
+            name="location"
+            value={profileForm.location}
+            onChange={handleProfileInputChange}
+            placeholder="Atlanta, Georgia"
+            maxLength={100}
+          />
+        </label>
+
+        <label>
+          GitHub URL
+          <input
+            type="url"
+            name="github_url"
+            value={profileForm.github_url}
+            onChange={handleProfileInputChange}
+            placeholder="https://github.com/username"
+          />
+        </label>
+
+        <label>
+          Portfolio URL
+          <input
+            type="url"
+            name="portfolio_url"
+            value={profileForm.portfolio_url}
+            onChange={handleProfileInputChange}
+            placeholder="https://yourportfolio.com"
+          />
+        </label>
+
+        <label>
+          Résumé URL
+          <input
+            type="url"
+            name="resume_url"
+            value={profileForm.resume_url}
+            onChange={handleProfileInputChange}
+            placeholder="https://example.com/resume"
+          />
+        </label>
+
+        {profileError && (
+          <p className="profile-form-error">
+            {profileError}
+          </p>
+        )}
+
+        <div className="modal-footer">
+          <button
+            type="button"
+            className="btn secondary"
+            onClick={closeProfileModal}
+          >
+            Cancel
+          </button>
+
+          <button
+            type="submit"
+            className="btn primary form-button"
+            disabled={isSavingProfile}
+          >
+            {isSavingProfile
+              ? "Saving..."
+              : "Save profile"}
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+)}
+
+{isModalOpen && (
+  <div className="modal-backdrop" onClick={closeModal}>
+    <div
+      className="modal-card"
+      onClick={(event) => event.stopPropagation()}
+    >
+      <div className="modal-header">
+        <div>
+          <p className="mini-label">
+            {editingEntryId ? "Edit Proof" : "Create Proof"}
+          </p>
+
+          <h2>
+            {editingEntryId
+              ? "Update brag entry"
+              : "Add a new brag entry"}
+          </h2>
+        </div>
+
+        <button
+          type="button"
+          className="modal-close"
+          onClick={closeModal}
+          aria-label="Close modal"
+        >
+          <X size={18} />
+        </button>
+      </div>
+
+      <form
+        className="entry-form"
+        onSubmit={handleCreateEntry}
+      >
+        <div className="form-row">
+          <label>
+            Title
+            <input
+              name="title"
+              value={formData.title}
+              onChange={handleInputChange}
+              placeholder="Debugged Docker networking issue"
+              required
+            />
+          </label>
+
+          <label>
+            Category
+            <input
+              name="category"
+              value={formData.category}
+              onChange={handleInputChange}
+              placeholder="Docker"
+              required
+            />
+          </label>
+        </div>
+
+        <div className="form-row">
+          <label>
+            Entry Date
+            <input
+              type="date"
+              name="entry_date"
+              value={formData.entry_date}
+              onChange={handleInputChange}
+              required
+            />
+          </label>
+
+          <label>
+            Entry Type
+            <select
+              name="entry_type"
+              value={formData.entry_type}
+              onChange={handleInputChange}
+              required
+            >
+              {ENTRY_TYPES.map((type) => (
+                <option key={type} value={type}>
+                  {type}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+
+        <label>
+          Situation
+          <textarea
+            name="situation"
+            value={formData.situation}
+            onChange={handleInputChange}
+            placeholder="What was happening?"
+            required
+          />
+        </label>
+
+        <label>
+          Action
+          <textarea
+            name="action"
+            value={formData.action}
+            onChange={handleInputChange}
+            placeholder="What did you do?"
+            required
+          />
+        </label>
+
+        <label>
+          Impact
+          <textarea
+            name="impact"
+            value={formData.impact}
+            onChange={handleInputChange}
+            placeholder="What changed because of your work?"
+            required
+          />
+        </label>
+
+        <label>
+          Lesson
+          <input
+            name="lesson"
+            value={formData.lesson}
+            onChange={handleInputChange}
+            placeholder="What did you learn?"
+          />
+        </label>
+
+        <label>
+          Tags
+          <input
+            name="tags"
+            value={formData.tags}
+            onChange={handleInputChange}
+            placeholder="Docker, FastAPI, MongoDB"
+          />
+        </label>
+
+        <label className="visibility-toggle">
+          <span>
+            Show this entry on my public BragStack
+          </span>
+
+          <input
+            type="checkbox"
+            name="is_public"
+            checked={formData.is_public}
+            onChange={handleInputChange}
+          />
+        </label>
+
+        <div className="modal-footer">
+          <button
+            type="button"
+            className="btn secondary"
+            onClick={closeModal}
+          >
+            Cancel
+          </button>
+
+          <button
+            className="btn primary form-button"
+            type="submit"
+            disabled={isSubmitting}
+          >
+            {isSubmitting
+              ? "Saving..."
+              : editingEntryId
+                ? "Update entry"
+                : "Save brag entry"}
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+)}
     </main>
   );
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,6 +3,7 @@ import { Pencil, Plus, Trash2, X } from "lucide-react";
 
 import AuthPage from "./AuthPage";
 import PublicBragPage from "./PublicBragPage";
+import LandingPage from "./LandingPage";
 
 import {
   createEntry,
@@ -55,6 +56,7 @@ function App() {
   const [formData, setFormData] = useState(EMPTY_FORM);
 
   const path = window.location.pathname;
+  const isLandingPage = path === "/";
   const isPublicPage = path.startsWith("/brag");
   const isLoginPage = path === "/login";
   const isRegisterPage = path === "/register";
@@ -92,7 +94,7 @@ function App() {
   useEffect(() => {
     const token = localStorage.getItem("bragstack_token");
 
-    if (isPublicPage || isLoginPage || isRegisterPage) {
+    if (isLandingPage || isPublicPage || isLoginPage || isRegisterPage) {
       return;
     }
 
@@ -106,7 +108,7 @@ function App() {
     }, 0);
 
     return () => window.clearTimeout(timeoutId);
-  }, [isPublicPage, isLoginPage, isRegisterPage]);
+  }, [isLandingPage,isPublicPage, isLoginPage, isRegisterPage]);
 
   function openCreateModal() {
     setEditingEntryId(null);
@@ -207,17 +209,21 @@ function App() {
   async function handleLogin(credentials) {
     const data = await loginUser(credentials);
     localStorage.setItem("bragstack_token", data.access_token);
-    window.location.href = "/";
+    window.location.href = "/app";
   }
 
   async function handleRegister(user) {
     const data = await registerUser(user);
     localStorage.setItem("bragstack_token", data.access_token);
-    window.location.href = "/";
+    window.location.href = "/app";
   }
 
   if (isPublicPage) {
     return <PublicBragPage />;
+  }
+
+  if (isLandingPage) {
+    return <LandingPage />;
   }
 
   if (isLoginPage) {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -382,6 +382,13 @@ function App() {
                     </div>
 
                     <div className="entry-actions">
+                      <span
+                        className={`visibility-badge ${entry.is_public ? "public" : "private"
+                          }`}
+                      >
+                        {entry.is_public ? "Public" : "Private"}
+                      </span>
+
                       <button
                         type="button"
                         className="icon-action"

--- a/frontend/src/LandingPage.css
+++ b/frontend/src/LandingPage.css
@@ -1,0 +1,947 @@
+:root {
+  --landing-bg: #070b14;
+  --landing-surface: #0d1526;
+  --landing-surface-light: #131e33;
+  --landing-border: rgba(148, 163, 184, 0.18);
+  --landing-text: #f8fafc;
+  --landing-muted: #a7b4c9;
+  --landing-blue: #a6dcff;
+  --landing-purple: #ad91ff;
+  --landing-cyan: #69e4f6;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+.landing-page {
+  min-height: 100vh;
+  overflow: hidden;
+  color: var(--landing-text);
+  background:
+    radial-gradient(
+      circle at 15% 5%,
+      rgba(58, 171, 214, 0.17),
+      transparent 28rem
+    ),
+    radial-gradient(
+      circle at 90% 10%,
+      rgba(157, 81, 255, 0.16),
+      transparent 30rem
+    ),
+    var(--landing-bg);
+}
+
+.landing-page a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.landing-nav {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  width: min(1180px, calc(100% - 2rem));
+  margin: 1rem auto 0;
+  padding: 0.8rem 0.9rem 0.8rem 1.2rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border: 1px solid var(--landing-border);
+  border-radius: 18px;
+  background: rgba(7, 11, 20, 0.78);
+  box-shadow: 0 18px 50px rgba(0, 0, 0, 0.2);
+  backdrop-filter: blur(18px);
+}
+
+.landing-logo {
+  font-size: 0.92rem;
+  font-weight: 900;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.landing-nav-links {
+  display: flex;
+  align-items: center;
+  gap: 2rem;
+}
+
+.landing-nav-links a,
+.landing-login-link {
+  color: var(--landing-muted);
+  font-size: 0.9rem;
+  font-weight: 700;
+  transition:
+    color 160ms ease,
+    transform 160ms ease;
+}
+
+.landing-nav-links a:hover,
+.landing-login-link:hover {
+  color: var(--landing-text);
+}
+
+.landing-nav-actions {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.landing-btn {
+  display: inline-flex;
+  min-height: 48px;
+  align-items: center;
+  justify-content: center;
+  gap: 0.55rem;
+  padding: 0.75rem 1.2rem;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  color: #08101d;
+  background: linear-gradient(
+    120deg,
+    var(--landing-blue),
+    var(--landing-purple)
+  );
+  box-shadow: 0 14px 35px rgba(124, 154, 255, 0.2);
+  font-size: 0.92rem;
+  font-weight: 900;
+  transition:
+    transform 160ms ease,
+    box-shadow 160ms ease,
+    border-color 160ms ease;
+}
+
+.landing-btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 42px rgba(124, 154, 255, 0.3);
+}
+
+.landing-btn-small {
+  min-height: 40px;
+  padding: 0.55rem 1rem;
+  font-size: 0.82rem;
+}
+
+.landing-btn-secondary {
+  color: var(--landing-text);
+  border-color: var(--landing-border);
+  background: rgba(15, 23, 42, 0.6);
+  box-shadow: none;
+}
+
+.landing-btn-secondary:hover {
+  border-color: rgba(166, 220, 255, 0.4);
+  box-shadow: none;
+}
+
+.landing-hero {
+  width: min(1180px, calc(100% - 2rem));
+  min-height: 720px;
+  margin: 0 auto;
+  padding: 7rem 0 5rem;
+  display: grid;
+  grid-template-columns: minmax(0, 1.05fr) minmax(420px, 0.95fr);
+  align-items: center;
+  gap: 4rem;
+}
+
+.landing-eyebrow {
+  width: fit-content;
+  margin-bottom: 1.4rem;
+  padding: 0.45rem 0.75rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  border: 1px solid rgba(105, 228, 246, 0.25);
+  border-radius: 999px;
+  color: var(--landing-blue);
+  background: rgba(39, 117, 158, 0.13);
+  font-size: 0.72rem;
+  font-weight: 900;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.landing-hero-copy h1 {
+  max-width: 780px;
+  margin: 0;
+  font-size: clamp(3.8rem, 7vw, 6.8rem);
+  line-height: 0.94;
+  letter-spacing: -0.07em;
+}
+
+.landing-hero-copy h1 span {
+  display: block;
+  padding-bottom: 0.08em;
+  background: linear-gradient(
+    90deg,
+    var(--landing-blue),
+    var(--landing-purple)
+  );
+  background-clip: text;
+  -webkit-background-clip: text;
+  color: transparent;
+}
+
+.landing-hero-description {
+  max-width: 660px;
+  margin: 1.8rem 0 0;
+  color: #c2ccdb;
+  font-size: 1.12rem;
+  line-height: 1.75;
+}
+
+.landing-hero-actions {
+  margin-top: 2rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.8rem;
+}
+
+.landing-trust-line {
+  margin-top: 1.2rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  color: #8290a6;
+  font-size: 0.8rem;
+  font-weight: 700;
+}
+
+.landing-proof-preview {
+  position: relative;
+  min-height: 520px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.preview-glow {
+  position: absolute;
+  width: 360px;
+  height: 360px;
+  border-radius: 50%;
+  background: rgba(128, 105, 255, 0.2);
+  filter: blur(80px);
+}
+
+.proof-preview-card {
+  position: relative;
+  z-index: 2;
+  width: min(100%, 455px);
+  padding: 1.6rem;
+  border: 1px solid rgba(160, 178, 210, 0.22);
+  border-radius: 26px;
+  background:
+    linear-gradient(
+      145deg,
+      rgba(24, 36, 59, 0.98),
+      rgba(12, 19, 35, 0.98)
+    );
+  box-shadow: 0 40px 90px rgba(0, 0, 0, 0.42);
+  transform: rotate(1deg);
+}
+
+.proof-preview-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.proof-preview-header p {
+  margin: 0 0 0.25rem;
+  font-size: 0.76rem;
+  font-weight: 900;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.proof-preview-header span {
+  color: #88e3ae;
+  font-size: 0.76rem;
+  font-weight: 800;
+}
+
+.proof-preview-avatar {
+  width: 50px;
+  height: 50px;
+  display: grid;
+  place-items: center;
+  border-radius: 16px;
+  color: #09101b;
+  background: linear-gradient(
+    135deg,
+    var(--landing-blue),
+    var(--landing-purple)
+  );
+  font-size: 1.2rem;
+  font-weight: 950;
+}
+
+.proof-preview-meta {
+  margin-top: 2.5rem;
+  color: var(--landing-blue);
+  font-size: 0.74rem;
+  font-weight: 900;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.proof-preview-card h2 {
+  margin: 0.7rem 0;
+  font-size: 1.85rem;
+  line-height: 1.15;
+  letter-spacing: -0.04em;
+}
+
+.proof-preview-card > p {
+  color: var(--landing-muted);
+  line-height: 1.65;
+}
+
+.proof-preview-result {
+  margin-top: 1.4rem;
+  padding: 1rem;
+  border: 1px solid rgba(166, 220, 255, 0.17);
+  border-radius: 16px;
+  background: rgba(85, 112, 168, 0.09);
+}
+
+.proof-preview-result span {
+  display: block;
+  margin-bottom: 0.4rem;
+  color: var(--landing-blue);
+  font-size: 0.69rem;
+  font-weight: 900;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.proof-preview-result strong {
+  line-height: 1.5;
+}
+
+.proof-preview-tags,
+.feature-preview-tags {
+  margin-top: 1.2rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.proof-preview-tags span,
+.feature-preview-tags span {
+  padding: 0.42rem 0.65rem;
+  border: 1px solid var(--landing-border);
+  border-radius: 999px;
+  color: #bdc7d8;
+  background: rgba(12, 20, 36, 0.8);
+  font-size: 0.72rem;
+  font-weight: 800;
+}
+
+.floating-proof-card {
+  position: absolute;
+  z-index: 4;
+  min-width: 170px;
+  padding: 0.9rem 1rem;
+  border: 1px solid rgba(166, 220, 255, 0.22);
+  border-radius: 16px;
+  background: rgba(13, 21, 38, 0.9);
+  box-shadow: 0 24px 55px rgba(0, 0, 0, 0.35);
+  backdrop-filter: blur(12px);
+}
+
+.floating-proof-card span {
+  display: block;
+  margin-bottom: 0.25rem;
+  color: var(--landing-muted);
+  font-size: 0.7rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.floating-proof-card strong {
+  font-size: 0.92rem;
+}
+
+.floating-proof-top {
+  top: 6%;
+  right: -2%;
+}
+
+.floating-proof-bottom {
+  bottom: 8%;
+  left: -4%;
+}
+
+.landing-use-strip {
+  width: min(1180px, calc(100% - 2rem));
+  margin: 0 auto 6rem;
+  padding: 1rem;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.65rem;
+  border: 1px solid var(--landing-border);
+  border-radius: 20px;
+  background: rgba(13, 21, 38, 0.55);
+}
+
+.landing-use-strip span {
+  padding: 0.55rem 0.85rem;
+  border: 1px solid rgba(148, 163, 184, 0.14);
+  border-radius: 999px;
+  color: #bcc7d8;
+  background: rgba(21, 33, 54, 0.65);
+  font-size: 0.78rem;
+  font-weight: 800;
+}
+
+.landing-problem-section,
+.landing-use-cases,
+.landing-workflow,
+.landing-pricing {
+  width: min(1180px, calc(100% - 2rem));
+  margin: 0 auto;
+  padding: 6rem 0;
+}
+
+.landing-section-heading {
+  max-width: 720px;
+  margin-bottom: 2.5rem;
+}
+
+.landing-section-heading > p,
+.landing-mini-label,
+.landing-final-cta > div > p {
+  margin: 0 0 0.8rem;
+  color: var(--landing-blue);
+  font-size: 0.72rem;
+  font-weight: 950;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+}
+
+.landing-section-heading h2,
+.landing-feature-copy h2,
+.landing-final-cta h2 {
+  margin: 0;
+  font-size: clamp(2.2rem, 5vw, 4.4rem);
+  line-height: 1.02;
+  letter-spacing: -0.055em;
+}
+
+.landing-section-heading > span {
+  display: block;
+  max-width: 650px;
+  margin-top: 1rem;
+  color: var(--landing-muted);
+  font-size: 1.02rem;
+  line-height: 1.7;
+}
+
+.problem-card-grid,
+.workflow-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.problem-card,
+.workflow-card,
+.use-case-card,
+.pricing-card {
+  border: 1px solid var(--landing-border);
+  background: linear-gradient(
+    145deg,
+    rgba(18, 29, 49, 0.88),
+    rgba(10, 17, 31, 0.88)
+  );
+}
+
+.problem-card {
+  min-height: 250px;
+  padding: 1.5rem;
+  border-radius: 22px;
+}
+
+.problem-card > span,
+.workflow-number {
+  color: var(--landing-blue);
+  font-size: 0.75rem;
+  font-weight: 950;
+  letter-spacing: 0.12em;
+}
+
+.problem-card h3,
+.workflow-card h3,
+.use-case-card h3 {
+  margin: 3.8rem 0 0.7rem;
+  font-size: 1.25rem;
+}
+
+.problem-card p,
+.workflow-card p,
+.use-case-card p {
+  margin: 0;
+  color: var(--landing-muted);
+  line-height: 1.65;
+}
+
+.use-case-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.use-case-card {
+  min-height: 260px;
+  padding: 1.35rem;
+  border-radius: 22px;
+  transition:
+    transform 180ms ease,
+    border-color 180ms ease,
+    background 180ms ease;
+}
+
+.use-case-card:hover {
+  transform: translateY(-5px);
+  border-color: rgba(166, 220, 255, 0.32);
+  background: rgba(22, 35, 58, 0.92);
+}
+
+.use-case-icon {
+  width: 43px;
+  height: 43px;
+  display: grid;
+  place-items: center;
+  border: 1px solid rgba(166, 220, 255, 0.2);
+  border-radius: 14px;
+  color: var(--landing-blue);
+  background: rgba(83, 141, 186, 0.11);
+}
+
+.use-case-card h3 {
+  margin-top: 3.3rem;
+}
+
+.workflow-card {
+  min-height: 270px;
+  padding: 1.6rem;
+  border-radius: 24px;
+}
+
+.workflow-card h3 {
+  margin-top: 4.7rem;
+  font-size: 1.5rem;
+}
+
+.landing-feature-section {
+  width: min(1180px, calc(100% - 2rem));
+  margin: 4rem auto;
+  padding: 4rem;
+  display: grid;
+  grid-template-columns: minmax(0, 0.9fr) minmax(420px, 1.1fr);
+  align-items: center;
+  gap: 4rem;
+  border: 1px solid var(--landing-border);
+  border-radius: 32px;
+  background:
+    radial-gradient(
+      circle at 90% 20%,
+      rgba(127, 95, 255, 0.14),
+      transparent 25rem
+    ),
+    rgba(12, 19, 34, 0.88);
+}
+
+.landing-feature-copy > p:not(.landing-mini-label) {
+  margin: 1.25rem 0 0;
+  color: var(--landing-muted);
+  line-height: 1.75;
+}
+
+.landing-feature-list {
+  margin-top: 1.6rem;
+  display: grid;
+  gap: 0.85rem;
+}
+
+.landing-feature-list div {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+  font-weight: 750;
+}
+
+.landing-feature-list svg,
+.pricing-card li svg {
+  flex: 0 0 auto;
+  color: #90e7b1;
+}
+
+.feature-dashboard-preview {
+  padding: 1.2rem;
+  border: 1px solid rgba(155, 178, 214, 0.2);
+  border-radius: 24px;
+  background: rgba(7, 12, 23, 0.72);
+  box-shadow: 0 35px 80px rgba(0, 0, 0, 0.32);
+}
+
+.feature-preview-header {
+  padding: 1rem;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0.8rem;
+}
+
+.feature-preview-header > div {
+  padding: 1rem;
+  border: 1px solid var(--landing-border);
+  border-radius: 16px;
+  background: rgba(18, 29, 49, 0.7);
+}
+
+.feature-preview-header span {
+  display: block;
+  margin-bottom: 0.6rem;
+  color: var(--landing-muted);
+  font-size: 0.72rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.feature-preview-header strong {
+  font-size: 1.9rem;
+}
+
+.feature-preview-entry {
+  margin-top: 0.4rem;
+  padding: 1.25rem;
+  border: 1px solid var(--landing-border);
+  border-radius: 18px;
+  background: rgba(18, 29, 49, 0.88);
+}
+
+.feature-preview-entry > div:first-child {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.feature-preview-entry small {
+  color: var(--landing-muted);
+}
+
+.feature-preview-badge {
+  padding: 0.32rem 0.55rem;
+  border: 1px solid rgba(74, 222, 128, 0.28);
+  border-radius: 999px;
+  color: #a5efbf;
+  background: rgba(34, 197, 94, 0.1);
+  font-size: 0.68rem;
+  font-weight: 900;
+}
+
+.feature-preview-entry h3 {
+  margin: 1.4rem 0 0.6rem;
+  font-size: 1.35rem;
+}
+
+.feature-preview-entry p {
+  margin: 0;
+  color: var(--landing-muted);
+  line-height: 1.65;
+}
+
+.pricing-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1.2rem;
+}
+
+.pricing-card {
+  position: relative;
+  padding: 2rem;
+  border-radius: 26px;
+}
+
+.pricing-card-featured {
+  border-color: rgba(173, 145, 255, 0.45);
+  background:
+    radial-gradient(
+      circle at 100% 0%,
+      rgba(155, 95, 255, 0.2),
+      transparent 20rem
+    ),
+    linear-gradient(
+      145deg,
+      rgba(25, 31, 59, 0.96),
+      rgba(12, 18, 34, 0.96)
+    );
+}
+
+.pricing-popular-label {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  padding: 0.4rem 0.65rem;
+  border-radius: 999px;
+  color: #e1d8ff;
+  background: rgba(139, 92, 246, 0.16);
+  font-size: 0.69rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+.pricing-card-header {
+  min-height: 110px;
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.pricing-card-header p {
+  margin: 0 0 0.35rem;
+  color: var(--landing-muted);
+  font-weight: 800;
+}
+
+.pricing-card-header h3 {
+  margin: 0;
+  font-size: 3rem;
+}
+
+.pricing-card-header h3 span {
+  color: var(--landing-muted);
+  font-size: 0.9rem;
+  font-weight: 700;
+}
+
+.pricing-card-header > span {
+  max-width: 175px;
+  color: var(--landing-muted);
+  font-size: 0.82rem;
+  text-align: right;
+}
+
+.pricing-card ul {
+  margin: 2rem 0;
+  padding: 0;
+  display: grid;
+  gap: 0.9rem;
+  list-style: none;
+}
+
+.pricing-card li {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  color: #d1d8e4;
+  font-weight: 700;
+}
+
+.pricing-button {
+  width: 100%;
+}
+
+.landing-final-cta {
+  width: min(1180px, calc(100% - 2rem));
+  margin: 4rem auto;
+  padding: 4rem;
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 3rem;
+  border: 1px solid rgba(166, 220, 255, 0.25);
+  border-radius: 32px;
+  background:
+    radial-gradient(
+      circle at 0% 100%,
+      rgba(56, 189, 248, 0.17),
+      transparent 24rem
+    ),
+    radial-gradient(
+      circle at 100% 0%,
+      rgba(168, 85, 247, 0.18),
+      transparent 24rem
+    ),
+    #0d1526;
+}
+
+.landing-final-cta > div > span {
+  display: block;
+  max-width: 650px;
+  margin-top: 1rem;
+  color: var(--landing-muted);
+  line-height: 1.7;
+}
+
+.landing-final-button {
+  flex: 0 0 auto;
+}
+
+.landing-footer {
+  width: min(1180px, calc(100% - 2rem));
+  margin: 0 auto;
+  padding: 2.2rem 0 3rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  border-top: 1px solid var(--landing-border);
+}
+
+.landing-footer p {
+  color: var(--landing-muted);
+  font-size: 0.85rem;
+}
+
+.landing-footer > div {
+  display: flex;
+  gap: 1rem;
+}
+
+.landing-footer > div a {
+  color: var(--landing-muted);
+  font-size: 0.84rem;
+  font-weight: 750;
+}
+
+@media (max-width: 980px) {
+  .landing-nav-links {
+    display: none;
+  }
+
+  .landing-hero {
+    grid-template-columns: 1fr;
+    padding-top: 5rem;
+  }
+
+  .landing-hero-copy {
+    text-align: center;
+  }
+
+  .landing-eyebrow,
+  .landing-hero-actions,
+  .landing-trust-line {
+    margin-right: auto;
+    margin-left: auto;
+    justify-content: center;
+  }
+
+  .landing-hero-description {
+    margin-right: auto;
+    margin-left: auto;
+  }
+
+  .landing-proof-preview {
+    width: min(100%, 590px);
+    margin: 0 auto;
+  }
+
+  .use-case-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .landing-feature-section {
+    padding: 2rem;
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 720px) {
+  .landing-nav {
+    width: calc(100% - 1rem);
+  }
+
+  .landing-login-link {
+    display: none;
+  }
+
+  .landing-hero,
+  .landing-problem-section,
+  .landing-use-cases,
+  .landing-workflow,
+  .landing-pricing,
+  .landing-feature-section,
+  .landing-final-cta,
+  .landing-footer,
+  .landing-use-strip {
+    width: calc(100% - 1.25rem);
+  }
+
+  .landing-hero {
+    min-height: auto;
+    padding-top: 4.5rem;
+    gap: 1rem;
+  }
+
+  .landing-hero-copy h1 {
+    font-size: clamp(3.3rem, 17vw, 5rem);
+  }
+
+  .landing-hero-description {
+    font-size: 1rem;
+  }
+
+  .landing-proof-preview {
+    min-height: 520px;
+  }
+
+  .floating-proof-card {
+    display: none;
+  }
+
+  .problem-card-grid,
+  .workflow-grid,
+  .use-case-grid,
+  .pricing-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .problem-card,
+  .workflow-card,
+  .use-case-card {
+    min-height: auto;
+  }
+
+  .problem-card h3,
+  .workflow-card h3,
+  .use-case-card h3 {
+    margin-top: 2.5rem;
+  }
+
+  .landing-feature-section {
+    margin-top: 2rem;
+    margin-bottom: 2rem;
+  }
+
+  .feature-preview-entry > div:first-child {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .landing-final-cta {
+    padding: 2rem;
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .landing-final-button {
+    width: 100%;
+  }
+
+  .landing-footer {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+}

--- a/frontend/src/LandingPage.jsx
+++ b/frontend/src/LandingPage.jsx
@@ -1,0 +1,486 @@
+import {
+  ArrowRight,
+  Briefcase,
+  Check,
+  FileText,
+  GraduationCap,
+  MessageSquare,
+  Sparkles,
+  Target,
+  TrendingUp,
+  Users,
+} from "lucide-react";
+
+import "./LandingPage.css";
+
+const useCases = [
+  {
+    icon: TrendingUp,
+    title: "Promotions",
+    description:
+      "Walk into promotion conversations with organized proof of your impact, growth, and added responsibilities.",
+  },
+  {
+    icon: MessageSquare,
+    title: "Interviews",
+    description:
+      "Turn real accomplishments into confident interview stories instead of trying to remember examples under pressure.",
+  },
+  {
+    icon: FileText,
+    title: "Performance reviews",
+    description:
+      "Build your review throughout the year instead of reconstructing twelve months of work the night before.",
+  },
+  {
+    icon: Users,
+    title: "1:1 meetings",
+    description:
+      "Bring wins, blockers, lessons, and progress into every conversation with your manager.",
+  },
+  {
+    icon: Target,
+    title: "Trainers and clients",
+    description:
+      "Document milestones, progress, completed goals, and measurable results over time.",
+  },
+  {
+    icon: Briefcase,
+    title: "Freelancers and consultants",
+    description:
+      "Turn completed projects into client updates, case studies, testimonials, and proof of value.",
+  },
+  {
+    icon: GraduationCap,
+    title: "Students and career changers",
+    description:
+      "Track projects, certifications, new skills, and portfolio evidence as your career develops.",
+  },
+  {
+    icon: Sparkles,
+    title: "Creators and founders",
+    description:
+      "Capture launches, experiments, customer wins, audience growth, and business milestones.",
+  },
+];
+
+const workflowSteps = [
+  {
+    number: "01",
+    title: "Capture",
+    description:
+      "Record the situation, action, impact, lesson, and skills while the details are still fresh.",
+  },
+  {
+    number: "02",
+    title: "Organize",
+    description:
+      "Keep accomplishments searchable by category, date, role, entry type, and skill.",
+  },
+  {
+    number: "03",
+    title: "Reuse",
+    description:
+      "Use your proof for interviews, reviews, promotions, résumés, portfolios, clients, and 1:1s.",
+  },
+];
+
+const freeFeatures = [
+  "Up to 30 proof entries",
+  "Five public entries",
+  "Basic skill tracking",
+  "Weekly progress summary",
+];
+
+const proFeatures = [
+  "Unlimited proof entries",
+  "Unlimited public entries",
+  "Advanced reports",
+  "Custom public profile",
+  "Export and résumé tools",
+];
+
+function LandingPage() {
+  return (
+    <main className="landing-page">
+      <header className="landing-nav">
+        <a className="landing-logo" href="/">
+          BragStack
+        </a>
+
+        <nav className="landing-nav-links" aria-label="Main navigation">
+          <a href="#use-cases">Use cases</a>
+          <a href="#how-it-works">How it works</a>
+          <a href="#pricing">Pricing</a>
+        </nav>
+
+        <div className="landing-nav-actions">
+          <a className="landing-login-link" href="/login">
+            Log in
+          </a>
+
+          <a className="landing-btn landing-btn-small" href="/register">
+            Start free
+          </a>
+        </div>
+      </header>
+
+      <section className="landing-hero">
+        <div className="landing-hero-copy">
+          <div className="landing-eyebrow">
+            <Sparkles size={15} />
+            Career proof, organized
+          </div>
+
+          <h1>
+            Your work deserves
+            <span> receipts.</span>
+          </h1>
+
+          <p className="landing-hero-description">
+            BragStack turns everyday wins, progress, and results into organized
+            proof you can use for promotions, interviews, performance reviews,
+            1:1s, client updates, and more.
+          </p>
+
+          <div className="landing-hero-actions">
+            <a className="landing-btn" href="/register">
+              Start building proof
+              <ArrowRight size={18} />
+            </a>
+
+            <a
+              className="landing-btn landing-btn-secondary"
+              href="#how-it-works"
+            >
+              See how it works
+            </a>
+          </div>
+
+          <p className="landing-trust-line">
+            Free to start
+            <span>•</span>
+            No credit card required
+            <span>•</span>
+            Private by default
+          </p>
+        </div>
+
+        <div className="landing-proof-preview">
+          <div className="preview-glow" />
+
+          <article className="proof-preview-card">
+            <div className="proof-preview-header">
+              <div>
+                <p>Recent proof</p>
+                <span>Public entry</span>
+              </div>
+
+              <div className="proof-preview-avatar">T</div>
+            </div>
+
+            <div className="proof-preview-meta">
+              Docker Support · July 2026
+            </div>
+
+            <h2>Reduced customer setup time by 35%</h2>
+
+            <p>
+              Created a repeatable troubleshooting workflow that helped
+              customers identify container networking problems faster.
+            </p>
+
+            <div className="proof-preview-result">
+              <span>Impact</span>
+              <strong>
+                Faster resolutions and a reusable process for the support team.
+              </strong>
+            </div>
+
+            <div className="proof-preview-tags">
+              <span>Docker</span>
+              <span>Networking</span>
+              <span>Support</span>
+            </div>
+          </article>
+
+          <div className="floating-proof-card floating-proof-top">
+            <span>Weekly proof</span>
+            <strong>7 wins captured</strong>
+          </div>
+
+          <div className="floating-proof-card floating-proof-bottom">
+            <span>Top skill</span>
+            <strong>Problem solving</strong>
+          </div>
+        </div>
+      </section>
+
+      <section className="landing-use-strip" aria-label="Popular use cases">
+        <span>Promotions</span>
+        <span>Interviews</span>
+        <span>1:1s</span>
+        <span>Reviews</span>
+        <span>Clients</span>
+        <span>Coaching</span>
+        <span>Portfolios</span>
+      </section>
+
+      <section className="landing-problem-section">
+        <div className="landing-section-heading">
+          <p>THE PROBLEM</p>
+          <h2>Great work is surprisingly easy to forget.</h2>
+          <span>
+            Projects move on, tickets close, meetings end, and months later
+            you’re expected to explain everything you accomplished.
+          </span>
+        </div>
+
+        <div className="problem-card-grid">
+          <article className="problem-card">
+            <span>01</span>
+            <h3>“I know I did a lot…”</h3>
+            <p>
+              The work happened, but the details and measurable results are
+              already fading.
+            </p>
+          </article>
+
+          <article className="problem-card">
+            <span>02</span>
+            <h3>“My résumé sounds generic.”</h3>
+            <p>
+              Your strongest examples are scattered across tickets, messages,
+              notes, and memory.
+            </p>
+          </article>
+
+          <article className="problem-card">
+            <span>03</span>
+            <h3>“My review is next week.”</h3>
+            <p>
+              Now you’re rebuilding an entire year of accomplishments in one
+              stressful sitting.
+            </p>
+          </article>
+        </div>
+      </section>
+
+      <section className="landing-use-cases" id="use-cases">
+        <div className="landing-section-heading">
+          <p>BUILT FOR REAL LIFE</p>
+          <h2>Useful whenever progress needs to be proven.</h2>
+          <span>
+            BragStack is not only for job searches. It helps people document
+            growth, value, outcomes, and momentum.
+          </span>
+        </div>
+
+        <div className="use-case-grid">
+          {useCases.map(({ icon: Icon, title, description }) => (
+            <article className="use-case-card" key={title}>
+              <div className="use-case-icon">
+                <Icon size={21} />
+              </div>
+
+              <h3>{title}</h3>
+              <p>{description}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="landing-workflow" id="how-it-works">
+        <div className="landing-section-heading">
+          <p>HOW IT WORKS</p>
+          <h2>From daily work to reusable proof.</h2>
+          <span>
+            A lightweight habit today becomes an advantage when the next
+            opportunity appears.
+          </span>
+        </div>
+
+        <div className="workflow-grid">
+          {workflowSteps.map((step) => (
+            <article className="workflow-card" key={step.number}>
+              <span className="workflow-number">{step.number}</span>
+              <h3>{step.title}</h3>
+              <p>{step.description}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="landing-feature-section">
+        <div className="landing-feature-copy">
+          <p className="landing-mini-label">YOUR PROOF LIBRARY</p>
+
+          <h2>Remember what you did — and why it mattered.</h2>
+
+          <p>
+            BragStack helps you capture more than a task title. Each entry
+            records the context, your action, the impact, what you learned, and
+            the skills you demonstrated.
+          </p>
+
+          <div className="landing-feature-list">
+            <div>
+              <Check size={17} />
+              Structured accomplishment entries
+            </div>
+
+            <div>
+              <Check size={17} />
+              Résumé-ready impact statements
+            </div>
+
+            <div>
+              <Check size={17} />
+              Public or private visibility controls
+            </div>
+
+            <div>
+              <Check size={17} />
+              Skill and progress tracking
+            </div>
+          </div>
+        </div>
+
+        <div className="feature-dashboard-preview">
+          <div className="feature-preview-header">
+            <div>
+              <span>Weekly entries</span>
+              <strong>12</strong>
+            </div>
+
+            <div>
+              <span>Skills tracked</span>
+              <strong>18</strong>
+            </div>
+          </div>
+
+          <div className="feature-preview-entry">
+            <div>
+              <span className="feature-preview-badge">Public</span>
+              <small>Customer Support · Current Job</small>
+            </div>
+
+            <h3>Improved escalation response process</h3>
+
+            <p>
+              Reduced repeated troubleshooting and gave the team a clearer path
+              for complex customer cases.
+            </p>
+
+            <div className="feature-preview-tags">
+              <span>Leadership</span>
+              <span>Communication</span>
+              <span>Process</span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="landing-pricing" id="pricing">
+        <div className="landing-section-heading">
+          <p>SIMPLE PRICING</p>
+          <h2>Start free. Upgrade when your proof grows.</h2>
+          <span>
+            Build the habit first, then unlock more tools when you need them.
+          </span>
+        </div>
+
+        <div className="pricing-grid">
+          <article className="pricing-card">
+            <div className="pricing-card-header">
+              <div>
+                <p>Free</p>
+                <h3>$0</h3>
+              </div>
+
+              <span>Build your proof</span>
+            </div>
+
+            <ul>
+              {freeFeatures.map((feature) => (
+                <li key={feature}>
+                  <Check size={17} />
+                  {feature}
+                </li>
+              ))}
+            </ul>
+
+            <a
+              className="landing-btn landing-btn-secondary pricing-button"
+              href="/register"
+            >
+              Start free
+            </a>
+          </article>
+
+          <article className="pricing-card pricing-card-featured">
+            <div className="pricing-popular-label">Founding plan</div>
+
+            <div className="pricing-card-header">
+              <div>
+                <p>Pro</p>
+
+                <h3>
+                  $6
+                  <span>/month</span>
+                </h3>
+              </div>
+
+              <span>Use your proof everywhere</span>
+            </div>
+
+            <ul>
+              {proFeatures.map((feature) => (
+                <li key={feature}>
+                  <Check size={17} />
+                  {feature}
+                </li>
+              ))}
+            </ul>
+
+            <a className="landing-btn pricing-button" href="/register">
+              Start with Pro
+              <ArrowRight size={17} />
+            </a>
+          </article>
+        </div>
+      </section>
+
+      <section className="landing-final-cta">
+        <div>
+          <p>YOUR NEXT OPPORTUNITY WILL ASK WHAT YOU’VE DONE.</p>
+          <h2>Make sure you have the proof.</h2>
+          <span>
+            Start capturing the wins, growth, and results that deserve to be
+            remembered.
+          </span>
+        </div>
+
+        <a className="landing-btn landing-final-button" href="/register">
+          Build my BragStack
+          <ArrowRight size={18} />
+        </a>
+      </section>
+
+      <footer className="landing-footer">
+        <a className="landing-logo" href="/">
+          BragStack
+        </a>
+
+        <p>Turn everyday progress into undeniable proof.</p>
+
+        <div>
+          <a href="/login">Log in</a>
+          <a href="/register">Create account</a>
+        </div>
+      </footer>
+    </main>
+  );
+}
+
+export default LandingPage;

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -54,6 +54,19 @@ export async function getCurrentUser() {
   return response.data;
 }
 
+export async function updateCurrentUserProfile(profile) {
+  const response = await api.patch("/auth/me/profile", profile);
+  return response.data;
+}
+
+export async function getPublicProfile(slug) {
+  const response = await api.get(
+    getPublicBragPath(slug, "/profile")
+  );
+
+  return response.data;
+}
+
 export async function getEntries() {
   const response = await api.get("/entries?limit=10&skip=0");
   return response.data;

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -121,3 +121,23 @@ export async function getPublicCategoriesSummary(slug) {
   const response = await api.get(getPublicBragPath(slug, "/categories/summary"));
   return response.data;
 }
+
+export async function getImpactReceipts() {
+  const response = await api.get(
+    "/impact-receipts?limit=20&skip=0"
+  );
+
+  return response.data;
+}
+
+export async function createImpactReceiptFromEntry(
+  entryId,
+  payload
+) {
+  const response = await api.post(
+    `/impact-receipts/from-entry/${entryId}`,
+    payload
+  );
+
+  return response.data;
+}


### PR DESCRIPTION
## Summary

Adds the first working version of Impact Receipts to BragStack.

Users can now turn an existing brag entry into a structured Impact Receipt containing their accomplishment, contribution, result, skills, evidence, shared credit, confirmations, trust signals, and visibility settings.

## Included

- Added Impact Receipt data models
- Added MongoDB `impact_receipts` collection
- Added authenticated receipt creation from an existing entry
- Added duplicate-receipt protection
- Added receipt ownership checks
- Added paginated receipt retrieval with `limit`, `skip`, and `has_more`
- Added Impact Receipt cards to the dashboard
- Added a Create Impact Receipt button to entry cards
- Added compact, expandable receipt details
- Added success and error feedback
- Added public-profile and landing-page improvements
- Added backend hot reload for local Docker development

## Validation

- Frontend production build passes
- Receipt creation tested through the API and frontend
- Receipts persist after page refresh
- Existing login, entries, users, and MongoDB data continue to work

## Follow-up work

A future branch will add a dedicated Impact Receipt library page, filters, pagination controls, editing, evidence management, and confirmation workflows.