### PR TITLE
Add app navigation, pagination, receipts page, and Proof Profile

### DIFF
--- a/backend/app/public_slug_routes.py
+++ b/backend/app/public_slug_routes.py
@@ -1,6 +1,6 @@
 from datetime import date, datetime, timedelta, timezone
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Query
 
 from app.database import (
     entries_collection,
@@ -154,24 +154,71 @@ def get_public_entry_query(slug: str) -> dict:
     }
 
 
-@router.get("/brag/{slug}")
-def get_public_brag_entries_by_slug(slug: str):
-    """Return public brag entries for a specific user's public profile."""
-    query = get_public_entry_query(slug)
+def get_monthly_activity(query: dict) -> list[dict]:
+    """Return accomplishment counts for the current month and five prior months."""
+    today = datetime.now(timezone.utc).date()
+    months = []
 
-    entries = [
-        serialize_entry(entry)
-        for entry in entries_collection.find(query).sort("created_at", -1)
-    ]
+    for offset in range(5, -1, -1):
+        year = today.year
+        month = today.month - offset
+
+        while month <= 0:
+            month += 12
+            year -= 1
+
+        months.append(
+            {
+                "key": f"{year:04d}-{month:02d}",
+                "label": datetime(year, month, 1).strftime("%b"),
+                "count": 0,
+            }
+        )
+
+    month_lookup = {item["key"]: item for item in months}
+
+    for entry in entries_collection.find(query):
+        work_date = parse_work_date(entry)
+        if work_date is None:
+            continue
+
+        key = f"{work_date.year:04d}-{work_date.month:02d}"
+        if key in month_lookup:
+            month_lookup[key]["count"] += 1
+
+    return months
+
+
+@router.get("/brag/{slug}")
+def get_public_brag_entries_by_slug(
+    slug: str,
+    limit: int = Query(default=6, ge=1, le=50),
+    skip: int = Query(default=0, ge=0),
+):
+    """Return paginated public brag entries for a user's Proof Profile."""
+    query = get_public_entry_query(slug)
+    total_entries = entries_collection.count_documents(query)
+    cursor = (
+        entries_collection.find(query)
+        .sort("created_at", -1)
+        .skip(skip)
+        .limit(limit)
+    )
+    entries = [serialize_entry(entry) for entry in cursor]
 
     return {
         "slug": normalize_slug(slug),
-        "total_entries": len(entries),
+        "total_entries": total_entries,
+        "limit": limit,
+        "skip": skip,
+        "returned_entries": len(entries),
+        "has_more": skip + limit < total_entries,
+        "activity_last_6_months": get_monthly_activity(query),
         "entries": entries,
         "message": (
             "No public entries yet."
-            if not entries
-            else "Public brag entries loaded successfully."
+            if total_entries == 0
+            else "Public proof entries loaded successfully."
         ),
     }
 

