### PR TITLE
Add public career analytics dashboard

### DIFF
--- a/frontend/src/PublicBragPage.css
+++ b/frontend/src/PublicBragPage.css
@@ -16,7 +16,8 @@
 .public-controls,
 .public-timeline,
 .sidebar-card,
-.public-notice {
+.public-notice,
+.analytics-shell {
   border: 1px solid rgba(148, 163, 184, 0.18);
   background: rgba(15, 23, 42, 0.72);
   backdrop-filter: blur(18px);
@@ -100,6 +101,227 @@
   font-weight: 800;
 }
 
+.analytics-shell {
+  padding: 28px;
+  margin-bottom: 20px;
+  overflow: hidden;
+  position: relative;
+}
+
+.analytics-shell::before {
+  content: "";
+  position: absolute;
+  width: 360px;
+  height: 360px;
+  border-radius: 50%;
+  right: -180px;
+  top: -180px;
+  background: radial-gradient(circle, rgba(56, 189, 248, 0.18), transparent 65%);
+  pointer-events: none;
+}
+
+.analytics-heading,
+.chart-card-heading,
+.analytics-kpi,
+.bar-chart-label,
+.skill-bar-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+}
+
+.analytics-heading {
+  align-items: flex-start;
+  margin-bottom: 20px;
+}
+
+.analytics-heading h2,
+.chart-card-heading h3 {
+  margin: 5px 0 0;
+  letter-spacing: -0.04em;
+}
+
+.analytics-heading h2 {
+  font-size: 2rem;
+}
+
+.analytics-heading p:not(.mini-label) {
+  margin: 8px 0 0;
+  color: #94a3b8;
+}
+
+.analytics-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 9px 12px;
+  border-radius: 999px;
+  color: #c4b5fd;
+  background: rgba(139, 92, 246, 0.11);
+  border: 1px solid rgba(196, 181, 253, 0.16);
+  font-size: 0.82rem;
+  font-weight: 900;
+  white-space: nowrap;
+}
+
+.analytics-kpis {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+  margin-bottom: 14px;
+}
+
+.analytics-kpi {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  padding: 18px;
+  border-radius: 22px;
+  background: linear-gradient(145deg, rgba(30, 41, 59, 0.82), rgba(2, 6, 23, 0.54));
+  border: 1px solid rgba(148, 163, 184, 0.14);
+}
+
+.analytics-kpi svg {
+  color: #7dd3fc;
+}
+
+.analytics-kpi span {
+  color: #cbd5e1;
+  font-weight: 800;
+}
+
+.analytics-kpi strong {
+  color: #f8fafc;
+  font-size: 1.55rem;
+  letter-spacing: -0.04em;
+}
+
+.analytics-kpi small {
+  grid-column: 1 / -1;
+  color: #64748b;
+  margin-top: 8px;
+  line-height: 1.45;
+}
+
+.analytics-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.chart-card {
+  min-width: 0;
+  padding: 20px;
+  border-radius: 24px;
+  background: rgba(2, 6, 23, 0.36);
+  border: 1px solid rgba(148, 163, 184, 0.13);
+}
+
+.skills-chart-card {
+  grid-column: 1 / -1;
+}
+
+.chart-card-heading {
+  align-items: flex-start;
+  margin-bottom: 20px;
+}
+
+.chart-card-heading h3 {
+  font-size: 1.2rem;
+}
+
+.chart-card-heading > span {
+  color: #64748b;
+  font-size: 0.78rem;
+  font-weight: 800;
+}
+
+.activity-chart {
+  min-height: 190px;
+}
+
+.activity-chart svg {
+  width: 100%;
+  height: 155px;
+  overflow: visible;
+}
+
+.activity-area {
+  fill: url(#activityFill);
+}
+
+.activity-line {
+  fill: none;
+  stroke: #7dd3fc;
+  stroke-width: 2.2;
+  vector-effect: non-scaling-stroke;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  filter: drop-shadow(0 0 7px rgba(56, 189, 248, 0.35));
+}
+
+.activity-dot {
+  fill: #f8fafc;
+  stroke: #38bdf8;
+  stroke-width: 1;
+  vector-effect: non-scaling-stroke;
+}
+
+.activity-labels {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 4px;
+  color: #64748b;
+  font-size: 0.72rem;
+  font-weight: 800;
+  text-align: center;
+}
+
+.bar-chart-list,
+.skill-bar-grid {
+  display: grid;
+  gap: 13px;
+}
+
+.bar-chart-label,
+.skill-bar-top {
+  margin-bottom: 6px;
+}
+
+.bar-chart-label span,
+.skill-bar-top span {
+  color: #cbd5e1;
+  font-size: 0.84rem;
+  font-weight: 800;
+}
+
+.bar-chart-label strong,
+.skill-bar-top strong {
+  color: #f8fafc;
+  font-size: 0.82rem;
+}
+
+.bar-chart-track,
+.skill-bar-track {
+  height: 8px;
+  border-radius: 999px;
+  background: rgba(30, 41, 59, 0.9);
+  overflow: hidden;
+}
+
+.bar-chart-track span,
+.skill-bar-track span {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, #38bdf8, #8b5cf6);
+  box-shadow: 0 0 18px rgba(56, 189, 248, 0.2);
+}
+
+.skill-bar-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
 .public-notice {
   padding: 14px 18px;
   margin-bottom: 20px;
@@ -133,9 +355,7 @@
   font: inherit;
 }
 
-.search-box input::placeholder {
-  color: #64748b;
-}
+.search-box input::placeholder { color: #64748b; }
 
 .filter-pills {
   display: flex;
@@ -166,9 +386,7 @@
 }
 
 .public-timeline,
-.sidebar-card {
-  padding: 26px;
-}
+.sidebar-card { padding: 26px; }
 
 .timeline-header {
   display: flex;
@@ -205,10 +423,7 @@
   gap: 18px;
 }
 
-.public-entry h3 {
-  margin: 6px 0 0;
-  font-size: 1.25rem;
-}
+.public-entry h3 { margin: 6px 0 0; font-size: 1.25rem; }
 
 .public-entry-meta {
   display: flex;
@@ -246,9 +461,7 @@
   border: 1px solid rgba(148, 163, 184, 0.12);
 }
 
-.proof-grid strong {
-  color: #f8fafc;
-}
+.proof-grid strong { color: #f8fafc; }
 
 .proof-grid p {
   color: #cbd5e1;
@@ -273,24 +486,28 @@
   gap: 16px;
 }
 
-.muted {
-  color: #94a3b8;
-}
+.muted { color: #94a3b8; }
 
 @media (max-width: 940px) {
   .public-hero,
-  .public-layout {
+  .public-layout,
+  .analytics-grid {
     grid-template-columns: 1fr;
   }
 
-  .public-entry-top,
-  .timeline-header {
-    flex-direction: column;
-  }
+  .skills-chart-card { grid-column: auto; }
 
-  .public-entry-meta {
-    justify-content: flex-start;
-  }
+  .analytics-kpis { grid-template-columns: 1fr; }
+
+  .public-entry-top,
+  .timeline-header,
+  .analytics-heading { flex-direction: column; }
+
+  .public-entry-meta { justify-content: flex-start; }
+}
+
+@media (max-width: 640px) {
+  .skill-bar-grid { grid-template-columns: 1fr; }
 }
 
 @media (max-width: 540px) {
@@ -303,15 +520,10 @@
   .public-proof-card,
   .public-controls,
   .public-timeline,
-  .sidebar-card {
-    border-radius: 24px;
-  }
+  .sidebar-card,
+  .analytics-shell { border-radius: 24px; }
 
-  .public-hero > div {
-    padding: 26px;
-  }
-
-  .public-hero h1 {
-    font-size: clamp(2.5rem, 15vw, 4rem);
-  }
+  .public-hero > div { padding: 26px; }
+  .public-hero h1 { font-size: clamp(2.5rem, 15vw, 4rem); }
+  .analytics-shell { padding: 20px; }
 }

--- a/frontend/src/PublicBragPage.jsx
+++ b/frontend/src/PublicBragPage.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { ExternalLink, Search } from "lucide-react";
+import { BarChart3, ExternalLink, Search, ShieldCheck, Sparkles } from "lucide-react";
 import {
   getPublicCategoriesSummary,
   getPublicEntries,
@@ -22,25 +22,15 @@ const FILTERS = [
 ];
 
 function normalizeTags(tags) {
-  if (Array.isArray(tags)) {
-    return tags;
-  }
-
+  if (Array.isArray(tags)) return tags;
   if (typeof tags === "string") {
-    return tags
-      .split(",")
-      .map((tag) => tag.trim())
-      .filter(Boolean);
+    return tags.split(",").map((tag) => tag.trim()).filter(Boolean);
   }
-
   return [];
 }
 
 function safeText(value) {
-  if (value === null || value === undefined) {
-    return "";
-  }
-
+  if (value === null || value === undefined) return "";
   return String(value);
 }
 
@@ -48,6 +38,71 @@ function formatSignal(value = "") {
   return value
     .replace(/-/g, " ")
     .replace(/\b\w/g, (character) => character.toUpperCase());
+}
+
+function buildMonthlyActivity(entries) {
+  const now = new Date();
+  const buckets = Array.from({ length: 6 }, (_, index) => {
+    const date = new Date(now.getFullYear(), now.getMonth() - (5 - index), 1);
+    return {
+      key: `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}`,
+      label: date.toLocaleDateString(undefined, { month: "short" }),
+      count: 0,
+    };
+  });
+
+  const indexByKey = Object.fromEntries(buckets.map((bucket, index) => [bucket.key, index]));
+
+  entries.forEach((entry) => {
+    if (!entry.entry_date) return;
+    const date = new Date(`${entry.entry_date}T00:00:00`);
+    if (Number.isNaN(date.getTime())) return;
+    const key = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}`;
+    const index = indexByKey[key];
+    if (index !== undefined) buckets[index].count += 1;
+  });
+
+  return buckets;
+}
+
+function ActivityChart({ data }) {
+  const max = Math.max(...data.map((item) => item.count), 1);
+  const points = data.map((item, index) => {
+    const x = data.length === 1 ? 50 : (index / (data.length - 1)) * 100;
+    const y = 82 - (item.count / max) * 58;
+    return { ...item, x, y };
+  });
+
+  return (
+    <div className="activity-chart" aria-label="Accomplishment activity over six months">
+      <svg viewBox="0 0 100 92" preserveAspectRatio="none" role="img">
+        <defs>
+          <linearGradient id="activityFill" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor="#38bdf8" stopOpacity="0.42" />
+            <stop offset="100%" stopColor="#8b5cf6" stopOpacity="0" />
+          </linearGradient>
+        </defs>
+        <path
+          className="activity-area"
+          d={`M 0 82 ${points.map((point) => `L ${point.x} ${point.y}`).join(" ")} L 100 82 Z`}
+        />
+        <polyline
+          className="activity-line"
+          points={points.map((point) => `${point.x},${point.y}`).join(" ")}
+        />
+        {points.map((point) => (
+          <circle key={point.key} cx={point.x} cy={point.y} r="1.8" className="activity-dot" />
+        ))}
+      </svg>
+      <div className="activity-labels">
+        {points.map((point) => (
+          <span key={point.key} title={`${point.count} accomplishment${point.count === 1 ? "" : "s"}`}>
+            {point.label}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
 }
 
 function PublicBragPage() {
@@ -69,21 +124,15 @@ function PublicBragPage() {
   useEffect(() => {
     async function loadPublicPage() {
       try {
-        const [
-          profileData,
-          entriesData,
-          receiptsData,
-          weeklyData,
-          tagsData,
-          categoriesData,
-        ] = await Promise.all([
-          getPublicProfile(publicSlug),
-          getPublicEntries(publicSlug),
-          getPublicImpactReceipts(publicSlug),
-          getPublicWeeklyReport(publicSlug),
-          getPublicTagsSummary(publicSlug),
-          getPublicCategoriesSummary(publicSlug),
-        ]);
+        const [profileData, entriesData, receiptsData, weeklyData, tagsData, categoriesData] =
+          await Promise.all([
+            getPublicProfile(publicSlug),
+            getPublicEntries(publicSlug),
+            getPublicImpactReceipts(publicSlug),
+            getPublicWeeklyReport(publicSlug),
+            getPublicTagsSummary(publicSlug),
+            getPublicCategoriesSummary(publicSlug),
+          ]);
 
         setProfile(profileData.profile ?? null);
         setEntries(entriesData.entries || []);
@@ -104,7 +153,6 @@ function PublicBragPage() {
   const filteredEntries = useMemo(() => {
     return entries.filter((entry) => {
       const tags = normalizeTags(entry.tags);
-
       const searchableText = [
         entry.title,
         entry.category,
@@ -122,14 +170,41 @@ function PublicBragPage() {
         .toLowerCase();
 
       const matchesSearch = searchableText.includes(searchTerm.toLowerCase());
-      const matchesFilter =
-        activeFilter === "All" || entry.entry_type === activeFilter;
-
+      const matchesFilter = activeFilter === "All" || entry.entry_type === activeFilter;
       return matchesSearch && matchesFilter;
     });
   }, [entries, searchTerm, activeFilter]);
 
-  const topTags = tagsSummary?.tags ? Object.entries(tagsSummary.tags) : [];
+  const analytics = useMemo(() => {
+    const categories = Object.entries(categoriesSummary?.categories || {});
+    const tags = Object.entries(tagsSummary?.tags || {});
+    const evidenceCount = impactReceipts.reduce(
+      (total, receipt) => total + (receipt.evidence?.length || 0),
+      0
+    );
+    const evidenceLinked = impactReceipts.filter((receipt) =>
+      receipt.trust_signals?.includes("evidence-linked")
+    ).length;
+    const receiptCoverage = entries.length
+      ? Math.min(100, Math.round((impactReceipts.length / entries.length) * 100))
+      : 0;
+    const evidenceCoverage = impactReceipts.length
+      ? Math.round((evidenceLinked / impactReceipts.length) * 100)
+      : 0;
+
+    return {
+      categories,
+      tags,
+      evidenceCount,
+      receiptCoverage,
+      evidenceCoverage,
+      monthlyActivity: buildMonthlyActivity(entries),
+    };
+  }, [entries, impactReceipts, tagsSummary, categoriesSummary]);
+
+  const topTags = analytics.tags;
+  const maxCategoryCount = Math.max(...analytics.categories.map(([, count]) => count), 1);
+  const maxSkillCount = Math.max(...topTags.map(([, count]) => count), 1);
   const displayName = profile?.name || "BragStack member";
   const avatarLetter = displayName.charAt(0).toUpperCase() || "B";
 
@@ -140,76 +215,131 @@ function PublicBragPage() {
           <p className="mini-label">Public BragStack</p>
           <h1>{displayName}&apos;s Career Proof Timeline</h1>
           <p>
-            {profile?.bio ||
-              "A searchable record of accomplishments, skill growth, and career proof."}
+            {profile?.bio || "A searchable record of accomplishments, skill growth, and career proof."}
           </p>
 
           <div className="public-actions">
             {profile?.github_url && (
-              <a
-                href={profile.github_url}
-                target="_blank"
-                rel="noreferrer"
-                className="public-button primary"
-              >
-                <ExternalLink size={17} />
-                GitHub
+              <a href={profile.github_url} target="_blank" rel="noreferrer" className="public-button primary">
+                <ExternalLink size={17} /> GitHub
               </a>
             )}
-
             {profile?.portfolio_url && (
-              <a
-                href={profile.portfolio_url}
-                target="_blank"
-                rel="noreferrer"
-                className="public-button secondary"
-              >
-                <ExternalLink size={17} />
-                Portfolio
+              <a href={profile.portfolio_url} target="_blank" rel="noreferrer" className="public-button secondary">
+                <ExternalLink size={17} /> Portfolio
               </a>
             )}
-
             {profile?.resume_url && (
-              <a
-                href={profile.resume_url}
-                target="_blank"
-                rel="noreferrer"
-                className="public-button secondary"
-              >
-                <ExternalLink size={17} />
-                Résumé
+              <a href={profile.resume_url} target="_blank" rel="noreferrer" className="public-button secondary">
+                <ExternalLink size={17} /> Résumé
               </a>
             )}
-
-            <a href="/" className="public-button secondary">
-              BragStack
-            </a>
+            <a href="/" className="public-button secondary">BragStack</a>
           </div>
         </div>
 
         <aside className="public-proof-card">
           <div className="avatar">{avatarLetter}</div>
           <h2>{profile?.headline || displayName}</h2>
-
           {(profile?.location || profile?.bio) && (
-            <p>
-              {[profile?.location, profile?.bio]
-                .filter(Boolean)
-                .join(" • ")}
-            </p>
+            <p>{[profile?.location, profile?.bio].filter(Boolean).join(" • ")}</p>
           )}
-
           <div className="public-stat-list">
             <span>{entries.length} total entries</span>
             <span>{impactReceipts.length} public receipts</span>
             <span>{weeklyReport?.total_entries ?? 0} this week</span>
             <span>{tagsSummary?.total_unique_tags ?? 0} skill tags</span>
-            <span>
-              {categoriesSummary?.total_unique_categories ?? 0} categories
-            </span>
+            <span>{categoriesSummary?.total_unique_categories ?? 0} categories</span>
           </div>
         </aside>
       </section>
+
+      {!isOffline && entries.length > 0 && (
+        <section className="analytics-shell">
+          <div className="analytics-heading">
+            <div>
+              <p className="mini-label">Career Analytics</p>
+              <h2>Impact at a glance</h2>
+              <p>Public accomplishments transformed into a visual career signal.</p>
+            </div>
+            <div className="analytics-badge"><Sparkles size={16} /> Live from public proof</div>
+          </div>
+
+          <div className="analytics-kpis">
+            <article className="analytics-kpi">
+              <BarChart3 size={19} />
+              <span>Receipt coverage</span>
+              <strong>{analytics.receiptCoverage}%</strong>
+              <small>{impactReceipts.length} of {entries.length} public wins have receipts</small>
+            </article>
+            <article className="analytics-kpi">
+              <ShieldCheck size={19} />
+              <span>Evidence-linked</span>
+              <strong>{analytics.evidenceCoverage}%</strong>
+              <small>{analytics.evidenceCount} public evidence item{analytics.evidenceCount === 1 ? "" : "s"}</small>
+            </article>
+            <article className="analytics-kpi">
+              <Sparkles size={19} />
+              <span>Skill breadth</span>
+              <strong>{tagsSummary?.total_unique_tags ?? 0}</strong>
+              <small>distinct skills demonstrated publicly</small>
+            </article>
+          </div>
+
+          <div className="analytics-grid">
+            <article className="chart-card activity-card">
+              <div className="chart-card-heading">
+                <div>
+                  <p className="mini-label">Momentum</p>
+                  <h3>Accomplishment activity</h3>
+                </div>
+                <span>Last 6 months</span>
+              </div>
+              <ActivityChart data={analytics.monthlyActivity} />
+            </article>
+
+            <article className="chart-card">
+              <div className="chart-card-heading">
+                <div>
+                  <p className="mini-label">Impact Mix</p>
+                  <h3>Proof by category</h3>
+                </div>
+                <span>{analytics.categories.length} areas</span>
+              </div>
+              <div className="bar-chart-list">
+                {analytics.categories.slice(0, 7).map(([category, count]) => (
+                  <div className="bar-chart-row" key={category}>
+                    <div className="bar-chart-label"><span>{category}</span><strong>{count}</strong></div>
+                    <div className="bar-chart-track">
+                      <span style={{ width: `${Math.max(8, (count / maxCategoryCount) * 100)}%` }} />
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </article>
+
+            <article className="chart-card skills-chart-card">
+              <div className="chart-card-heading">
+                <div>
+                  <p className="mini-label">Skills</p>
+                  <h3>Most demonstrated skills</h3>
+                </div>
+                <span>Public proof</span>
+              </div>
+              <div className="skill-bar-grid">
+                {topTags.slice(0, 8).map(([tag, count]) => (
+                  <div className="skill-bar" key={tag}>
+                    <div className="skill-bar-top"><span>{tag}</span><strong>{count}</strong></div>
+                    <div className="skill-bar-track">
+                      <span style={{ width: `${Math.max(8, (count / maxSkillCount) * 100)}%` }} />
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </article>
+          </div>
+        </section>
+      )}
 
       {isOffline && (
         <section className="public-notice">
@@ -227,7 +357,6 @@ function PublicBragPage() {
             placeholder="Search skills, projects, categories, and results..."
           />
         </div>
-
         <div className="filter-pills">
           {FILTERS.map((filter) => (
             <button
@@ -247,58 +376,32 @@ function PublicBragPage() {
           {impactReceipts.length > 0 && (
             <>
               <div className="timeline-header">
-                <div>
-                  <p className="mini-label">Verified Structure</p>
-                  <h2>Public Impact Receipts</h2>
-                </div>
-
+                <div><p className="mini-label">Verified Structure</p><h2>Public Impact Receipts</h2></div>
                 <span>{impactReceipts.length} receipts</span>
               </div>
-
               {impactReceipts.map((receipt) => (
                 <article className="public-entry" key={receipt.id}>
                   <div className="public-entry-top">
-                    <div>
-                      <p className="mini-label">Impact Receipt</p>
-                      <h3>{receipt.accomplishment}</h3>
-                    </div>
-
+                    <div><p className="mini-label">Impact Receipt</p><h3>{receipt.accomplishment}</h3></div>
                     <div className="public-entry-meta">
                       {receipt.trust_signals?.map((signal) => (
-                        <span key={`${receipt.id}-${signal}`}>
-                          {formatSignal(signal)}
-                        </span>
+                        <span key={`${receipt.id}-${signal}`}>{formatSignal(signal)}</span>
                       ))}
                     </div>
                   </div>
-
                   <div className="proof-grid">
-                    <div>
-                      <strong>Contribution</strong>
-                      <p>{receipt.contribution}</p>
-                    </div>
-
-                    <div>
-                      <strong>Result</strong>
-                      <p>{receipt.result}</p>
-                    </div>
+                    <div><strong>Contribution</strong><p>{receipt.contribution}</p></div>
+                    <div><strong>Result</strong><p>{receipt.result}</p></div>
                   </div>
-
                   {receipt.evidence?.length > 0 && (
                     <div className="proof-grid">
                       {receipt.evidence.map((item, index) => (
-                        <div key={`${receipt.id}-evidence-${index}`}>
-                          <strong>{item.title}</strong>
-                          <p>{item.description || item.reference}</p>
-                        </div>
+                        <div key={`${receipt.id}-evidence-${index}`}><strong>{item.title}</strong><p>{item.description || item.reference}</p></div>
                       ))}
                     </div>
                   )}
-
                   <div className="tags">
-                    {receipt.skills?.map((skill) => (
-                      <span key={`${receipt.id}-${skill}`}>{skill}</span>
-                    ))}
+                    {receipt.skills?.map((skill) => <span key={`${receipt.id}-${skill}`}>{skill}</span>)}
                   </div>
                 </article>
               ))}
@@ -306,72 +409,29 @@ function PublicBragPage() {
           )}
 
           <div className="timeline-header">
-            <div>
-              <p className="mini-label">Career Evidence</p>
-              <h2>Readable proof entries</h2>
-            </div>
-
+            <div><p className="mini-label">Career Evidence</p><h2>Readable proof entries</h2></div>
             <span>{filteredEntries.length} results</span>
           </div>
 
           {filteredEntries.length === 0 ? (
-            <div className="public-empty">
-              <h3>No matching entries found.</h3>
-              <p>Try searching a different skill or clearing the filters.</p>
-            </div>
+            <div className="public-empty"><h3>No matching entries found.</h3><p>Try searching a different skill or clearing the filters.</p></div>
           ) : (
             filteredEntries.map((entry) => {
               const tags = normalizeTags(entry.tags);
-
               return (
                 <article className="public-entry" key={entry.id}>
                   <div className="public-entry-top">
-                    <div>
-                      <p className="mini-label">
-                        {entry.category ?? "General"}
-                      </p>
-                      <h3>{entry.title ?? "Untitled entry"}</h3>
-                    </div>
-
-                    <div className="public-entry-meta">
-                      <span>{entry.entry_type ?? "General"}</span>
-                      <span>{entry.entry_date ?? "No date"}</span>
-                    </div>
+                    <div><p className="mini-label">{entry.category ?? "General"}</p><h3>{entry.title ?? "Untitled entry"}</h3></div>
+                    <div className="public-entry-meta"><span>{entry.entry_type ?? "General"}</span><span>{entry.entry_date ?? "No date"}</span></div>
                   </div>
-
-                  <p className="public-bullet">
-                    {entry.resume_bullet ?? "No resume bullet generated yet."}
-                  </p>
-
+                  <p className="public-bullet">{entry.resume_bullet ?? "No resume bullet generated yet."}</p>
                   <div className="proof-grid">
-                    <div>
-                      <strong>Situation</strong>
-                      <p>{entry.situation ?? "No situation added."}</p>
-                    </div>
-
-                    <div>
-                      <strong>Action</strong>
-                      <p>{entry.action ?? "No action added."}</p>
-                    </div>
-
-                    <div>
-                      <strong>Impact</strong>
-                      <p>{entry.impact ?? "No impact added."}</p>
-                    </div>
-
-                    {entry.lesson && (
-                      <div>
-                        <strong>Lesson</strong>
-                        <p>{entry.lesson}</p>
-                      </div>
-                    )}
+                    <div><strong>Situation</strong><p>{entry.situation ?? "No situation added."}</p></div>
+                    <div><strong>Action</strong><p>{entry.action ?? "No action added."}</p></div>
+                    <div><strong>Impact</strong><p>{entry.impact ?? "No impact added."}</p></div>
+                    {entry.lesson && <div><strong>Lesson</strong><p>{entry.lesson}</p></div>}
                   </div>
-
-                  <div className="tags">
-                    {tags.map((tag) => (
-                      <span key={tag}>{tag}</span>
-                    ))}
-                  </div>
+                  <div className="tags">{tags.map((tag) => <span key={tag}>{tag}</span>)}</div>
                 </article>
               );
             })
@@ -380,49 +440,21 @@ function PublicBragPage() {
 
         <aside className="public-sidebar">
           <section className="sidebar-card">
-            <p className="mini-label">Top Skills</p>
-            <h2>Skill signal</h2>
-
-            {topTags.length === 0 ? (
-              <p className="muted">No skills found yet.</p>
-            ) : (
+            <p className="mini-label">Top Skills</p><h2>Skill signal</h2>
+            {topTags.length === 0 ? <p className="muted">No skills found yet.</p> : (
               <div className="skill-list">
                 {topTags.slice(0, 8).map(([tag, count]) => (
-                  <div className="skill-row" key={tag}>
-                    <span>{tag}</span>
-                    <strong>{count}</strong>
-                  </div>
+                  <div className="skill-row" key={tag}><span>{tag}</span><strong>{count}</strong></div>
                 ))}
               </div>
             )}
           </section>
-
           <section className="sidebar-card">
-            <p className="mini-label">Profile</p>
-            <h2>More proof</h2>
-
+            <p className="mini-label">Profile</p><h2>More proof</h2>
             <div className="proof-links">
-              {profile?.github_url && (
-                <a href={profile.github_url} target="_blank" rel="noreferrer">
-                  GitHub <span>Open</span>
-                </a>
-              )}
-
-              {profile?.resume_url && (
-                <a href={profile.resume_url} target="_blank" rel="noreferrer">
-                  Résumé <span>Open</span>
-                </a>
-              )}
-
-              {profile?.portfolio_url && (
-                <a
-                  href={profile.portfolio_url}
-                  target="_blank"
-                  rel="noreferrer"
-                >
-                  Portfolio <span>Visit</span>
-                </a>
-              )}
+              {profile?.github_url && <a href={profile.github_url} target="_blank" rel="noreferrer">GitHub <span>Open</span></a>}
+              {profile?.resume_url && <a href={profile.resume_url} target="_blank" rel="noreferrer">Résumé <span>Open</span></a>}
+              {profile?.portfolio_url && <a href={profile.portfolio_url} target="_blank" rel="noreferrer">Portfolio <span>Visit</span></a>}
             </div>
           </section>
         </aside>


### PR DESCRIPTION
## What changed

- adds a public career analytics section above the proof timeline
- shows receipt coverage, evidence-linked coverage, and public skill breadth
- adds a six-month accomplishment activity trend
- adds proof-by-category and most-demonstrated-skills bar charts
- derives analytics from existing public entry, receipt, tag, and category APIs
- keeps the implementation dependency-light with CSS and SVG rather than adding a charting package

## Why

BragStack public pages should communicate career evidence at a glance, not just list entries. These visuals turn existing proof into a recruiter-friendly impact dashboard while preserving the detailed timeline below.

## Validation

Preview this branch in Codespaces and verify responsive layout, public-data-only calculations, and existing public profile/timeline behavior before merging into the V1.1 branch.