--- a/frontend/src/AccomplishmentsPage.css
+++ b/frontend/src/AccomplishmentsPage.css
@@ -1,0 +1,264 @@
+.accomplishments-page {
+  width: min(1180px, calc(100% - 40px));
+  margin: 0 auto;
+  padding: 42px 0 72px;
+}
+
+.accomplishments-hero,
+.accomplishments-toolbar,
+.accomplishment-card,
+.accomplishments-empty,
+.accomplishments-error {
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  background: rgba(15, 23, 42, 0.72);
+  backdrop-filter: blur(18px);
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.28);
+}
+
+.accomplishments-hero {
+  display: flex;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 34px;
+  border-radius: 30px;
+  margin-bottom: 18px;
+}
+
+.accomplishments-hero h1 {
+  margin: 8px 0 12px;
+  font-size: clamp(2.4rem, 5vw, 4.4rem);
+  letter-spacing: -0.06em;
+  line-height: 0.98;
+}
+
+.accomplishments-hero p {
+  max-width: 760px;
+  color: #cbd5e1;
+  line-height: 1.7;
+}
+
+.accomplishments-add {
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  min-height: 44px;
+  padding: 0 18px;
+  border-radius: 999px;
+  color: #020617;
+  background: linear-gradient(135deg, #f8fafc, #bae6fd);
+  text-decoration: none;
+  font-weight: 900;
+  white-space: nowrap;
+}
+
+.accomplishments-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  padding: 16px;
+  border-radius: 22px;
+  margin-bottom: 18px;
+}
+
+.accomplishments-toolbar > p {
+  margin: 0;
+  color: #94a3b8;
+  white-space: nowrap;
+}
+
+.accomplishments-search {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 14px;
+  border-radius: 16px;
+  color: #93c5fd;
+  background: rgba(2, 6, 23, 0.4);
+  border: 1px solid rgba(148, 163, 184, 0.14);
+}
+
+.accomplishments-search input {
+  width: 100%;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: #f8fafc;
+  font: inherit;
+}
+
+.accomplishments-list {
+  display: grid;
+  gap: 16px;
+}
+
+.accomplishment-card {
+  padding: 24px;
+  border-radius: 26px;
+}
+
+.accomplishment-card-top {
+  display: flex;
+  justify-content: space-between;
+  gap: 18px;
+  align-items: flex-start;
+}
+
+.accomplishment-card h2 {
+  margin: 6px 0 0;
+  font-size: 1.35rem;
+}
+
+.proof-public,
+.proof-private {
+  flex: 0 0 auto;
+  padding: 7px 10px;
+  border-radius: 999px;
+  font-size: 0.76rem;
+  font-weight: 900;
+}
+
+.proof-public {
+  color: #bbf7d0;
+  background: rgba(34, 197, 94, 0.1);
+  border: 1px solid rgba(34, 197, 94, 0.2);
+}
+
+.proof-private {
+  color: #cbd5e1;
+  background: rgba(148, 163, 184, 0.08);
+  border: 1px solid rgba(148, 163, 184, 0.16);
+}
+
+.accomplishment-bullet {
+  margin: 16px 0;
+  color: #dbeafe;
+  line-height: 1.7;
+}
+
+.accomplishment-proof-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.accomplishment-proof-grid > div {
+  padding: 14px;
+  border-radius: 18px;
+  background: rgba(2, 6, 23, 0.36);
+  border: 1px solid rgba(148, 163, 184, 0.1);
+}
+
+.accomplishment-proof-grid strong {
+  color: #f8fafc;
+}
+
+.accomplishment-proof-grid p {
+  margin-bottom: 0;
+  color: #cbd5e1;
+  line-height: 1.6;
+}
+
+.accomplishment-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 16px;
+}
+
+.accomplishment-tags span {
+  padding: 6px 10px;
+  border-radius: 999px;
+  color: #bae6fd;
+  background: rgba(14, 165, 233, 0.08);
+  border: 1px solid rgba(14, 165, 233, 0.14);
+  font-size: 0.8rem;
+  font-weight: 800;
+}
+
+.accomplishments-empty,
+.accomplishments-error {
+  padding: 28px;
+  border-radius: 24px;
+  text-align: center;
+}
+
+.accomplishments-error {
+  color: #fecaca;
+  margin-bottom: 16px;
+}
+
+.pagination {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  margin-top: 24px;
+}
+
+.pagination > button,
+.pagination-pages button {
+  min-height: 40px;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: rgba(15, 23, 42, 0.7);
+  color: #e2e8f0;
+  cursor: pointer;
+  font-weight: 800;
+}
+
+.pagination > button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 14px;
+}
+
+.pagination-pages {
+  display: flex;
+  gap: 7px;
+}
+
+.pagination-pages button {
+  width: 40px;
+}
+
+.pagination-pages button.active {
+  color: #020617;
+  background: linear-gradient(135deg, #f8fafc, #bae6fd);
+}
+
+.pagination button:disabled {
+  cursor: not-allowed;
+  opacity: 0.4;
+}
+
+@media (max-width: 760px) {
+  .accomplishments-page {
+    width: min(100% - 24px, 1180px);
+    padding-top: 24px;
+  }
+
+  .accomplishments-hero,
+  .accomplishments-toolbar,
+  .accomplishment-card-top {
+    flex-direction: column;
+  }
+
+  .accomplishments-toolbar {
+    align-items: stretch;
+  }
+
+  .accomplishments-toolbar > p {
+    white-space: normal;
+  }
+
+  .accomplishment-proof-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .pagination {
+    flex-wrap: wrap;
+  }
+}

--- a/frontend/src/AccomplishmentsPage.jsx
+++ b/frontend/src/AccomplishmentsPage.jsx
@@ -1,0 +1,236 @@
+import { useEffect, useMemo, useState } from "react";
+import { ChevronLeft, ChevronRight, Search } from "lucide-react";
+
+import { getEntries } from "./api";
+import "./AccomplishmentsPage.css";
+
+const PAGE_SIZE = 10;
+
+function AccomplishmentsPage() {
+  const [entries, setEntries] = useState([]);
+  const [page, setPage] = useState(1);
+  const [totalEntries, setTotalEntries] = useState(0);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [searchTerm, setSearchTerm] = useState("");
+
+  useEffect(() => {
+    let isMounted = true;
+
+    async function loadPage() {
+      setIsLoading(true);
+      setError("");
+
+      try {
+        const data = await getEntries(PAGE_SIZE, (page - 1) * PAGE_SIZE);
+
+        if (!isMounted) {
+          return;
+        }
+
+        setEntries(data.entries ?? []);
+        setTotalEntries(data.total_entries ?? 0);
+      } catch (requestError) {
+        if (requestError.response?.status === 401) {
+          localStorage.removeItem("bragstack_token");
+          window.location.assign("/login");
+          return;
+        }
+
+        if (isMounted) {
+          setError("BragStack could not load your accomplishments.");
+        }
+      } finally {
+        if (isMounted) {
+          setIsLoading(false);
+        }
+      }
+    }
+
+    void loadPage();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [page]);
+
+  const totalPages = Math.max(1, Math.ceil(totalEntries / PAGE_SIZE));
+  const startEntry = totalEntries === 0 ? 0 : (page - 1) * PAGE_SIZE + 1;
+  const endEntry = Math.min(page * PAGE_SIZE, totalEntries);
+
+  const visibleEntries = useMemo(() => {
+    const query = searchTerm.trim().toLowerCase();
+
+    if (!query) {
+      return entries;
+    }
+
+    return entries.filter((entry) => {
+      const searchable = [
+        entry.title,
+        entry.category,
+        entry.entry_type,
+        entry.situation,
+        entry.action,
+        entry.impact,
+        entry.lesson,
+        ...(entry.tags ?? []),
+      ]
+        .filter(Boolean)
+        .join(" ")
+        .toLowerCase();
+
+      return searchable.includes(query);
+    });
+  }, [entries, searchTerm]);
+
+  const pageNumbers = useMemo(() => {
+    const first = Math.max(1, page - 2);
+    const last = Math.min(totalPages, first + 4);
+    const adjustedFirst = Math.max(1, last - 4);
+
+    return Array.from(
+      { length: last - adjustedFirst + 1 },
+      (_, index) => adjustedFirst + index
+    );
+  }, [page, totalPages]);
+
+  function goToPage(nextPage) {
+    const safePage = Math.min(Math.max(nextPage, 1), totalPages);
+    setPage(safePage);
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  }
+
+  return (
+    <main className="accomplishments-page">
+      <header className="accomplishments-hero">
+        <div>
+          <p className="mini-label">Career Evidence Library</p>
+          <h1>Your accomplishments</h1>
+          <p>
+            Browse the complete record of situations, actions, outcomes, skills,
+            and public proof you have captured in BragStack.
+          </p>
+        </div>
+
+        <a className="accomplishments-add" href="/app#entries">
+          + Add accomplishment
+        </a>
+      </header>
+
+      <section className="accomplishments-toolbar">
+        <div className="accomplishments-search">
+          <Search size={18} />
+          <input
+            value={searchTerm}
+            onChange={(event) => setSearchTerm(event.target.value)}
+            placeholder="Filter this page by skill, category, action, or impact..."
+          />
+        </div>
+
+        <p>
+          Showing <strong>{startEntry}–{endEntry}</strong> of{" "}
+          <strong>{totalEntries}</strong> accomplishments
+        </p>
+      </section>
+
+      {error && <div className="accomplishments-error">{error}</div>}
+
+      {isLoading ? (
+        <section className="accomplishments-empty">Loading accomplishments…</section>
+      ) : visibleEntries.length === 0 ? (
+        <section className="accomplishments-empty">
+          <h2>No accomplishments found.</h2>
+          <p>
+            {searchTerm
+              ? "Try a different search on this page."
+              : "Add your first accomplishment from the Overview page."}
+          </p>
+        </section>
+      ) : (
+        <section className="accomplishments-list">
+          {visibleEntries.map((entry) => (
+            <article className="accomplishment-card" key={entry.id}>
+              <div className="accomplishment-card-top">
+                <div>
+                  <p className="mini-label">
+                    {entry.category} • {entry.entry_type} • {entry.entry_date}
+                  </p>
+                  <h2>{entry.title}</h2>
+                </div>
+
+                <span className={entry.is_public ? "proof-public" : "proof-private"}>
+                  {entry.is_public ? "Public proof" : "Private proof"}
+                </span>
+              </div>
+
+              <p className="accomplishment-bullet">{entry.resume_bullet}</p>
+
+              <div className="accomplishment-proof-grid">
+                <div>
+                  <strong>Situation</strong>
+                  <p>{entry.situation}</p>
+                </div>
+                <div>
+                  <strong>Action</strong>
+                  <p>{entry.action}</p>
+                </div>
+                <div>
+                  <strong>Impact</strong>
+                  <p>{entry.impact}</p>
+                </div>
+                {entry.lesson && (
+                  <div>
+                    <strong>Lesson</strong>
+                    <p>{entry.lesson}</p>
+                  </div>
+                )}
+              </div>
+
+              <div className="accomplishment-tags">
+                {entry.tags?.map((tag) => <span key={tag}>{tag}</span>)}
+              </div>
+            </article>
+          ))}
+        </section>
+      )}
+
+      {totalPages > 1 && (
+        <nav className="pagination" aria-label="Accomplishments pages">
+          <button
+            type="button"
+            onClick={() => goToPage(page - 1)}
+            disabled={page === 1}
+          >
+            <ChevronLeft size={17} />
+            Previous
+          </button>
+
+          <div className="pagination-pages">
+            {pageNumbers.map((pageNumber) => (
+              <button
+                type="button"
+                key={pageNumber}
+                className={pageNumber === page ? "active" : ""}
+                onClick={() => goToPage(pageNumber)}
+              >
+                {pageNumber}
+              </button>
+            ))}
+          </div>
+
+          <button
+            type="button"
+            onClick={() => goToPage(page + 1)}
+            disabled={page === totalPages}
+          >
+            Next
+            <ChevronRight size={17} />
+          </button>
+        </nav>
+      )}
+    </main>
+  );
+}
+
+export default AccomplishmentsPage;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,6 +1,3 @@
-
-
-
 import { useEffect, useState } from "react";
 import { Pencil, Plus, Trash2, X } from "lucide-react";
 
@@ -27,6 +24,7 @@ import {
 } from "./api";
 import "./App.css";
 
+const DASHBOARD_PAGE_SIZE = 5;
 const ENTRY_TYPES = [
   "Current Job",
   "Previous Job",
@@ -69,6 +67,7 @@ const EMPTY_PROFILE_FORM = {
 function App() {
   const [currentUser, setCurrentUser] = useState(null);
   const [entries, setEntries] = useState([]);
+  const [entriesMeta, setEntriesMeta] = useState({ total_entries: 0 });
   const [impactReceipts, setImpactReceipts] = useState([]);
   const [creatingReceiptEntryId, setCreatingReceiptEntryId] = useState(null);
   const [receiptNotice, setReceiptNotice] = useState("");
@@ -93,6 +92,10 @@ function App() {
   const isLoginPage = path === "/login";
   const isRegisterPage = path === "/register";
   const isReportsPage = path === "/app/reports";
+  const dashboardPage = Math.max(
+    1,
+    Number(new URLSearchParams(window.location.search).get("page")) || 1,
+  );
 
   async function loadDashboard() {
     try {
@@ -105,7 +108,10 @@ function App() {
         categoriesData,
       ] = await Promise.all([
         getCurrentUser(),
-        getEntries(),
+        getEntries(
+          DASHBOARD_PAGE_SIZE,
+          (dashboardPage - 1) * DASHBOARD_PAGE_SIZE,
+        ),
         getImpactReceipts(),
         getWeeklyReport(),
         getTagsSummary(),
@@ -114,6 +120,9 @@ function App() {
 
       setCurrentUser(userData);
       setEntries(entriesData.entries ?? []);
+      setEntriesMeta({
+        total_entries: entriesData.total_entries ?? 0,
+      });
       setImpactReceipts(receiptsData.receipts ?? []);
       setWeeklyReport(weeklyData);
       setTagsSummary(tagsData);
@@ -176,7 +185,7 @@ function App() {
 
       setProfileError(
         error.response?.data?.detail ??
-          "Your profile could not be saved."
+          "Your profile could not be saved.",
       );
     } finally {
       setIsSavingProfile(false);
@@ -212,6 +221,7 @@ function App() {
     isLoginPage,
     isRegisterPage,
     isReportsPage,
+    dashboardPage,
   ]);
 
   function openCreateModal() {
@@ -328,13 +338,11 @@ function App() {
       console.error(error);
 
       if (error.response?.status === 409) {
-        setReceiptError(
-          "This entry already has an Impact Receipt."
-        );
+        setReceiptError("This entry already has an Impact Receipt.");
       } else {
         setReceiptError(
           error.response?.data?.detail ??
-            "The Impact Receipt could not be created."
+            "The Impact Receipt could not be created.",
         );
       }
     } finally {
@@ -358,13 +366,13 @@ function App() {
       setReceiptNotice(
         nextVisibility
           ? "Impact Receipt is now public."
-          : "Impact Receipt is now private."
+          : "Impact Receipt is now private.",
       );
     } catch (error) {
       console.error(error);
       setReceiptError(
         error.response?.data?.detail ??
-          "Receipt visibility could not be updated."
+          "Receipt visibility could not be updated.",
       );
     } finally {
       setUpdatingReceiptId(null);
@@ -383,12 +391,10 @@ function App() {
     window.location.href = "/app";
   }
 
-  const topTags = tagsSummary?.tags
-    ? Object.entries(tagsSummary.tags)
-    : [];
+  const topTags = tagsSummary?.tags ? Object.entries(tagsSummary.tags) : [];
 
   const receiptSourceEntryIds = new Set(
-    impactReceipts.map((receipt) => receipt.source_entry_id)
+    impactReceipts.map((receipt) => receipt.source_entry_id),
   );
 
   if (isPublicPage) {
@@ -404,12 +410,7 @@ function App() {
   }
 
   if (isRegisterPage) {
-    return (
-      <AuthPage
-        mode="register"
-        onRegister={handleRegister}
-      />
-    );
+    return <AuthPage mode="register" onRegister={handleRegister} />;
   }
 
   if (isReportsPage) {
@@ -421,6 +422,18 @@ function App() {
   if (!token) {
     return null;
   }
+
+  const totalDashboardPages = Math.max(
+    1,
+    Math.ceil(entriesMeta.total_entries / DASHBOARD_PAGE_SIZE),
+  );
+  const dashboardStart = entriesMeta.total_entries
+    ? (dashboardPage - 1) * DASHBOARD_PAGE_SIZE + 1
+    : 0;
+  const dashboardEnd = Math.min(
+    dashboardPage * DASHBOARD_PAGE_SIZE,
+    entriesMeta.total_entries,
+  );
 
   return (
     <main className="page">
@@ -434,9 +447,8 @@ function App() {
           </h1>
 
           <p>
-            Track technical wins, skill growth, resume bullets,
-            and project evidence in one clean portfolio-ready
-            space.
+            Track technical wins, skill growth, resume bullets, and project
+            evidence in one clean portfolio-ready space.
           </p>
 
           <div className="hero-actions">
@@ -444,10 +456,7 @@ function App() {
               View proof
             </a>
 
-            <a
-              className="btn secondary"
-              href="/app/reports"
-            >
+            <a className="btn secondary" href="/app/reports">
               Reports
             </a>
 
@@ -464,7 +473,7 @@ function App() {
 
         <aside className="profile-card">
           <div className="profile-card-heading">
-            <p className="mini-label">Public Proof Card</p>
+            <p className="mini-label">Proof Profile Card</p>
 
             <button
               type="button"
@@ -491,14 +500,10 @@ function App() {
               "Add a professional headline to introduce yourself."}
           </p>
 
-          {currentUser?.bio && (
-            <p className="profile-bio">{currentUser.bio}</p>
-          )}
+          {currentUser?.bio && <p className="profile-bio">{currentUser.bio}</p>}
 
           {currentUser?.location && (
-            <p className="profile-location">
-              {currentUser.location}
-            </p>
+            <p className="profile-location">{currentUser.location}</p>
           )}
 
           <div className="proof-links">
@@ -508,7 +513,7 @@ function App() {
                 target="_blank"
                 rel="noreferrer"
               >
-                Public BragStack <span>View profile</span>
+                Proof Profile <span>View profile</span>
               </a>
             )}
 
@@ -548,9 +553,7 @@ function App() {
       {isOffline && (
         <section className="notice">
           <strong>Connection problem</strong>
-          <span>
-            BragStack could not load all dashboard data.
-          </span>
+          <span>BragStack could not load all dashboard data.</span>
         </section>
       )}
 
@@ -563,100 +566,71 @@ function App() {
 
         <article className="stat-card">
           <p>Unique Tags</p>
-          <strong>
-            {tagsSummary?.total_unique_tags ?? 0}
-          </strong>
+          <strong>{tagsSummary?.total_unique_tags ?? 0}</strong>
           <span>Skills tracked across entries</span>
         </article>
 
         <article className="stat-card">
           <p>Categories</p>
-          <strong>
-            {categoriesSummary?.total_unique_categories ?? 0}
-          </strong>
+          <strong>{categoriesSummary?.total_unique_categories ?? 0}</strong>
           <span>Career areas documented</span>
         </article>
       </section>
 
-      <section
-        className="impact-section"
-        id="impact-receipts"
-      >
+      <section className="impact-section" id="impact-receipts">
         <div className="impact-section-header">
           <div>
-            <p className="mini-label">
-              Evidence-Backed Proof
-            </p>
+            <p className="mini-label">Evidence-Backed Proof</p>
             <h2>Impact Receipts</h2>
             <p>
-              Structured proof of what you contributed, what changed,
-              and what evidence supports it.
+              Structured proof of what you contributed, what changed, and what
+              evidence supports it.
             </p>
           </div>
 
           <span className="impact-count">
             {impactReceipts.length}{" "}
-            {impactReceipts.length === 1
-              ? "receipt"
-              : "receipts"}
+            {impactReceipts.length === 1 ? "receipt" : "receipts"}
           </span>
         </div>
 
         {receiptNotice && (
-          <p className="receipt-feedback success">
-            {receiptNotice}
-          </p>
+          <p className="receipt-feedback success">{receiptNotice}</p>
         )}
 
         {receiptError && (
-          <p className="receipt-feedback error">
-            {receiptError}
-          </p>
+          <p className="receipt-feedback error">{receiptError}</p>
         )}
 
         {impactReceipts.length === 0 ? (
           <div className="impact-empty-state">
             <h3>No Impact Receipts yet.</h3>
-            <p>
-              Use the Create Impact Receipt button on a meaningful
-              entry below.
-            </p>
+            <p>Use the Create Impact Receipt button on a meaningful entry below.</p>
           </div>
         ) : (
           <div className="impact-receipt-grid">
             {impactReceipts.map((receipt) => (
-              <article
-                className="impact-receipt-card compact"
-                key={receipt.id}
-              >
+              <article className="impact-receipt-card compact" key={receipt.id}>
                 <div className="impact-receipt-top">
                   <div>
-                    <p className="mini-label">
-                      Impact Receipt
-                    </p>
+                    <p className="mini-label">Impact Receipt</p>
                     <h3>{receipt.accomplishment}</h3>
                   </div>
 
                   <div className="entry-actions">
                     <span
                       className={`visibility-badge ${
-                        receipt.is_public
-                          ? "public"
-                          : "private"
+                        receipt.is_public ? "public" : "private"
                       }`}
                     >
-                      {receipt.is_public
-                        ? "Public"
-                        : "Private"}
+                      {receipt.is_public ? "Public" : "Private"}
                     </span>
 
                     <button
                       type="button"
                       className="profile-edit-button"
                       disabled={updatingReceiptId === receipt.id}
-                      onClick={() =>
-                        handleToggleReceiptVisibility(receipt)
-                      }
+                      onClick={() => handleToggleReceiptVisibility(receipt)}
                     >
                       {updatingReceiptId === receipt.id
                         ? "Saving..."
@@ -673,16 +647,11 @@ function App() {
                 </div>
 
                 <div className="receipt-summary-row">
-                  <span>
-                    {receipt.evidence?.length ?? 0} evidence
-                  </span>
-                  <span>
-                    {receipt.credit?.length ?? 0} contributors
-                  </span>
+                  <span>{receipt.evidence?.length ?? 0} evidence</span>
+                  <span>{receipt.credit?.length ?? 0} contributors</span>
                   <span>
                     {receipt.confirmations?.filter(
-                      (confirmation) =>
-                        confirmation.status === "confirmed"
+                      (confirmation) => confirmation.status === "confirmed",
                     ).length ?? 0}{" "}
                     confirmed
                   </span>
@@ -690,9 +659,7 @@ function App() {
 
                 <div className="trust-signal-list">
                   {receipt.trust_signals?.map((signal) => (
-                    <span key={signal}>
-                      {formatLabel(signal)}
-                    </span>
+                    <span key={signal}>{formatLabel(signal)}</span>
                   ))}
                 </div>
 
@@ -722,48 +689,36 @@ function App() {
                         <span>Evidence</span>
 
                         <div className="impact-evidence-list">
-                          {receipt.evidence.map(
-                            (evidenceItem, index) => (
-                              <div
-                                className="impact-evidence-item"
-                                key={`${evidenceItem.title}-${index}`}
+                          {receipt.evidence.map((evidenceItem, index) => (
+                            <div
+                              className="impact-evidence-item"
+                              key={`${evidenceItem.title}-${index}`}
+                            >
+                              <strong>{evidenceItem.title}</strong>
+
+                              <small>
+                                {formatLabel(evidenceItem.evidence_type)}
+                              </small>
+
+                              {evidenceItem.reference && (
+                                <p>{evidenceItem.reference}</p>
+                              )}
+
+                              {evidenceItem.description && (
+                                <p>{evidenceItem.description}</p>
+                              )}
+
+                              <span
+                                className={`visibility-badge ${
+                                  evidenceItem.is_public ? "public" : "private"
+                                }`}
                               >
-                                <strong>
-                                  {evidenceItem.title}
-                                </strong>
-
-                                <small>
-                                  {formatLabel(
-                                    evidenceItem.evidence_type
-                                  )}
-                                </small>
-
-                                {evidenceItem.reference && (
-                                  <p>
-                                    {evidenceItem.reference}
-                                  </p>
-                                )}
-
-                                {evidenceItem.description && (
-                                  <p>
-                                    {evidenceItem.description}
-                                  </p>
-                                )}
-
-                                <span
-                                  className={`visibility-badge ${
-                                    evidenceItem.is_public
-                                      ? "public"
-                                      : "private"
-                                  }`}
-                                >
-                                  {evidenceItem.is_public
-                                    ? "Public evidence"
-                                    : "Private evidence"}
-                                </span>
-                              </div>
-                            )
-                          )}
+                                {evidenceItem.is_public
+                                  ? "Public evidence"
+                                  : "Private evidence"}
+                              </span>
+                            </div>
+                          ))}
                         </div>
                       </div>
                     )}
@@ -773,19 +728,13 @@ function App() {
                         <span>Shared credit</span>
 
                         <div className="impact-credit-list">
-                          {receipt.credit.map(
-                            (creditItem, index) => (
-                              <p
-                                key={`${creditItem.name}-${index}`}
-                              >
-                                <strong>
-                                  {creditItem.name}
-                                </strong>
-                                {" — "}
-                                {creditItem.contribution}
-                              </p>
-                            )
-                          )}
+                          {receipt.credit.map((creditItem, index) => (
+                            <p key={`${creditItem.name}-${index}`}>
+                              <strong>{creditItem.name}</strong>
+                              {" — "}
+                              {creditItem.contribution}
+                            </p>
+                          ))}
                         </div>
                       </div>
                     )}
@@ -839,109 +788,124 @@ function App() {
             <div className="empty-state">
               <h3>No entries loaded yet.</h3>
               <p>
-                Add a brag entry to begin building your
-                evidence-backed career record.
+                Add a brag entry to begin building your evidence-backed career
+                record.
               </p>
             </div>
           ) : (
-            <div className="entry-list">
-              {entries.map((entry) => {
-                const hasReceipt = receiptSourceEntryIds.has(
-                  entry.id
-                );
-                const isCreatingReceipt =
-                  creatingReceiptEntryId === entry.id;
+            <>
+              <div className="entry-list">
+                {entries.map((entry) => {
+                  const hasReceipt = receiptSourceEntryIds.has(entry.id);
+                  const isCreatingReceipt = creatingReceiptEntryId === entry.id;
 
-                return (
-                  <article
-                    className="entry-card"
-                    key={entry.id}
-                  >
-                  <div className="entry-top">
-                    <div>
-                      <p className="mini-label">
-                        {entry.category}
-                        {entry.entry_type
-                          ? ` • ${entry.entry_type}`
-                          : ""}
-                        {entry.entry_date
-                          ? ` • ${entry.entry_date}`
-                          : ""}
-                      </p>
+                  return (
+                    <article className="entry-card" key={entry.id}>
+                      <div className="entry-top">
+                        <div>
+                          <p className="mini-label">
+                            {entry.category}
+                            {entry.entry_type ? ` • ${entry.entry_type}` : ""}
+                            {entry.entry_date ? ` • ${entry.entry_date}` : ""}
+                          </p>
 
-                      <h3>{entry.title}</h3>
-                    </div>
+                          <h3>{entry.title}</h3>
+                        </div>
 
-                    <div className="entry-actions">
-                      <span
-                        className={`visibility-badge ${
-                          entry.is_public
-                            ? "public"
-                            : "private"
-                        }`}
-                      >
-                        {entry.is_public
-                          ? "Public"
-                          : "Private"}
-                      </span>
+                        <div className="entry-actions">
+                          <span
+                            className={`visibility-badge ${
+                              entry.is_public ? "public" : "private"
+                            }`}
+                          >
+                            {entry.is_public ? "Public" : "Private"}
+                          </span>
 
-                      <button
-                        type="button"
-                        className="icon-action"
-                        onClick={() =>
-                          openEditModal(entry)
-                        }
-                        aria-label="Edit entry"
-                        title="Edit entry"
-                      >
-                        <Pencil
-                          size={17}
-                          strokeWidth={2.4}
-                        />
-                      </button>
+                          <button
+                            type="button"
+                            className="icon-action"
+                            onClick={() => openEditModal(entry)}
+                            aria-label="Edit entry"
+                            title="Edit entry"
+                          >
+                            <Pencil size={17} strokeWidth={2.4} />
+                          </button>
 
-                      <button
-                        type="button"
-                        className="icon-action danger"
-                        onClick={() =>
-                          handleDeleteEntry(entry.id)
-                        }
-                        aria-label="Delete entry"
-                        title="Delete entry"
-                      >
-                        <Trash2 size={16} />
-                      </button>
-                    </div>
-                  </div>
+                          <button
+                            type="button"
+                            className="icon-action danger"
+                            onClick={() => handleDeleteEntry(entry.id)}
+                            aria-label="Delete entry"
+                            title="Delete entry"
+                          >
+                            <Trash2 size={16} />
+                          </button>
+                        </div>
+                      </div>
 
-                  <p>{entry.resume_bullet}</p>
+                      <p>{entry.resume_bullet}</p>
 
-                  <div className="tags">
-                    {entry.tags?.map((tag) => (
-                      <span key={tag}>{tag}</span>
-                    ))}
-                  </div>
+                      <div className="tags">
+                        {entry.tags?.map((tag) => (
+                          <span key={tag}>{tag}</span>
+                        ))}
+                      </div>
 
-                  <div className="entry-receipt-action">
-                    <button
-                      type="button"
-                      className="btn secondary receipt-button"
-                      disabled={hasReceipt || isCreatingReceipt}
-                      onClick={() =>
-                        handleCreateImpactReceipt(entry.id)
-                      }
+                      <div className="entry-receipt-action">
+                        <button
+                          type="button"
+                          className="btn secondary receipt-button"
+                          disabled={hasReceipt || isCreatingReceipt}
+                          onClick={() => handleCreateImpactReceipt(entry.id)}
+                        >
+                          {isCreatingReceipt
+                            ? "Creating receipt..."
+                            : hasReceipt
+                              ? "Impact Receipt created"
+                              : "Create Impact Receipt"}
+                        </button>
+                      </div>
+                    </article>
+                  );
+                })}
+              </div>
+
+              <div className="pagination-shell">
+                <span className="pagination-summary">
+                  Showing {dashboardStart}–{dashboardEnd} of{" "}
+                  {entriesMeta.total_entries} accomplishments · Page{" "}
+                  {dashboardPage} of {totalDashboardPages}
+                </span>
+                <div className="pagination-controls">
+                  {dashboardPage > 1 ? (
+                    <a href={`/app?page=${dashboardPage - 1}#entries`}>
+                      Previous
+                    </a>
+                  ) : (
+                    <span className="disabled">Previous</span>
+                  )}
+
+                  {Array.from(
+                    { length: totalDashboardPages },
+                    (_, index) => index + 1,
+                  ).map((pageNumber) => (
+                    <a
+                      className={pageNumber === dashboardPage ? "active" : ""}
+                      href={`/app?page=${pageNumber}#entries`}
+                      key={pageNumber}
                     >
-                      {isCreatingReceipt
-                        ? "Creating receipt..."
-                        : hasReceipt
-                          ? "Impact Receipt created"
-                          : "Create Impact Receipt"}
-                    </button>
-                  </div>
-                </article>
-                );
-              })}
-            </div>
+                      {pageNumber}
+                    </a>
+                  ))}
+
+                  {dashboardPage < totalDashboardPages ? (
+                    <a href={`/app?page=${dashboardPage + 1}#entries`}>Next</a>
+                  ) : (
+                    <span className="disabled">Next</span>
+                  )}
+                </div>
+              </div>
+            </>
           )}
         </article>
 
@@ -951,10 +915,7 @@ function App() {
 
           {topTags.length === 0 ? (
             <div className="empty-state small">
-              <p>
-                Your top skills will show here after entries
-                load.
-              </p>
+              <p>Your top skills will show here after entries load.</p>
             </div>
           ) : (
             <div className="skill-list">
@@ -970,20 +931,15 @@ function App() {
       </section>
 
       {isProfileModalOpen && (
-        <div
-          className="modal-backdrop"
-          onClick={closeProfileModal}
-        >
+        <div className="modal-backdrop" onClick={closeProfileModal}>
           <div
             className="modal-card profile-modal-card"
             onClick={(event) => event.stopPropagation()}
           >
             <div className="modal-header">
               <div>
-                <p className="mini-label">
-                  Profile Settings
-                </p>
-                <h2>Edit your public profile</h2>
+                <p className="mini-label">Profile Settings</p>
+                <h2>Edit your Proof Profile</h2>
               </div>
 
               <button
@@ -996,10 +952,7 @@ function App() {
               </button>
             </div>
 
-            <form
-              className="entry-form"
-              onSubmit={handleProfileSubmit}
-            >
+            <form className="entry-form" onSubmit={handleProfileSubmit}>
               <label>
                 Display name
                 <input
@@ -1079,9 +1032,7 @@ function App() {
               </label>
 
               {profileError && (
-                <p className="profile-form-error">
-                  {profileError}
-                </p>
+                <p className="profile-form-error">{profileError}</p>
               )}
 
               <div className="modal-footer">
@@ -1098,9 +1049,7 @@ function App() {
                   className="btn primary form-button"
                   disabled={isSavingProfile}
                 >
-                  {isSavingProfile
-                    ? "Saving..."
-                    : "Save profile"}
+                  {isSavingProfile ? "Saving..." : "Save profile"}
                 </button>
               </div>
             </form>
@@ -1109,10 +1058,7 @@ function App() {
       )}
 
       {isModalOpen && (
-        <div
-          className="modal-backdrop"
-          onClick={closeModal}
-        >
+        <div className="modal-backdrop" onClick={closeModal}>
           <div
             className="modal-card"
             onClick={(event) => event.stopPropagation()}
@@ -1120,15 +1066,11 @@ function App() {
             <div className="modal-header">
               <div>
                 <p className="mini-label">
-                  {editingEntryId
-                    ? "Edit Proof"
-                    : "Create Proof"}
+                  {editingEntryId ? "Edit Proof" : "Create Proof"}
                 </p>
 
                 <h2>
-                  {editingEntryId
-                    ? "Update brag entry"
-                    : "Add a new brag entry"}
+                  {editingEntryId ? "Update brag entry" : "Add a new brag entry"}
                 </h2>
               </div>
 
@@ -1142,10 +1084,7 @@ function App() {
               </button>
             </div>
 
-            <form
-              className="entry-form"
-              onSubmit={handleCreateEntry}
-            >
+            <form className="entry-form" onSubmit={handleCreateEntry}>
               <div className="form-row">
                 <label>
                   Title
@@ -1253,9 +1192,7 @@ function App() {
               </label>
 
               <label className="visibility-toggle">
-                <span>
-                  Show this entry on my public BragStack
-                </span>
+                <span>Show this entry on my Proof Profile</span>
 
                 <input
                   type="checkbox"

--- a/frontend/src/AppShell.css
+++ b/frontend/src/AppShell.css
@@ -1,0 +1,170 @@
+.app-shell {
+  min-height: 100vh;
+}
+
+.app-sidebar {
+  position: fixed;
+  inset: 18px auto 18px 18px;
+  width: 238px;
+  z-index: 30;
+  display: flex;
+  flex-direction: column;
+  padding: 18px;
+  border-radius: 28px;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: rgba(15, 23, 42, 0.9);
+  backdrop-filter: blur(22px);
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.34);
+}
+
+.sidebar-brand,
+.sidebar-nav a,
+.sidebar-add {
+  text-decoration: none;
+}
+
+.sidebar-brand {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  color: #f8fafc;
+}
+
+.sidebar-brand > span:last-child,
+.sidebar-user > span:last-child {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.sidebar-brand small,
+.sidebar-user small {
+  color: #94a3b8;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sidebar-logo,
+.sidebar-user-avatar {
+  display: grid;
+  place-items: center;
+  flex: 0 0 auto;
+  width: 40px;
+  height: 40px;
+  border-radius: 14px;
+  font-weight: 950;
+  color: #020617;
+  background: linear-gradient(135deg, #f8fafc, #bae6fd, #c4b5fd);
+}
+
+.sidebar-add {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
+  margin: 22px 0 16px;
+  padding: 0 14px;
+  border-radius: 14px;
+  color: #020617;
+  background: linear-gradient(135deg, #f8fafc, #bae6fd);
+  font-weight: 900;
+}
+
+.sidebar-nav {
+  display: grid;
+  gap: 6px;
+}
+
+.sidebar-nav a {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  padding: 11px 12px;
+  border-radius: 14px;
+  color: #cbd5e1;
+  font-weight: 800;
+}
+
+.sidebar-nav a:hover,
+.sidebar-nav a.active {
+  color: #f8fafc;
+  background: rgba(59, 130, 246, 0.12);
+  border: 1px solid rgba(147, 197, 253, 0.14);
+}
+
+.sidebar-footer {
+  margin-top: auto;
+  padding-top: 18px;
+  border-top: 1px solid rgba(148, 163, 184, 0.14);
+}
+
+.sidebar-user {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+}
+
+.sidebar-user-avatar {
+  width: 34px;
+  height: 34px;
+  border-radius: 12px;
+}
+
+.sidebar-footer button {
+  width: 100%;
+  margin-top: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  min-height: 40px;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  background: rgba(30, 41, 59, 0.55);
+  color: #cbd5e1;
+  cursor: pointer;
+  font-weight: 800;
+}
+
+.authenticated-content {
+  padding-left: 274px;
+}
+
+@media (max-width: 980px) {
+  .app-sidebar {
+    position: sticky;
+    inset: 0;
+    width: auto;
+    margin: 0;
+    border-radius: 0 0 22px 22px;
+    padding: 12px 16px;
+  }
+
+  .sidebar-brand,
+  .sidebar-footer,
+  .sidebar-add {
+    display: none;
+  }
+
+  .sidebar-nav {
+    display: flex;
+    gap: 8px;
+    overflow-x: auto;
+    scrollbar-width: none;
+  }
+
+  .sidebar-nav::-webkit-scrollbar {
+    display: none;
+  }
+
+  .sidebar-nav a {
+    flex: 0 0 auto;
+    white-space: nowrap;
+  }
+
+  .authenticated-content {
+    padding-left: 0;
+  }
+}

--- a/frontend/src/AppSidebar.jsx
+++ b/frontend/src/AppSidebar.jsx
@@ -14,7 +14,7 @@ import "./AppShell.css";
 const NAV_ITEMS = [
   { href: "/app", label: "Overview", icon: Home },
   { href: "/app/accomplishments", label: "Accomplishments", icon: ListChecks },
-  { href: "/app#impact-receipts", label: "Impact Receipts", icon: ReceiptText },
+  { href: "/app/impact-receipts", label: "Impact Receipts", icon: ReceiptText },
   { href: "/app/reports", label: "Reports", icon: FileText },
 ];
 
@@ -67,10 +67,7 @@ function AppSidebar() {
 
       <nav className="sidebar-nav" aria-label="BragStack navigation">
         {NAV_ITEMS.map(({ href, label, icon: Icon }) => {
-          const hrefPath = href.split("#")[0];
-          const isActive = hrefPath === "/app"
-            ? path === "/app" && !href.includes("#")
-            : path === hrefPath;
+          const isActive = path === href;
 
           return (
             <a className={isActive ? "active" : ""} href={href} key={href}>
@@ -83,7 +80,7 @@ function AppSidebar() {
         {user?.public_slug && (
           <a href={`/brag/${user.public_slug}`} target="_blank" rel="noreferrer">
             <UserRound size={18} />
-            <span>Public Profile</span>
+            <span>Proof Profile</span>
           </a>
         )}
       </nav>

--- a/frontend/src/AppSidebar.jsx
+++ b/frontend/src/AppSidebar.jsx
@@ -1,0 +1,118 @@
+import { useEffect, useState } from "react";
+import {
+  BarChart3,
+  FileText,
+  Home,
+  ListChecks,
+  LogOut,
+  ReceiptText,
+  Settings,
+  UserRound,
+} from "lucide-react";
+
+import { getCurrentUser } from "./api";
+import "./AppShell.css";
+
+const NAV_ITEMS = [
+  { href: "/app", label: "Overview", icon: Home },
+  { href: "/app/accomplishments", label: "Accomplishments", icon: ListChecks },
+  { href: "/app#impact-receipts", label: "Impact Receipts", icon: ReceiptText },
+  { href: "/app/reports", label: "Reports", icon: FileText },
+];
+
+function AppSidebar() {
+  const [user, setUser] = useState(null);
+  const path = window.location.pathname;
+
+  useEffect(() => {
+    let isMounted = true;
+
+    async function loadUser() {
+      try {
+        const data = await getCurrentUser();
+        if (isMounted) {
+          setUser(data);
+        }
+      } catch (error) {
+        if (error.response?.status === 401) {
+          localStorage.removeItem("bragstack_token");
+          window.location.assign("/login");
+        }
+      }
+    }
+
+    void loadUser();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  function logout() {
+    localStorage.removeItem("bragstack_token");
+    window.location.assign("/login");
+  }
+
+  return (
+    <aside className="app-sidebar">
+      <a className="sidebar-brand" href="/app">
+        <span className="sidebar-logo">B</span>
+        <span>
+          <strong>BragStack</strong>
+          <small>Career proof</small>
+        </span>
+      </a>
+
+      <a className="sidebar-add" href="/app#entries">
+        + Add accomplishment
+      </a>
+
+      <nav className="sidebar-nav" aria-label="BragStack navigation">
+        {NAV_ITEMS.map(({ href, label, icon: Icon }) => {
+          const hrefPath = href.split("#")[0];
+          const isActive = hrefPath === "/app"
+            ? path === "/app" && !href.includes("#")
+            : path === hrefPath;
+
+          return (
+            <a className={isActive ? "active" : ""} href={href} key={href}>
+              <Icon size={18} />
+              <span>{label}</span>
+            </a>
+          );
+        })}
+
+        {user?.public_slug && (
+          <a href={`/brag/${user.public_slug}`} target="_blank" rel="noreferrer">
+            <UserRound size={18} />
+            <span>Public Profile</span>
+          </a>
+        )}
+
+        <a href="/app#profile-settings">
+          <Settings size={18} />
+          <span>Settings</span>
+        </a>
+      </nav>
+
+      <div className="sidebar-footer">
+        <div className="sidebar-user">
+          <span className="sidebar-user-avatar">
+            {user?.name?.charAt(0).toUpperCase() || "B"}
+          </span>
+          <span>
+            <strong>{user?.name || "BragStack member"}</strong>
+            <small>{user?.headline || "Build your proof"}</small>
+          </span>
+        </div>
+
+        <button type="button" onClick={logout}>
+          <LogOut size={17} />
+          Logout
+        </button>
+      </div>
+    </aside>
+  );
+}
+
+export default AppSidebar;

--- a/frontend/src/AppSidebar.jsx
+++ b/frontend/src/AppSidebar.jsx
@@ -1,12 +1,10 @@
 import { useEffect, useState } from "react";
 import {
-  BarChart3,
   FileText,
   Home,
   ListChecks,
   LogOut,
   ReceiptText,
-  Settings,
   UserRound,
 } from "lucide-react";
 
@@ -88,11 +86,6 @@ function AppSidebar() {
             <span>Public Profile</span>
           </a>
         )}
-
-        <a href="/app#profile-settings">
-          <Settings size={18} />
-          <span>Settings</span>
-        </a>
       </nav>
 
       <div className="sidebar-footer">

--- a/frontend/src/ImpactReceiptsPage.jsx
+++ b/frontend/src/ImpactReceiptsPage.jsx
@@ -1,0 +1,192 @@
+import { useEffect, useMemo, useState } from "react";
+import { ExternalLink, ReceiptText, ShieldCheck } from "lucide-react";
+
+import { getImpactReceipts, updateImpactReceipt } from "./api";
+
+function formatLabel(value = "") {
+  return value
+    .replace(/-/g, " ")
+    .replace(/\b\w/g, (character) => character.toUpperCase());
+}
+
+function ImpactReceiptsPage() {
+  const [receipts, setReceipts] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [updatingId, setUpdatingId] = useState(null);
+
+  async function loadReceipts() {
+    try {
+      const data = await getImpactReceipts();
+      setReceipts(data.receipts ?? []);
+      setError("");
+    } catch (err) {
+      if (err.response?.status === 401) {
+        localStorage.removeItem("bragstack_token");
+        window.location.assign("/login");
+        return;
+      }
+      setError("Impact Receipts could not be loaded.");
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    void loadReceipts();
+  }, []);
+
+  const stats = useMemo(() => {
+    const publicCount = receipts.filter((receipt) => receipt.is_public).length;
+    const evidenceCount = receipts.reduce(
+      (total, receipt) => total + (receipt.evidence?.length ?? 0),
+      0,
+    );
+    const confirmedCount = receipts.reduce(
+      (total, receipt) =>
+        total +
+        (receipt.confirmations?.filter(
+          (confirmation) => confirmation.status === "confirmed",
+        ).length ?? 0),
+      0,
+    );
+
+    return { publicCount, evidenceCount, confirmedCount };
+  }, [receipts]);
+
+  async function toggleVisibility(receipt) {
+    setUpdatingId(receipt.id);
+    try {
+      await updateImpactReceipt(receipt.id, {
+        is_public: !receipt.is_public,
+      });
+      await loadReceipts();
+    } catch (err) {
+      setError(
+        err.response?.data?.detail ?? "Receipt visibility could not be changed.",
+      );
+    } finally {
+      setUpdatingId(null);
+    }
+  }
+
+  return (
+    <main className="product-page receipt-library-page">
+      <section className="product-page-hero">
+        <div>
+          <p className="mini-label">Evidence-backed career proof</p>
+          <h1>Impact Receipts</h1>
+          <p>
+            Your strongest accomplishments, packaged with contribution, result,
+            evidence, skills, and trust signals.
+          </p>
+        </div>
+        <a className="product-page-link" href="/app/accomplishments">
+          Create from an accomplishment <ExternalLink size={16} />
+        </a>
+      </section>
+
+      <section className="receipt-kpi-grid">
+        <article>
+          <ReceiptText size={20} />
+          <span>Total receipts</span>
+          <strong>{receipts.length}</strong>
+        </article>
+        <article>
+          <ShieldCheck size={20} />
+          <span>Public receipts</span>
+          <strong>{stats.publicCount}</strong>
+        </article>
+        <article>
+          <span className="receipt-kpi-dot" />
+          <span>Evidence items</span>
+          <strong>{stats.evidenceCount}</strong>
+        </article>
+        <article>
+          <span className="receipt-kpi-dot" />
+          <span>Confirmed signals</span>
+          <strong>{stats.confirmedCount}</strong>
+        </article>
+      </section>
+
+      {error && <div className="product-alert error">{error}</div>}
+
+      {isLoading ? (
+        <section className="product-empty">Loading Impact Receipts…</section>
+      ) : receipts.length === 0 ? (
+        <section className="product-empty">
+          <h2>No receipts yet.</h2>
+          <p>
+            Turn a meaningful accomplishment into a receipt to start building
+            portable evidence of your work.
+          </p>
+          <a href="/app/accomplishments">Browse accomplishments</a>
+        </section>
+      ) : (
+        <section className="receipt-library-grid">
+          {receipts.map((receipt) => (
+            <article className="receipt-library-card" key={receipt.id}>
+              <div className="receipt-library-card-top">
+                <div>
+                  <p className="mini-label">Impact Receipt</p>
+                  <h2>{receipt.accomplishment}</h2>
+                </div>
+                <button
+                  type="button"
+                  className={`visibility-pill ${
+                    receipt.is_public ? "public" : "private"
+                  }`}
+                  disabled={updatingId === receipt.id}
+                  onClick={() => toggleVisibility(receipt)}
+                >
+                  {updatingId === receipt.id
+                    ? "Saving…"
+                    : receipt.is_public
+                      ? "Public"
+                      : "Private"}
+                </button>
+              </div>
+
+              <div className="receipt-proof-columns">
+                <div>
+                  <span>Contribution</span>
+                  <p>{receipt.contribution}</p>
+                </div>
+                <div>
+                  <span>Result</span>
+                  <p>{receipt.result}</p>
+                </div>
+              </div>
+
+              <div className="receipt-signal-row">
+                <span>{receipt.evidence?.length ?? 0} evidence</span>
+                <span>{receipt.skills?.length ?? 0} skills</span>
+                <span>{receipt.credit?.length ?? 0} contributors</span>
+              </div>
+
+              {receipt.skills?.length > 0 && (
+                <div className="receipt-chip-row">
+                  {receipt.skills.map((skill) => (
+                    <span key={`${receipt.id}-${skill}`}>{skill}</span>
+                  ))}
+                </div>
+              )}
+
+              {receipt.trust_signals?.length > 0 && (
+                <div className="receipt-trust-row">
+                  {receipt.trust_signals.map((signal) => (
+                    <span key={`${receipt.id}-${signal}`}>
+                      <ShieldCheck size={14} /> {formatLabel(signal)}
+                    </span>
+                  ))}
+                </div>
+              )}
+            </article>
+          ))}
+        </section>
+      )}
+    </main>
+  );
+}
+
+export default ImpactReceiptsPage;

--- a/frontend/src/ProductPolish.css
+++ b/frontend/src/ProductPolish.css
@@ -1,0 +1,263 @@
+.product-page {
+  width: min(1180px, calc(100% - 40px));
+  margin: 0 auto;
+  padding: 34px 0 72px;
+}
+
+.product-page-hero {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 24px;
+  padding: 34px;
+  border-radius: 30px;
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  background: linear-gradient(145deg, rgba(15, 23, 42, 0.92), rgba(17, 24, 39, 0.72));
+  box-shadow: 0 28px 90px rgba(0, 0, 0, 0.28);
+}
+
+.product-page-hero h1 {
+  margin: 8px 0 10px;
+  font-size: clamp(2.8rem, 6vw, 5rem);
+  line-height: 0.95;
+  letter-spacing: -0.07em;
+}
+
+.product-page-hero p {
+  max-width: 760px;
+  color: #cbd5e1;
+  line-height: 1.7;
+}
+
+.product-page-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 16px;
+  border-radius: 999px;
+  color: #020617;
+  background: linear-gradient(135deg, #f8fafc, #bae6fd);
+  text-decoration: none;
+  font-weight: 900;
+  white-space: nowrap;
+}
+
+.receipt-kpi-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 14px;
+  margin: 16px 0;
+}
+
+.receipt-kpi-grid article {
+  display: grid;
+  gap: 6px;
+  padding: 20px;
+  border-radius: 24px;
+  border: 1px solid rgba(148, 163, 184, 0.15);
+  background: rgba(15, 23, 42, 0.72);
+}
+
+.receipt-kpi-grid article > span {
+  color: #94a3b8;
+  font-weight: 800;
+}
+
+.receipt-kpi-grid article strong {
+  font-size: 2rem;
+  letter-spacing: -0.04em;
+}
+
+.receipt-kpi-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 999px;
+  background: #38bdf8;
+  box-shadow: 0 0 0 6px rgba(56, 189, 248, 0.1);
+}
+
+.receipt-library-grid {
+  display: grid;
+  gap: 16px;
+}
+
+.receipt-library-card {
+  padding: 26px;
+  border-radius: 28px;
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  background: rgba(15, 23, 42, 0.76);
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.22);
+}
+
+.receipt-library-card-top,
+.receipt-proof-columns,
+.receipt-signal-row,
+.receipt-chip-row,
+.receipt-trust-row {
+  display: flex;
+  gap: 12px;
+}
+
+.receipt-library-card-top {
+  justify-content: space-between;
+  align-items: flex-start;
+}
+
+.receipt-library-card h2 {
+  margin: 6px 0 0;
+  font-size: 1.45rem;
+}
+
+.visibility-pill {
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 999px;
+  padding: 8px 12px;
+  color: #e2e8f0;
+  background: rgba(30, 41, 59, 0.74);
+  font-weight: 900;
+  cursor: pointer;
+}
+
+.visibility-pill.public {
+  color: #bbf7d0;
+  border-color: rgba(74, 222, 128, 0.25);
+}
+
+.receipt-proof-columns {
+  margin-top: 20px;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.receipt-proof-columns > div {
+  padding: 18px;
+  border-radius: 20px;
+  background: rgba(2, 6, 23, 0.4);
+  border: 1px solid rgba(148, 163, 184, 0.11);
+}
+
+.receipt-proof-columns span {
+  color: #7dd3fc;
+  font-size: 0.78rem;
+  font-weight: 900;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.receipt-proof-columns p {
+  margin-bottom: 0;
+  color: #dbeafe;
+  line-height: 1.65;
+}
+
+.receipt-signal-row,
+.receipt-chip-row,
+.receipt-trust-row {
+  flex-wrap: wrap;
+  margin-top: 16px;
+}
+
+.receipt-signal-row span,
+.receipt-chip-row span,
+.receipt-trust-row span {
+  border-radius: 999px;
+  padding: 7px 10px;
+  background: rgba(30, 41, 59, 0.74);
+  border: 1px solid rgba(148, 163, 184, 0.14);
+  color: #cbd5e1;
+  font-size: 0.8rem;
+  font-weight: 800;
+}
+
+.receipt-trust-row span {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: #bfdbfe;
+}
+
+.product-empty,
+.product-alert {
+  margin-top: 16px;
+  padding: 26px;
+  border-radius: 24px;
+  border: 1px solid rgba(148, 163, 184, 0.15);
+  background: rgba(15, 23, 42, 0.72);
+}
+
+.product-alert.error {
+  color: #fecaca;
+}
+
+.pagination-shell {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  margin-top: 20px;
+  padding-top: 18px;
+  border-top: 1px solid rgba(148, 163, 184, 0.14);
+}
+
+.pagination-summary {
+  color: #94a3b8;
+  font-size: 0.9rem;
+  font-weight: 700;
+}
+
+.pagination-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.pagination-controls a,
+.pagination-controls span {
+  min-width: 38px;
+  height: 38px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: rgba(30, 41, 59, 0.7);
+  color: #dbeafe;
+  text-decoration: none;
+  font-weight: 900;
+}
+
+.pagination-controls .active {
+  color: #020617;
+  background: linear-gradient(135deg, #f8fafc, #bae6fd);
+}
+
+.pagination-controls .disabled {
+  opacity: 0.38;
+  pointer-events: none;
+}
+
+@media (max-width: 820px) {
+  .product-page-hero,
+  .pagination-shell {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .receipt-kpi-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .receipt-proof-columns {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 520px) {
+  .product-page {
+    width: min(100% - 24px, 1180px);
+  }
+
+  .receipt-kpi-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/src/ProofProfile.css
+++ b/frontend/src/ProofProfile.css
@@ -1,0 +1,625 @@
+.proof-profile {
+  min-height: 100vh;
+  color: #e5eefc;
+  background:
+    radial-gradient(circle at 12% 8%, rgba(56, 189, 248, 0.14), transparent 28%),
+    radial-gradient(circle at 88% 18%, rgba(168, 85, 247, 0.14), transparent 30%),
+    #050816;
+}
+
+.proof-profile-inner {
+  width: min(1200px, calc(100% - 40px));
+  margin: 0 auto;
+  padding: 24px 0 72px;
+}
+
+.proof-topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  margin-bottom: 18px;
+}
+
+.proof-brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  color: #f8fafc;
+  text-decoration: none;
+  font-weight: 950;
+  letter-spacing: -0.03em;
+}
+
+.proof-brand-mark {
+  display: grid;
+  place-items: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 12px;
+  color: #020617;
+  background: linear-gradient(135deg, #e0f2fe, #c4b5fd);
+}
+
+.proof-topbar-tag {
+  color: #94a3b8;
+  font-size: 0.86rem;
+  font-weight: 800;
+}
+
+.proof-hero {
+  position: relative;
+  overflow: hidden;
+  display: grid;
+  grid-template-columns: minmax(0, 1.5fr) minmax(300px, 0.7fr);
+  gap: 18px;
+  padding: 42px;
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  border-radius: 34px;
+  background: linear-gradient(145deg, rgba(15, 23, 42, 0.94), rgba(17, 24, 39, 0.74));
+  box-shadow: 0 32px 100px rgba(0, 0, 0, 0.32);
+}
+
+.proof-hero::after {
+  content: "";
+  position: absolute;
+  width: 420px;
+  height: 420px;
+  right: -210px;
+  top: -210px;
+  border-radius: 999px;
+  background: radial-gradient(circle, rgba(56, 189, 248, 0.2), transparent 67%);
+  pointer-events: none;
+}
+
+.proof-eyebrow {
+  margin: 0;
+  color: #7dd3fc;
+  font-size: 0.76rem;
+  font-weight: 950;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.proof-hero h1 {
+  max-width: 800px;
+  margin: 12px 0 12px;
+  font-size: clamp(3rem, 7vw, 6.4rem);
+  line-height: 0.88;
+  letter-spacing: -0.075em;
+}
+
+.proof-hero h1 span {
+  display: block;
+  background: linear-gradient(90deg, #f8fafc, #7dd3fc 48%, #c4b5fd);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.proof-headline {
+  margin: 0 0 14px;
+  color: #dbeafe;
+  font-size: clamp(1.15rem, 2vw, 1.55rem);
+  font-weight: 850;
+}
+
+.proof-bio {
+  max-width: 760px;
+  margin: 0;
+  color: #aebbd0;
+  line-height: 1.75;
+  font-size: 1.02rem;
+}
+
+.proof-location {
+  margin: 14px 0 0;
+  color: #7dd3fc;
+  font-weight: 800;
+}
+
+.proof-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 24px;
+}
+
+.proof-action {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 42px;
+  padding: 0 15px;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  color: #e2e8f0;
+  background: rgba(15, 23, 42, 0.55);
+  text-decoration: none;
+  font-weight: 900;
+}
+
+.proof-action.primary {
+  color: #020617;
+  background: linear-gradient(135deg, #f8fafc, #bae6fd);
+  border-color: transparent;
+}
+
+.proof-scorecard {
+  align-self: stretch;
+  display: grid;
+  align-content: space-between;
+  gap: 16px;
+  padding: 22px;
+  border-radius: 26px;
+  border: 1px solid rgba(148, 163, 184, 0.14);
+  background: rgba(2, 6, 23, 0.46);
+  backdrop-filter: blur(12px);
+}
+
+.proof-avatar {
+  display: grid;
+  place-items: center;
+  width: 58px;
+  height: 58px;
+  border-radius: 18px;
+  color: #020617;
+  background: linear-gradient(135deg, #bae6fd, #c4b5fd);
+  font-size: 1.4rem;
+  font-weight: 950;
+}
+
+.proof-scorecard h2 {
+  margin: 8px 0 0;
+  font-size: 1.35rem;
+}
+
+.proof-score-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.proof-score-grid article {
+  padding: 13px;
+  border-radius: 18px;
+  background: rgba(30, 41, 59, 0.62);
+  border: 1px solid rgba(148, 163, 184, 0.1);
+}
+
+.proof-score-grid strong {
+  display: block;
+  font-size: 1.45rem;
+  letter-spacing: -0.04em;
+}
+
+.proof-score-grid span {
+  color: #94a3b8;
+  font-size: 0.76rem;
+  font-weight: 800;
+}
+
+.proof-section {
+  margin-top: 18px;
+  padding: 28px;
+  border-radius: 30px;
+  border: 1px solid rgba(148, 163, 184, 0.15);
+  background: rgba(15, 23, 42, 0.7);
+  box-shadow: 0 24px 70px rgba(0, 0, 0, 0.22);
+}
+
+.proof-section-heading {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 18px;
+}
+
+.proof-section-heading h2 {
+  margin: 6px 0 0;
+  font-size: clamp(1.8rem, 3vw, 2.6rem);
+  letter-spacing: -0.05em;
+}
+
+.proof-section-heading p:not(.proof-eyebrow) {
+  max-width: 650px;
+  margin: 7px 0 0;
+  color: #94a3b8;
+}
+
+.proof-live-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 11px;
+  border-radius: 999px;
+  color: #bfdbfe;
+  background: rgba(56, 189, 248, 0.08);
+  border: 1px solid rgba(125, 211, 252, 0.15);
+  font-size: 0.78rem;
+  font-weight: 900;
+}
+
+.proof-kpi-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.proof-kpi {
+  padding: 18px;
+  border-radius: 22px;
+  background: rgba(2, 6, 23, 0.42);
+  border: 1px solid rgba(148, 163, 184, 0.1);
+}
+
+.proof-kpi span {
+  color: #94a3b8;
+  font-size: 0.8rem;
+  font-weight: 850;
+}
+
+.proof-kpi strong {
+  display: block;
+  margin-top: 6px;
+  font-size: 2rem;
+  letter-spacing: -0.05em;
+}
+
+.proof-kpi small {
+  display: block;
+  margin-top: 4px;
+  color: #64748b;
+}
+
+.proof-analytics-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.2fr) minmax(0, 1fr);
+  gap: 14px;
+  margin-top: 14px;
+}
+
+.proof-chart-card {
+  padding: 18px;
+  border-radius: 22px;
+  background: rgba(2, 6, 23, 0.4);
+  border: 1px solid rgba(148, 163, 184, 0.1);
+}
+
+.proof-chart-card h3 {
+  margin: 0 0 14px;
+  font-size: 1rem;
+}
+
+.proof-activity {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 10px;
+  min-height: 170px;
+  align-items: end;
+}
+
+.proof-activity-item {
+  display: grid;
+  gap: 8px;
+  justify-items: center;
+}
+
+.proof-activity-bar-wrap {
+  width: 100%;
+  height: 130px;
+  display: flex;
+  align-items: end;
+  padding: 0 6px;
+}
+
+.proof-activity-bar {
+  width: 100%;
+  min-height: 8px;
+  border-radius: 12px 12px 5px 5px;
+  background: linear-gradient(180deg, #38bdf8, #8b5cf6);
+  box-shadow: 0 8px 28px rgba(56, 189, 248, 0.18);
+}
+
+.proof-activity-item span {
+  color: #64748b;
+  font-size: 0.72rem;
+  font-weight: 850;
+}
+
+.proof-bars {
+  display: grid;
+  gap: 11px;
+}
+
+.proof-bar-row {
+  display: grid;
+  gap: 6px;
+}
+
+.proof-bar-label {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  color: #cbd5e1;
+  font-size: 0.8rem;
+  font-weight: 800;
+}
+
+.proof-bar-track {
+  height: 8px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: rgba(51, 65, 85, 0.55);
+}
+
+.proof-bar-track span {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, #38bdf8, #a78bfa);
+}
+
+.proof-receipt-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.proof-receipt {
+  padding: 20px;
+  border-radius: 24px;
+  background: linear-gradient(145deg, rgba(30, 41, 59, 0.74), rgba(15, 23, 42, 0.82));
+  border: 1px solid rgba(125, 211, 252, 0.13);
+}
+
+.proof-receipt h3 {
+  margin: 6px 0 14px;
+  font-size: 1.25rem;
+}
+
+.proof-receipt-block {
+  padding: 13px;
+  margin-top: 9px;
+  border-radius: 16px;
+  background: rgba(2, 6, 23, 0.34);
+}
+
+.proof-receipt-block span {
+  color: #7dd3fc;
+  font-size: 0.72rem;
+  font-weight: 900;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.proof-receipt-block p {
+  margin: 5px 0 0;
+  color: #dbeafe;
+  line-height: 1.55;
+}
+
+.proof-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+  margin-top: 12px;
+}
+
+.proof-chips span {
+  padding: 6px 9px;
+  border-radius: 999px;
+  color: #cbd5e1;
+  background: rgba(30, 41, 59, 0.7);
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  font-size: 0.75rem;
+  font-weight: 800;
+}
+
+.proof-controls {
+  display: grid;
+  gap: 12px;
+  margin-bottom: 18px;
+}
+
+.proof-search {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 13px 15px;
+  border-radius: 18px;
+  background: rgba(2, 6, 23, 0.38);
+  border: 1px solid rgba(148, 163, 184, 0.14);
+}
+
+.proof-search input {
+  width: 100%;
+  border: 0;
+  outline: none;
+  background: transparent;
+  color: #f8fafc;
+  font: inherit;
+}
+
+.proof-filter-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.proof-filter-row button {
+  padding: 8px 11px;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.14);
+  color: #cbd5e1;
+  background: rgba(30, 41, 59, 0.58);
+  font-weight: 800;
+  cursor: pointer;
+}
+
+.proof-filter-row button.active {
+  color: #020617;
+  background: linear-gradient(135deg, #f8fafc, #bae6fd);
+}
+
+.proof-entry-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.proof-entry-card {
+  display: grid;
+  gap: 14px;
+  padding: 21px;
+  border-radius: 24px;
+  background: rgba(2, 6, 23, 0.38);
+  border: 1px solid rgba(148, 163, 184, 0.11);
+}
+
+.proof-entry-card h3 {
+  margin: 4px 0 0;
+  font-size: 1.2rem;
+}
+
+.proof-entry-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+}
+
+.proof-entry-meta span {
+  color: #93c5fd;
+  font-size: 0.75rem;
+  font-weight: 850;
+}
+
+.proof-entry-impact {
+  padding: 14px;
+  border-radius: 17px;
+  background: linear-gradient(135deg, rgba(14, 165, 233, 0.08), rgba(139, 92, 246, 0.08));
+  border: 1px solid rgba(125, 211, 252, 0.12);
+}
+
+.proof-entry-impact strong {
+  color: #f8fafc;
+}
+
+.proof-entry-impact p,
+.proof-entry-details p {
+  margin: 6px 0 0;
+  color: #b9c7da;
+  line-height: 1.6;
+}
+
+.proof-entry-details {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.proof-entry-details > div {
+  padding: 12px;
+  border-radius: 16px;
+  background: rgba(15, 23, 42, 0.48);
+}
+
+.proof-entry-details strong {
+  color: #c4b5fd;
+  font-size: 0.78rem;
+}
+
+.proof-pagination {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  margin-top: 20px;
+  padding-top: 18px;
+  border-top: 1px solid rgba(148, 163, 184, 0.12);
+}
+
+.proof-pagination-summary {
+  color: #94a3b8;
+  font-size: 0.86rem;
+  font-weight: 800;
+}
+
+.proof-pagination-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+}
+
+.proof-pagination-controls button {
+  min-width: 38px;
+  height: 38px;
+  padding: 0 10px;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  color: #dbeafe;
+  background: rgba(30, 41, 59, 0.66);
+  font-weight: 900;
+  cursor: pointer;
+}
+
+.proof-pagination-controls button.active {
+  color: #020617;
+  background: linear-gradient(135deg, #f8fafc, #bae6fd);
+}
+
+.proof-pagination-controls button:disabled {
+  opacity: 0.36;
+  cursor: default;
+}
+
+.proof-empty,
+.proof-error {
+  padding: 28px;
+  border-radius: 22px;
+  text-align: center;
+  background: rgba(2, 6, 23, 0.36);
+  border: 1px dashed rgba(148, 163, 184, 0.22);
+  color: #94a3b8;
+}
+
+@media (max-width: 900px) {
+  .proof-hero,
+  .proof-analytics-grid,
+  .proof-receipt-grid,
+  .proof-entry-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .proof-kpi-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 620px) {
+  .proof-profile-inner {
+    width: min(100% - 24px, 1200px);
+  }
+
+  .proof-hero,
+  .proof-section {
+    padding: 22px;
+    border-radius: 24px;
+  }
+
+  .proof-hero h1 {
+    font-size: clamp(2.7rem, 17vw, 4.4rem);
+  }
+
+  .proof-section-heading,
+  .proof-pagination {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .proof-entry-details,
+  .proof-score-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/src/PublicBragPage.jsx
+++ b/frontend/src/PublicBragPage.jsx
@@ -1,5 +1,12 @@
 import { useEffect, useMemo, useState } from "react";
-import { BarChart3, ExternalLink, Search, ShieldCheck, Sparkles } from "lucide-react";
+import {
+  ExternalLink,
+  MapPin,
+  Search,
+  ShieldCheck,
+  Sparkles,
+} from "lucide-react";
+
 import {
   getPublicCategoriesSummary,
   getPublicEntries,
@@ -9,8 +16,9 @@ import {
   getPublicWeeklyReport,
 } from "./api";
 
-import "./PublicBragPage.css";
+import "./ProofProfile.css";
 
+const PAGE_SIZE = 4;
 const FILTERS = [
   "All",
   "Current Job",
@@ -29,9 +37,22 @@ function normalizeTags(tags) {
   return [];
 }
 
-function safeText(value) {
-  if (value === null || value === undefined) return "";
-  return String(value);
+function searchableEntry(entry) {
+  return [
+    entry.title,
+    entry.category,
+    entry.entry_type,
+    entry.entry_date,
+    entry.resume_bullet,
+    entry.situation,
+    entry.action,
+    entry.impact,
+    entry.lesson,
+    ...normalizeTags(entry.tags),
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
 }
 
 function formatSignal(value = "") {
@@ -40,94 +61,33 @@ function formatSignal(value = "") {
     .replace(/\b\w/g, (character) => character.toUpperCase());
 }
 
-function buildMonthlyActivity(entries) {
-  const now = new Date();
-  const buckets = Array.from({ length: 6 }, (_, index) => {
-    const date = new Date(now.getFullYear(), now.getMonth() - (5 - index), 1);
-    return {
-      key: `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}`,
-      label: date.toLocaleDateString(undefined, { month: "short" }),
-      count: 0,
-    };
-  });
-
-  const indexByKey = Object.fromEntries(buckets.map((bucket, index) => [bucket.key, index]));
-
-  entries.forEach((entry) => {
-    if (!entry.entry_date) return;
-    const date = new Date(`${entry.entry_date}T00:00:00`);
-    if (Number.isNaN(date.getTime())) return;
-    const key = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}`;
-    const index = indexByKey[key];
-    if (index !== undefined) buckets[index].count += 1;
-  });
-
-  return buckets;
-}
-
-function ActivityChart({ data }) {
-  const max = Math.max(...data.map((item) => item.count), 1);
-  const points = data.map((item, index) => {
-    const x = data.length === 1 ? 50 : (index / (data.length - 1)) * 100;
-    const y = 82 - (item.count / max) * 58;
-    return { ...item, x, y };
-  });
-
-  return (
-    <div className="activity-chart" aria-label="Accomplishment activity over six months">
-      <svg viewBox="0 0 100 92" preserveAspectRatio="none" role="img">
-        <defs>
-          <linearGradient id="activityFill" x1="0" y1="0" x2="0" y2="1">
-            <stop offset="0%" stopColor="#38bdf8" stopOpacity="0.42" />
-            <stop offset="100%" stopColor="#8b5cf6" stopOpacity="0" />
-          </linearGradient>
-        </defs>
-        <path
-          className="activity-area"
-          d={`M 0 82 ${points.map((point) => `L ${point.x} ${point.y}`).join(" ")} L 100 82 Z`}
-        />
-        <polyline
-          className="activity-line"
-          points={points.map((point) => `${point.x},${point.y}`).join(" ")}
-        />
-        {points.map((point) => (
-          <circle key={point.key} cx={point.x} cy={point.y} r="1.8" className="activity-dot" />
-        ))}
-      </svg>
-      <div className="activity-labels">
-        {points.map((point) => (
-          <span key={point.key} title={`${point.count} accomplishment${point.count === 1 ? "" : "s"}`}>
-            {point.label}
-          </span>
-        ))}
-      </div>
-    </div>
-  );
-}
-
 function PublicBragPage() {
   const [profile, setProfile] = useState(null);
   const [entries, setEntries] = useState([]);
+  const [entryMeta, setEntryMeta] = useState({
+    total_entries: 0,
+    activity_last_6_months: [],
+  });
   const [impactReceipts, setImpactReceipts] = useState([]);
   const [weeklyReport, setWeeklyReport] = useState(null);
   const [tagsSummary, setTagsSummary] = useState(null);
   const [categoriesSummary, setCategoriesSummary] = useState(null);
+  const [page, setPage] = useState(1);
   const [searchTerm, setSearchTerm] = useState("");
   const [activeFilter, setActiveFilter] = useState("All");
   const [isOffline, setIsOffline] = useState(false);
 
   const publicSlug = useMemo(() => {
-    const [, page, slug] = window.location.pathname.split("/");
-    return page === "brag" ? slug : undefined;
+    const [, route, slug] = window.location.pathname.split("/");
+    return route === "brag" ? slug : undefined;
   }, []);
 
   useEffect(() => {
-    async function loadPublicPage() {
+    async function loadProfileData() {
       try {
-        const [profileData, entriesData, receiptsData, weeklyData, tagsData, categoriesData] =
+        const [profileData, receiptsData, weeklyData, tagsData, categoriesData] =
           await Promise.all([
             getPublicProfile(publicSlug),
-            getPublicEntries(publicSlug),
             getPublicImpactReceipts(publicSlug),
             getPublicWeeklyReport(publicSlug),
             getPublicTagsSummary(publicSlug),
@@ -135,330 +95,435 @@ function PublicBragPage() {
           ]);
 
         setProfile(profileData.profile ?? null);
-        setEntries(entriesData.entries || []);
-        setImpactReceipts(receiptsData.receipts || []);
+        setImpactReceipts(receiptsData.receipts ?? []);
         setWeeklyReport(weeklyData);
         setTagsSummary(tagsData);
         setCategoriesSummary(categoriesData);
         setIsOffline(false);
-      } catch (err) {
-        console.error("Failed to load public BragStack page:", err);
+      } catch (error) {
+        console.error("Failed to load Proof Profile:", error);
         setIsOffline(true);
       }
     }
 
-    void loadPublicPage();
+    void loadProfileData();
   }, [publicSlug]);
 
-  const filteredEntries = useMemo(() => {
-    return entries.filter((entry) => {
-      const tags = normalizeTags(entry.tags);
-      const searchableText = [
-        entry.title,
-        entry.category,
-        entry.entry_type,
-        entry.entry_date,
-        entry.resume_bullet,
-        entry.situation,
-        entry.action,
-        entry.impact,
-        entry.lesson,
-        ...tags,
-      ]
-        .map(safeText)
-        .join(" ")
-        .toLowerCase();
+  useEffect(() => {
+    async function loadPage() {
+      try {
+        const data = await getPublicEntries(
+          publicSlug,
+          PAGE_SIZE,
+          (page - 1) * PAGE_SIZE,
+        );
+        setEntries(data.entries ?? []);
+        setEntryMeta({
+          total_entries: data.total_entries ?? 0,
+          activity_last_6_months: data.activity_last_6_months ?? [],
+        });
+        setIsOffline(false);
+      } catch (error) {
+        console.error("Failed to load Proof Profile entries:", error);
+        setIsOffline(true);
+      }
+    }
 
-      const matchesSearch = searchableText.includes(searchTerm.toLowerCase());
-      const matchesFilter = activeFilter === "All" || entry.entry_type === activeFilter;
+    void loadPage();
+  }, [publicSlug, page]);
+
+  useEffect(() => {
+    setPage(1);
+  }, [searchTerm, activeFilter]);
+
+  const filteredEntries = useMemo(() => {
+    const query = searchTerm.trim().toLowerCase();
+
+    return entries.filter((entry) => {
+      const matchesSearch = !query || searchableEntry(entry).includes(query);
+      const matchesFilter =
+        activeFilter === "All" || entry.entry_type === activeFilter;
       return matchesSearch && matchesFilter;
     });
   }, [entries, searchTerm, activeFilter]);
 
-  const analytics = useMemo(() => {
-    const categories = Object.entries(categoriesSummary?.categories || {});
-    const tags = Object.entries(tagsSummary?.tags || {});
-    const evidenceCount = impactReceipts.reduce(
-      (total, receipt) => total + (receipt.evidence?.length || 0),
-      0
-    );
-    const evidenceLinked = impactReceipts.filter((receipt) =>
-      receipt.trust_signals?.includes("evidence-linked")
-    ).length;
-    const receiptCoverage = entries.length
-      ? Math.min(100, Math.round((impactReceipts.length / entries.length) * 100))
-      : 0;
-    const evidenceCoverage = impactReceipts.length
-      ? Math.round((evidenceLinked / impactReceipts.length) * 100)
-      : 0;
+  const categories = Object.entries(categoriesSummary?.categories ?? {});
+  const tags = Object.entries(tagsSummary?.tags ?? {});
+  const maxCategoryCount = Math.max(...categories.map(([, count]) => count), 1);
+  const maxActivity = Math.max(
+    ...entryMeta.activity_last_6_months.map((item) => item.count),
+    1,
+  );
 
-    return {
-      categories,
-      tags,
-      evidenceCount,
-      receiptCoverage,
-      evidenceCoverage,
-      monthlyActivity: buildMonthlyActivity(entries),
-    };
-  }, [entries, impactReceipts, tagsSummary, categoriesSummary]);
+  const evidenceCount = impactReceipts.reduce(
+    (total, receipt) => total + (receipt.evidence?.length ?? 0),
+    0,
+  );
+  const evidenceLinked = impactReceipts.filter((receipt) =>
+    receipt.trust_signals?.includes("evidence-linked"),
+  ).length;
+  const receiptCoverage = entryMeta.total_entries
+    ? Math.min(
+        100,
+        Math.round((impactReceipts.length / entryMeta.total_entries) * 100),
+      )
+    : 0;
+  const evidenceCoverage = impactReceipts.length
+    ? Math.round((evidenceLinked / impactReceipts.length) * 100)
+    : 0;
 
-  const topTags = analytics.tags;
-  const maxCategoryCount = Math.max(...analytics.categories.map(([, count]) => count), 1);
-  const maxSkillCount = Math.max(...topTags.map(([, count]) => count), 1);
   const displayName = profile?.name || "BragStack member";
   const avatarLetter = displayName.charAt(0).toUpperCase() || "B";
+  const totalPages = Math.max(
+    1,
+    Math.ceil(entryMeta.total_entries / PAGE_SIZE),
+  );
+  const start = entryMeta.total_entries
+    ? (page - 1) * PAGE_SIZE + 1
+    : 0;
+  const end = Math.min(page * PAGE_SIZE, entryMeta.total_entries);
 
   return (
-    <main className="public-page">
-      <section className="public-hero">
-        <div>
-          <p className="mini-label">Public BragStack</p>
-          <h1>{displayName}&apos;s Career Proof Timeline</h1>
-          <p>
-            {profile?.bio || "A searchable record of accomplishments, skill growth, and career proof."}
-          </p>
+    <main className="proof-profile">
+      <div className="proof-profile-inner">
+        <header className="proof-topbar">
+          <a className="proof-brand" href="/">
+            <span className="proof-brand-mark">B</span>
+            <span>BragStack</span>
+          </a>
+          <span className="proof-topbar-tag">Proof Profile</span>
+        </header>
 
-          <div className="public-actions">
-            {profile?.github_url && (
-              <a href={profile.github_url} target="_blank" rel="noreferrer" className="public-button primary">
-                <ExternalLink size={17} /> GitHub
-              </a>
-            )}
-            {profile?.portfolio_url && (
-              <a href={profile.portfolio_url} target="_blank" rel="noreferrer" className="public-button secondary">
-                <ExternalLink size={17} /> Portfolio
-              </a>
-            )}
-            {profile?.resume_url && (
-              <a href={profile.resume_url} target="_blank" rel="noreferrer" className="public-button secondary">
-                <ExternalLink size={17} /> Résumé
-              </a>
-            )}
-            <a href="/" className="public-button secondary">BragStack</a>
-          </div>
-        </div>
+        <section className="proof-hero">
+          <div>
+            <p className="proof-eyebrow">Proof Profile</p>
+            <h1>
+              Career proof,
+              <span>not just claims.</span>
+            </h1>
+            <p className="proof-headline">
+              {profile?.headline || `${displayName}'s evidence-backed career story`}
+            </p>
+            <p className="proof-bio">
+              {profile?.bio ||
+                "A living record of accomplishments, demonstrated skills, and evidence-backed impact."}
+            </p>
 
-        <aside className="public-proof-card">
-          <div className="avatar">{avatarLetter}</div>
-          <h2>{profile?.headline || displayName}</h2>
-          {(profile?.location || profile?.bio) && (
-            <p>{[profile?.location, profile?.bio].filter(Boolean).join(" • ")}</p>
-          )}
-          <div className="public-stat-list">
-            <span>{entries.length} total entries</span>
-            <span>{impactReceipts.length} public receipts</span>
-            <span>{weeklyReport?.total_entries ?? 0} this week</span>
-            <span>{tagsSummary?.total_unique_tags ?? 0} skill tags</span>
-            <span>{categoriesSummary?.total_unique_categories ?? 0} categories</span>
-          </div>
-        </aside>
-      </section>
+            {profile?.location && (
+              <p className="proof-location">
+                <MapPin size={15} /> {profile.location}
+              </p>
+            )}
 
-      {!isOffline && entries.length > 0 && (
-        <section className="analytics-shell">
-          <div className="analytics-heading">
-            <div>
-              <p className="mini-label">Career Analytics</p>
-              <h2>Impact at a glance</h2>
-              <p>Public accomplishments transformed into a visual career signal.</p>
+            <div className="proof-actions">
+              {profile?.github_url && (
+                <a
+                  className="proof-action primary"
+                  href={profile.github_url}
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  GitHub <ExternalLink size={15} />
+                </a>
+              )}
+              {profile?.portfolio_url && (
+                <a
+                  className="proof-action"
+                  href={profile.portfolio_url}
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  Portfolio <ExternalLink size={15} />
+                </a>
+              )}
+              {profile?.resume_url && (
+                <a
+                  className="proof-action"
+                  href={profile.resume_url}
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  Résumé <ExternalLink size={15} />
+                </a>
+              )}
             </div>
-            <div className="analytics-badge"><Sparkles size={16} /> Live from public proof</div>
           </div>
 
-          <div className="analytics-kpis">
-            <article className="analytics-kpi">
-              <BarChart3 size={19} />
-              <span>Receipt coverage</span>
-              <strong>{analytics.receiptCoverage}%</strong>
-              <small>{impactReceipts.length} of {entries.length} public wins have receipts</small>
-            </article>
-            <article className="analytics-kpi">
-              <ShieldCheck size={19} />
-              <span>Evidence-linked</span>
-              <strong>{analytics.evidenceCoverage}%</strong>
-              <small>{analytics.evidenceCount} public evidence item{analytics.evidenceCount === 1 ? "" : "s"}</small>
-            </article>
-            <article className="analytics-kpi">
-              <Sparkles size={19} />
-              <span>Skill breadth</span>
-              <strong>{tagsSummary?.total_unique_tags ?? 0}</strong>
-              <small>distinct skills demonstrated publicly</small>
-            </article>
-          </div>
-
-          <div className="analytics-grid">
-            <article className="chart-card activity-card">
-              <div className="chart-card-heading">
-                <div>
-                  <p className="mini-label">Momentum</p>
-                  <h3>Accomplishment activity</h3>
-                </div>
-                <span>Last 6 months</span>
-              </div>
-              <ActivityChart data={analytics.monthlyActivity} />
-            </article>
-
-            <article className="chart-card">
-              <div className="chart-card-heading">
-                <div>
-                  <p className="mini-label">Impact Mix</p>
-                  <h3>Proof by category</h3>
-                </div>
-                <span>{analytics.categories.length} areas</span>
-              </div>
-              <div className="bar-chart-list">
-                {analytics.categories.slice(0, 7).map(([category, count]) => (
-                  <div className="bar-chart-row" key={category}>
-                    <div className="bar-chart-label"><span>{category}</span><strong>{count}</strong></div>
-                    <div className="bar-chart-track">
-                      <span style={{ width: `${Math.max(8, (count / maxCategoryCount) * 100)}%` }} />
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </article>
-
-            <article className="chart-card skills-chart-card">
-              <div className="chart-card-heading">
-                <div>
-                  <p className="mini-label">Skills</p>
-                  <h3>Most demonstrated skills</h3>
-                </div>
-                <span>Public proof</span>
-              </div>
-              <div className="skill-bar-grid">
-                {topTags.slice(0, 8).map(([tag, count]) => (
-                  <div className="skill-bar" key={tag}>
-                    <div className="skill-bar-top"><span>{tag}</span><strong>{count}</strong></div>
-                    <div className="skill-bar-track">
-                      <span style={{ width: `${Math.max(8, (count / maxSkillCount) * 100)}%` }} />
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </article>
-          </div>
+          <aside className="proof-scorecard">
+            <div>
+              <div className="proof-avatar">{avatarLetter}</div>
+              <h2>{displayName}</h2>
+            </div>
+            <div className="proof-score-grid">
+              <article>
+                <strong>{entryMeta.total_entries}</strong>
+                <span>public wins</span>
+              </article>
+              <article>
+                <strong>{impactReceipts.length}</strong>
+                <span>Impact Receipts</span>
+              </article>
+              <article>
+                <strong>{tagsSummary?.total_unique_tags ?? 0}</strong>
+                <span>skills shown</span>
+              </article>
+              <article>
+                <strong>{weeklyReport?.total_entries ?? 0}</strong>
+                <span>this week</span>
+              </article>
+            </div>
+          </aside>
         </section>
-      )}
 
-      {isOffline && (
-        <section className="public-notice">
-          <strong>Unable to load profile</strong>
-          <span>Public BragStack data could not be loaded right now.</span>
-        </section>
-      )}
+        {isOffline && (
+          <section className="proof-section">
+            <div className="proof-error">
+              Proof Profile data could not be loaded right now.
+            </div>
+          </section>
+        )}
 
-      <section className="public-controls">
-        <div className="search-box">
-          <Search size={18} />
-          <input
-            value={searchTerm}
-            onChange={(event) => setSearchTerm(event.target.value)}
-            placeholder="Search skills, projects, categories, and results..."
-          />
-        </div>
-        <div className="filter-pills">
-          {FILTERS.map((filter) => (
-            <button
-              type="button"
-              key={filter}
-              className={activeFilter === filter ? "active" : ""}
-              onClick={() => setActiveFilter(filter)}
-            >
-              {filter}
-            </button>
-          ))}
-        </div>
-      </section>
-
-      <section className="public-layout">
-        <section className="public-timeline">
-          {impactReceipts.length > 0 && (
-            <>
-              <div className="timeline-header">
-                <div><p className="mini-label">Verified Structure</p><h2>Public Impact Receipts</h2></div>
-                <span>{impactReceipts.length} receipts</span>
+        {!isOffline && entryMeta.total_entries > 0 && (
+          <section className="proof-section">
+            <div className="proof-section-heading">
+              <div>
+                <p className="proof-eyebrow">Career signal</p>
+                <h2>Impact at a glance</h2>
+                <p>
+                  A visual summary of the evidence behind this career story.
+                </p>
               </div>
-              {impactReceipts.map((receipt) => (
-                <article className="public-entry" key={receipt.id}>
-                  <div className="public-entry-top">
-                    <div><p className="mini-label">Impact Receipt</p><h3>{receipt.accomplishment}</h3></div>
-                    <div className="public-entry-meta">
-                      {receipt.trust_signals?.map((signal) => (
-                        <span key={`${receipt.id}-${signal}`}>{formatSignal(signal)}</span>
-                      ))}
+              <span className="proof-live-badge">
+                <Sparkles size={14} /> Live from public proof
+              </span>
+            </div>
+
+            <div className="proof-kpi-grid">
+              <article className="proof-kpi">
+                <span>Receipt coverage</span>
+                <strong>{receiptCoverage}%</strong>
+                <small>
+                  {impactReceipts.length} of {entryMeta.total_entries} wins packaged as receipts
+                </small>
+              </article>
+              <article className="proof-kpi">
+                <span>Evidence-linked</span>
+                <strong>{evidenceCoverage}%</strong>
+                <small>{evidenceCount} public evidence items</small>
+              </article>
+              <article className="proof-kpi">
+                <span>Skill breadth</span>
+                <strong>{tagsSummary?.total_unique_tags ?? 0}</strong>
+                <small>distinct demonstrated skills</small>
+              </article>
+            </div>
+
+            <div className="proof-analytics-grid">
+              <article className="proof-chart-card">
+                <h3>Accomplishment momentum · last 6 months</h3>
+                <div className="proof-activity">
+                  {entryMeta.activity_last_6_months.map((item) => (
+                    <div className="proof-activity-item" key={item.key}>
+                      <div className="proof-activity-bar-wrap">
+                        <span
+                          className="proof-activity-bar"
+                          style={{
+                            height: `${Math.max(
+                              8,
+                              (item.count / maxActivity) * 100,
+                            )}%`,
+                          }}
+                          title={`${item.count} accomplishments`}
+                        />
+                      </div>
+                      <span>{item.label}</span>
                     </div>
-                  </div>
-                  <div className="proof-grid">
-                    <div><strong>Contribution</strong><p>{receipt.contribution}</p></div>
-                    <div><strong>Result</strong><p>{receipt.result}</p></div>
-                  </div>
-                  {receipt.evidence?.length > 0 && (
-                    <div className="proof-grid">
-                      {receipt.evidence.map((item, index) => (
-                        <div key={`${receipt.id}-evidence-${index}`}><strong>{item.title}</strong><p>{item.description || item.reference}</p></div>
-                      ))}
+                  ))}
+                </div>
+              </article>
+
+              <article className="proof-chart-card">
+                <h3>Proof by category</h3>
+                <div className="proof-bars">
+                  {categories.slice(0, 7).map(([category, count]) => (
+                    <div className="proof-bar-row" key={category}>
+                      <div className="proof-bar-label">
+                        <span>{category}</span>
+                        <strong>{count}</strong>
+                      </div>
+                      <div className="proof-bar-track">
+                        <span
+                          style={{
+                            width: `${Math.max(
+                              8,
+                              (count / maxCategoryCount) * 100,
+                            )}%`,
+                          }}
+                        />
+                      </div>
                     </div>
-                  )}
-                  <div className="tags">
-                    {receipt.skills?.map((skill) => <span key={`${receipt.id}-${skill}`}>{skill}</span>)}
+                  ))}
+                </div>
+              </article>
+            </div>
+          </section>
+        )}
+
+        {impactReceipts.length > 0 && (
+          <section className="proof-section">
+            <div className="proof-section-heading">
+              <div>
+                <p className="proof-eyebrow">Featured proof</p>
+                <h2>Impact Receipts</h2>
+                <p>
+                  Structured proof of contribution, result, skills, and evidence.
+                </p>
+              </div>
+              <span className="proof-live-badge">
+                <ShieldCheck size={14} /> {impactReceipts.length} public
+              </span>
+            </div>
+
+            <div className="proof-receipt-grid">
+              {impactReceipts.slice(0, 4).map((receipt) => (
+                <article className="proof-receipt" key={receipt.id}>
+                  <p className="proof-eyebrow">Impact Receipt</p>
+                  <h3>{receipt.accomplishment}</h3>
+                  <div className="proof-receipt-block">
+                    <span>Contribution</span>
+                    <p>{receipt.contribution}</p>
+                  </div>
+                  <div className="proof-receipt-block">
+                    <span>Result</span>
+                    <p>{receipt.result}</p>
+                  </div>
+                  <div className="proof-chips">
+                    {receipt.trust_signals?.map((signal) => (
+                      <span key={`${receipt.id}-${signal}`}>
+                        {formatSignal(signal)}
+                      </span>
+                    ))}
+                    {receipt.skills?.slice(0, 4).map((skill) => (
+                      <span key={`${receipt.id}-${skill}`}>{skill}</span>
+                    ))}
                   </div>
                 </article>
               ))}
-            </>
-          )}
+            </div>
+          </section>
+        )}
 
-          <div className="timeline-header">
-            <div><p className="mini-label">Career Evidence</p><h2>Readable proof entries</h2></div>
-            <span>{filteredEntries.length} results</span>
+        <section className="proof-section">
+          <div className="proof-section-heading">
+            <div>
+              <p className="proof-eyebrow">Evidence library</p>
+              <h2>Explore the work</h2>
+              <p>
+                Search the action, impact, projects, skills, and lessons behind the profile.
+              </p>
+            </div>
+          </div>
+
+          <div className="proof-controls">
+            <div className="proof-search">
+              <Search size={17} />
+              <input
+                value={searchTerm}
+                onChange={(event) => setSearchTerm(event.target.value)}
+                placeholder="Search this page by skill, action, impact, or project..."
+              />
+            </div>
+            <div className="proof-filter-row">
+              {FILTERS.map((filter) => (
+                <button
+                  type="button"
+                  key={filter}
+                  className={activeFilter === filter ? "active" : ""}
+                  onClick={() => setActiveFilter(filter)}
+                >
+                  {filter}
+                </button>
+              ))}
+            </div>
           </div>
 
           {filteredEntries.length === 0 ? (
-            <div className="public-empty"><h3>No matching entries found.</h3><p>Try searching a different skill or clearing the filters.</p></div>
-          ) : (
-            filteredEntries.map((entry) => {
-              const tags = normalizeTags(entry.tags);
-              return (
-                <article className="public-entry" key={entry.id}>
-                  <div className="public-entry-top">
-                    <div><p className="mini-label">{entry.category ?? "General"}</p><h3>{entry.title ?? "Untitled entry"}</h3></div>
-                    <div className="public-entry-meta"><span>{entry.entry_type ?? "General"}</span><span>{entry.entry_date ?? "No date"}</span></div>
-                  </div>
-                  <p className="public-bullet">{entry.resume_bullet ?? "No resume bullet generated yet."}</p>
-                  <div className="proof-grid">
-                    <div><strong>Situation</strong><p>{entry.situation ?? "No situation added."}</p></div>
-                    <div><strong>Action</strong><p>{entry.action ?? "No action added."}</p></div>
-                    <div><strong>Impact</strong><p>{entry.impact ?? "No impact added."}</p></div>
-                    {entry.lesson && <div><strong>Lesson</strong><p>{entry.lesson}</p></div>}
-                  </div>
-                  <div className="tags">{tags.map((tag) => <span key={tag}>{tag}</span>)}</div>
-                </article>
-              );
-            })
-          )}
-        </section>
-
-        <aside className="public-sidebar">
-          <section className="sidebar-card">
-            <p className="mini-label">Top Skills</p><h2>Skill signal</h2>
-            {topTags.length === 0 ? <p className="muted">No skills found yet.</p> : (
-              <div className="skill-list">
-                {topTags.slice(0, 8).map(([tag, count]) => (
-                  <div className="skill-row" key={tag}><span>{tag}</span><strong>{count}</strong></div>
-                ))}
-              </div>
-            )}
-          </section>
-          <section className="sidebar-card">
-            <p className="mini-label">Profile</p><h2>More proof</h2>
-            <div className="proof-links">
-              {profile?.github_url && <a href={profile.github_url} target="_blank" rel="noreferrer">GitHub <span>Open</span></a>}
-              {profile?.resume_url && <a href={profile.resume_url} target="_blank" rel="noreferrer">Résumé <span>Open</span></a>}
-              {profile?.portfolio_url && <a href={profile.portfolio_url} target="_blank" rel="noreferrer">Portfolio <span>Visit</span></a>}
+            <div className="proof-empty">
+              No matching proof on this page. Try another filter or page.
             </div>
-          </section>
-        </aside>
-      </section>
+          ) : (
+            <div className="proof-entry-grid">
+              {filteredEntries.map((entry) => (
+                <article className="proof-entry-card" key={entry.id}>
+                  <div>
+                    <p className="proof-eyebrow">{entry.category || "General"}</p>
+                    <h3>{entry.title}</h3>
+                  </div>
+                  <div className="proof-entry-meta">
+                    <span>{entry.entry_type || "General"}</span>
+                    <span>{entry.entry_date || "No date"}</span>
+                  </div>
+                  <div className="proof-entry-impact">
+                    <strong>Impact</strong>
+                    <p>{entry.impact || entry.resume_bullet}</p>
+                  </div>
+                  <div className="proof-entry-details">
+                    <div>
+                      <strong>Action</strong>
+                      <p>{entry.action || "No action added."}</p>
+                    </div>
+                    <div>
+                      <strong>Situation</strong>
+                      <p>{entry.situation || "No situation added."}</p>
+                    </div>
+                  </div>
+                  <div className="proof-chips">
+                    {normalizeTags(entry.tags).map((tag) => (
+                      <span key={`${entry.id}-${tag}`}>{tag}</span>
+                    ))}
+                  </div>
+                </article>
+              ))}
+            </div>
+          )}
+
+          <div className="proof-pagination">
+            <span className="proof-pagination-summary">
+              Showing {start}–{end} of {entryMeta.total_entries} public wins · Page {page} of {totalPages}
+            </span>
+            <div className="proof-pagination-controls">
+              <button
+                type="button"
+                disabled={page === 1}
+                onClick={() => setPage((current) => Math.max(1, current - 1))}
+              >
+                Previous
+              </button>
+              {Array.from({ length: totalPages }, (_, index) => index + 1).map(
+                (pageNumber) => (
+                  <button
+                    type="button"
+                    className={pageNumber === page ? "active" : ""}
+                    key={pageNumber}
+                    onClick={() => setPage(pageNumber)}
+                  >
+                    {pageNumber}
+                  </button>
+                ),
+              )}
+              <button
+                type="button"
+                disabled={page === totalPages}
+                onClick={() =>
+                  setPage((current) => Math.min(totalPages, current + 1))
+                }
+              >
+                Next
+              </button>
+            </div>
+          </div>
+        </section>
+      </div>
     </main>
   );
 }

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -108,8 +108,10 @@ export async function deleteEntry(entryId) {
   return response.data;
 }
 
-export async function getPublicEntries(slug) {
-  const response = await api.get(getPublicBragPath(slug));
+export async function getPublicEntries(slug, limit = 6, skip = 0) {
+  const response = await api.get(getPublicBragPath(slug), {
+    params: { limit, skip },
+  });
   return response.data;
 }
 

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -71,8 +71,10 @@ export async function getPublicProfile(slug) {
   return response.data;
 }
 
-export async function getEntries() {
-  const response = await api.get("/entries?limit=10&skip=0");
+export async function getEntries(limit = 10, skip = 0) {
+  const response = await api.get("/entries", {
+    params: { limit, skip },
+  });
   return response.data;
 }
 

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -2,14 +2,22 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 
 import "./index.css";
+import "./ProductPolish.css";
 import App from "./App.jsx";
 import AccomplishmentsPage from "./AccomplishmentsPage.jsx";
+import ImpactReceiptsPage from "./ImpactReceiptsPage.jsx";
 import AppSidebar from "./AppSidebar.jsx";
 
 const path = window.location.pathname;
 const isAuthenticatedApp = path.startsWith("/app");
-const isAccomplishmentsPage = path === "/app/accomplishments";
-const Content = isAccomplishmentsPage ? AccomplishmentsPage : App;
+
+let Content = App;
+
+if (path === "/app/accomplishments") {
+  Content = AccomplishmentsPage;
+} else if (path === "/app/impact-receipts") {
+  Content = ImpactReceiptsPage;
+}
 
 createRoot(document.getElementById("root")).render(
   <StrictMode>

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,10 +1,27 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './index.css'
-import App from './App.jsx'
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
 
-createRoot(document.getElementById('root')).render(
+import "./index.css";
+import App from "./App.jsx";
+import AccomplishmentsPage from "./AccomplishmentsPage.jsx";
+import AppSidebar from "./AppSidebar.jsx";
+
+const path = window.location.pathname;
+const isAuthenticatedApp = path.startsWith("/app");
+const isAccomplishmentsPage = path === "/app/accomplishments";
+const Content = isAccomplishmentsPage ? AccomplishmentsPage : App;
+
+createRoot(document.getElementById("root")).render(
   <StrictMode>
-    <App />
+    {isAuthenticatedApp ? (
+      <div className="app-shell">
+        <AppSidebar />
+        <div className="authenticated-content">
+          <Content />
+        </div>
+      </div>
+    ) : (
+      <Content />
+    )}
   </StrictMode>,
-)
+);


### PR DESCRIPTION
## What changed

- adds a persistent authenticated sidebar for Overview, Accomplishments, Impact Receipts, Reports, and Proof Profile
- fixes Impact Receipts navigation by giving receipts a dedicated `/app/impact-receipts` page
- adds a paginated accomplishments library at `/app/accomplishments` with server-backed `limit` / `skip`
- adds visible pagination to Overview at 5 wins per page so the seeded demo immediately shows multiple pages
- adds server-backed pagination to the public proof feed
- renames the public-facing profile experience to **Proof Profile**
- redesigns Proof Profile with a stronger hero, proof scorecard, career analytics, featured Impact Receipts, evidence library, and visible pagination
- adds six-month public accomplishment activity data from the backend
- keeps public analytics based only on public entries / receipts / evidence
- keeps the authenticated shell responsive across desktop and smaller screens

## Why

BragStack now has enough product surface area that a single dashboard and a generic public page no longer scale. This pass creates clearer product navigation, makes large accomplishment histories browsable, and turns the public profile into a recruiter-friendly evidence showcase instead of a plain list.

## Validation

Preview `feature/sidebar-pagination` in Codespaces. Verify:

1. Impact Receipts opens its own page rather than Overview.
2. Overview shows 5 wins per page with visible Previous / numbered / Next controls.
3. Accomplishments still paginates at 10 per page.
4. Proof Profile shows the new visual design and public proof pagination.
5. Backend/public APIs continue to expose only public data.