### PR TITLE
Add Free/Pro foundation and premium marketing experience

### DIFF
--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -8,6 +8,7 @@ from jose import JWTError, jwt
 from passlib.context import CryptContext
 
 from app.database import users_collection
+from app.plans import get_entitlements_for_user, get_plan_for_user
 
 SECRET_KEY = os.getenv("JWT_SECRET", "change-this-dev-secret")
 ALGORITHM = "HS256"
@@ -21,87 +22,46 @@ oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/login")
 
 
 def hash_password(password: str) -> str:
-    """Hash a plain-text password.
-
-    Args:
-        password: The plain-text password supplied by the user.
-
-    Returns:
-        A securely hashed password string.
-    """
+    """Hash a plain-text password."""
     return password_context.hash(password)
 
 
 def verify_password(plain_password: str, hashed_password: str) -> bool:
-    """Verify a plain-text password against a stored password hash.
-
-    Args:
-        plain_password: The plain-text password supplied during login.
-        hashed_password: The hashed password stored in MongoDB.
-
-    Returns:
-        True if the password is valid, otherwise False.
-    """
+    """Verify a plain-text password against a stored password hash."""
     return password_context.verify(plain_password, hashed_password)
 
 
 def create_access_token(data: dict) -> str:
-    """Create a signed JWT access token.
-
-    Args:
-        data: The payload data to include in the token.
-
-    Returns:
-        A signed JWT access token string.
-    """
+    """Create a signed JWT access token."""
     payload = data.copy()
-
     expire = datetime.now(timezone.utc) + timedelta(
         minutes=ACCESS_TOKEN_EXPIRE_MINUTES
     )
-
     payload.update({"exp": expire})
-
     return jwt.encode(payload, SECRET_KEY, algorithm=ALGORITHM)
 
 
 def serialize_user(user: dict) -> dict:
-    """Convert a MongoDB user document into an API-safe response dictionary.
-
-    Args:
-        user: The MongoDB user document.
-
-    Returns:
-        A dictionary containing safe user fields.
-    """
+    """Convert a MongoDB user document into an API-safe response dictionary."""
     return {
-    "id": str(user["_id"]),
-    "name": user.get("name", ""),
-    "email": user.get("email", ""),
-    "public_slug": user.get("public_slug", ""),
-    "headline": user.get("headline", ""),
-    "bio": user.get("bio", ""),
-    "location": user.get("location", ""),
-    "github_url": user.get("github_url", ""),
-    "portfolio_url": user.get("portfolio_url", ""),
-    "resume_url": user.get("resume_url", ""),
-    "created_at": user.get("created_at"),
-}
+        "id": str(user["_id"]),
+        "name": user.get("name", ""),
+        "email": user.get("email", ""),
+        "public_slug": user.get("public_slug", ""),
+        "headline": user.get("headline", ""),
+        "bio": user.get("bio", ""),
+        "location": user.get("location", ""),
+        "github_url": user.get("github_url", ""),
+        "portfolio_url": user.get("portfolio_url", ""),
+        "resume_url": user.get("resume_url", ""),
+        "plan": get_plan_for_user(user),
+        "entitlements": get_entitlements_for_user(user),
+        "created_at": user.get("created_at"),
+    }
 
 
 async def get_current_user(token: str = Depends(oauth2_scheme)) -> dict:
-    """Return the currently authenticated user from a JWT bearer token.
-
-    Args:
-        token: The JWT access token from the Authorization header.
-
-    Returns:
-        The authenticated user document from MongoDB.
-
-    Raises:
-        HTTPException: If the token is missing, invalid, expired, or does not
-            match an existing user.
-    """
+    """Return the currently authenticated user from a JWT bearer token."""
     credentials_error = HTTPException(
         status_code=status.HTTP_401_UNAUTHORIZED,
         detail="Could not validate credentials",
@@ -111,10 +71,8 @@ async def get_current_user(token: str = Depends(oauth2_scheme)) -> dict:
     try:
         payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
         user_id: str | None = payload.get("sub")
-
         if user_id is None:
             raise credentials_error
-
     except JWTError:
         raise credentials_error
 
@@ -122,7 +80,6 @@ async def get_current_user(token: str = Depends(oauth2_scheme)) -> dict:
         raise credentials_error
 
     user = users_collection.find_one({"_id": ObjectId(user_id)})
-
     if user is None:
         raise credentials_error
 

--- a/backend/app/plans.py
+++ b/backend/app/plans.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import HTTPException, status
+
+FREE_ENTRY_LIMIT = 5
+FREE_IMPACT_RECEIPT_LIMIT = 1
+
+PLAN_FEATURES: dict[str, dict[str, Any]] = {
+    "free": {
+        "max_entries": FREE_ENTRY_LIMIT,
+        "max_impact_receipts": FREE_IMPACT_RECEIPT_LIMIT,
+        "advanced_reports": False,
+        "performance_review_builder": False,
+        "promotion_packet": False,
+        "integrations": False,
+        "advanced_public_analytics": False,
+        "export_pdf": False,
+    },
+    "pro": {
+        "max_entries": None,
+        "max_impact_receipts": None,
+        "advanced_reports": True,
+        "performance_review_builder": True,
+        "promotion_packet": True,
+        "integrations": True,
+        "advanced_public_analytics": True,
+        "export_pdf": True,
+    },
+}
+
+
+def normalize_plan(plan: str | None) -> str:
+    """Return a supported plan name, defaulting unknown values to free."""
+    normalized = (plan or "free").strip().lower()
+    return normalized if normalized in PLAN_FEATURES else "free"
+
+
+def get_plan_for_user(user: dict) -> str:
+    """Return the normalized billing plan for a user document."""
+    return normalize_plan(user.get("plan"))
+
+
+def get_entitlements_for_user(user: dict) -> dict[str, Any]:
+    """Return a copy of the entitlement map for the user's current plan."""
+    return dict(PLAN_FEATURES[get_plan_for_user(user)])
+
+
+def require_feature(user: dict, feature_name: str) -> None:
+    """Raise 403 when a user's plan does not include a feature."""
+    entitlements = get_entitlements_for_user(user)
+    if entitlements.get(feature_name):
+        return
+
+    raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail={
+            "code": "pro_feature_required",
+            "message": "This feature requires BragStack Pro.",
+            "feature": feature_name,
+            "plan": get_plan_for_user(user),
+        },
+    )
+
+
+def enforce_usage_limit(
+    *,
+    user: dict,
+    entitlement_name: str,
+    current_count: int,
+    resource_name: str,
+) -> None:
+    """Raise 403 when a capped plan has reached a resource limit."""
+    entitlements = get_entitlements_for_user(user)
+    limit = entitlements.get(entitlement_name)
+
+    if limit is None or current_count < limit:
+        return
+
+    raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail={
+            "code": "plan_limit_reached",
+            "message": (
+                f"Your {get_plan_for_user(user).title()} plan includes "
+                f"{limit} {resource_name}. Upgrade to BragStack Pro for unlimited access."
+            ),
+            "resource": resource_name,
+            "limit": limit,
+            "current": current_count,
+            "plan": get_plan_for_user(user),
+        },
+    )

--- a/backend/app/plans.py
+++ b/backend/app/plans.py
@@ -7,6 +7,17 @@ from fastapi import HTTPException, status
 FREE_ENTRY_LIMIT = 5
 FREE_IMPACT_RECEIPT_LIMIT = 1
 
+PLAN_PRICING: dict[str, dict[str, Any]] = {
+    "free": {"monthly": 0, "label": "Free"},
+    "pro": {"monthly": 9, "label": "Pro"},
+    "team": {
+        "monthly_per_user": 15,
+        "minimum_seats": 3,
+        "label": "Team",
+    },
+    "enterprise": {"monthly": None, "label": "Enterprise"},
+}
+
 PLAN_FEATURES: dict[str, dict[str, Any]] = {
     "free": {
         "max_entries": FREE_ENTRY_LIMIT,
@@ -17,6 +28,13 @@ PLAN_FEATURES: dict[str, dict[str, Any]] = {
         "integrations": False,
         "advanced_public_analytics": False,
         "export_pdf": False,
+        "team_review_packets": False,
+        "shared_templates": False,
+        "manager_verification": False,
+        "org_analytics": False,
+        "sso": False,
+        "audit_logs": False,
+        "retention_controls": False,
     },
     "pro": {
         "max_entries": None,
@@ -27,6 +45,47 @@ PLAN_FEATURES: dict[str, dict[str, Any]] = {
         "integrations": True,
         "advanced_public_analytics": True,
         "export_pdf": True,
+        "team_review_packets": False,
+        "shared_templates": False,
+        "manager_verification": False,
+        "org_analytics": False,
+        "sso": False,
+        "audit_logs": False,
+        "retention_controls": False,
+    },
+    "team": {
+        "max_entries": None,
+        "max_impact_receipts": None,
+        "advanced_reports": True,
+        "performance_review_builder": True,
+        "promotion_packet": True,
+        "integrations": True,
+        "advanced_public_analytics": True,
+        "export_pdf": True,
+        "team_review_packets": True,
+        "shared_templates": True,
+        "manager_verification": True,
+        "org_analytics": True,
+        "sso": False,
+        "audit_logs": False,
+        "retention_controls": False,
+    },
+    "enterprise": {
+        "max_entries": None,
+        "max_impact_receipts": None,
+        "advanced_reports": True,
+        "performance_review_builder": True,
+        "promotion_packet": True,
+        "integrations": True,
+        "advanced_public_analytics": True,
+        "export_pdf": True,
+        "team_review_packets": True,
+        "shared_templates": True,
+        "manager_verification": True,
+        "org_analytics": True,
+        "sso": True,
+        "audit_logs": True,
+        "retention_controls": True,
     },
 }
 
@@ -47,6 +106,11 @@ def get_entitlements_for_user(user: dict) -> dict[str, Any]:
     return dict(PLAN_FEATURES[get_plan_for_user(user)])
 
 
+def get_pricing_for_user(user: dict) -> dict[str, Any]:
+    """Return display pricing metadata for the user's current plan."""
+    return dict(PLAN_PRICING[get_plan_for_user(user)])
+
+
 def require_feature(user: dict, feature_name: str) -> None:
     """Raise 403 when a user's plan does not include a feature."""
     entitlements = get_entitlements_for_user(user)
@@ -56,8 +120,8 @@ def require_feature(user: dict, feature_name: str) -> None:
     raise HTTPException(
         status_code=status.HTTP_403_FORBIDDEN,
         detail={
-            "code": "pro_feature_required",
-            "message": "This feature requires BragStack Pro.",
+            "code": "paid_feature_required",
+            "message": "This feature is not included in your BragStack plan.",
             "feature": feature_name,
             "plan": get_plan_for_user(user),
         },
@@ -84,7 +148,7 @@ def enforce_usage_limit(
             "code": "plan_limit_reached",
             "message": (
                 f"Your {get_plan_for_user(user).title()} plan includes "
-                f"{limit} {resource_name}. Upgrade to BragStack Pro for unlimited access."
+                f"{limit} {resource_name}. Upgrade for unlimited access."
             ),
             "resource": resource_name,
             "limit": limit,

--- a/frontend/src/LandingPage.jsx
+++ b/frontend/src/LandingPage.jsx
@@ -1,483 +1,210 @@
 import {
   ArrowRight,
+  BarChart3,
   Briefcase,
   Check,
   FileText,
   GraduationCap,
+  LockKeyhole,
   MessageSquare,
+  ReceiptText,
+  ShieldCheck,
   Sparkles,
   Target,
   TrendingUp,
   Users,
+  Zap,
 } from "lucide-react";
 
 import "./LandingPage.css";
+import "./LandingPageMonetization.css";
 
 const useCases = [
-  {
-    icon: TrendingUp,
-    title: "Promotions",
-    description:
-      "Walk into promotion conversations with organized proof of your impact, growth, and added responsibilities.",
-  },
-  {
-    icon: MessageSquare,
-    title: "Interviews",
-    description:
-      "Turn real accomplishments into confident interview stories instead of trying to remember examples under pressure.",
-  },
-  {
-    icon: FileText,
-    title: "Performance reviews",
-    description:
-      "Build your review throughout the year instead of reconstructing twelve months of work the night before.",
-  },
-  {
-    icon: Users,
-    title: "1:1 meetings",
-    description:
-      "Bring wins, blockers, lessons, and progress into every conversation with your manager.",
-  },
-  {
-    icon: Target,
-    title: "Trainers and clients",
-    description:
-      "Document milestones, progress, completed goals, and measurable results over time.",
-  },
-  {
-    icon: Briefcase,
-    title: "Freelancers and consultants",
-    description:
-      "Turn completed projects into client updates, case studies, testimonials, and proof of value.",
-  },
-  {
-    icon: GraduationCap,
-    title: "Students and career changers",
-    description:
-      "Track projects, certifications, new skills, and portfolio evidence as your career develops.",
-  },
-  {
-    icon: Sparkles,
-    title: "Creators and founders",
-    description:
-      "Capture launches, experiments, customer wins, audience growth, and business milestones.",
-  },
+  { icon: TrendingUp, title: "Promotions", description: "Walk into promotion conversations with organized proof of impact, growth, and added responsibility." },
+  { icon: MessageSquare, title: "Interviews", description: "Turn real accomplishments into confident stories instead of trying to remember examples under pressure." },
+  { icon: FileText, title: "Performance reviews", description: "Build your review throughout the year instead of reconstructing twelve months of work the night before." },
+  { icon: Users, title: "1:1 meetings", description: "Bring wins, blockers, lessons, and progress into every conversation with your manager." },
+  { icon: Target, title: "Clients and coaching", description: "Document milestones, completed goals, measurable results, and evidence over time." },
+  { icon: Briefcase, title: "Freelancers", description: "Turn completed projects into client updates, case studies, testimonials, and proof of value." },
+  { icon: GraduationCap, title: "Career changers", description: "Track projects, certifications, new skills, and portfolio evidence as your career develops." },
+  { icon: Sparkles, title: "Creators and founders", description: "Capture launches, experiments, customer wins, audience growth, and business milestones." },
 ];
 
 const workflowSteps = [
-  {
-    number: "01",
-    title: "Capture",
-    description:
-      "Record the situation, action, impact, lesson, and skills while the details are still fresh.",
-  },
-  {
-    number: "02",
-    title: "Organize",
-    description:
-      "Keep accomplishments searchable by category, date, role, entry type, and skill.",
-  },
-  {
-    number: "03",
-    title: "Reuse",
-    description:
-      "Use your proof for interviews, reviews, promotions, résumés, portfolios, clients, and 1:1s.",
-  },
+  { number: "01", title: "Capture the win", description: "Save the situation, your action, the result, lessons, and skills while the details are still fresh." },
+  { number: "02", title: "Turn it into proof", description: "Create Impact Receipts with contribution, result, evidence, skills, credit, and optional public visibility." },
+  { number: "03", title: "See your career patterns", description: "Watch skills, categories, evidence coverage, and accomplishment activity build into a career analytics story." },
+  { number: "04", title: "Package the evidence", description: "Use your history for performance reviews, promotion packets, résumé bullets, interview stories, and public proof." },
+  { number: "05", title: "Walk in prepared", description: "Stop rebuilding your career from memory. Bring organized evidence into the conversations that affect your next move." },
 ];
 
-const freeFeatures = [
-  "Up to 30 proof entries",
-  "Five public entries",
-  "Basic skill tracking",
-  "Weekly progress summary",
-];
-
-const proFeatures = [
-  "Unlimited proof entries",
-  "Unlimited public entries",
-  "Advanced reports",
-  "Custom public profile",
-  "Export and résumé tools",
+const plans = [
+  {
+    name: "Free",
+    price: "$0",
+    tagline: "Prove the habit works",
+    features: ["5 proof entries", "1 Impact Receipt", "Basic reports", "Basic public proof profile", "Skill tracking"],
+    cta: "Start free",
+    href: "/register",
+  },
+  {
+    name: "Pro",
+    price: "$9",
+    suffix: "/month",
+    tagline: "Turn your work history into leverage",
+    featured: true,
+    badge: "Best for your career",
+    features: ["Unlimited proof + Impact Receipts", "Advanced career analytics", "Performance Review Builder", "Promotion Packet", "PDF and career exports", "Integrations and advanced public profile"],
+    cta: "Unlock BragStack Pro",
+    href: "/register",
+  },
+  {
+    name: "Team",
+    price: "$15",
+    suffix: "/user / month",
+    tagline: "Help teams document growth without surveillance",
+    badge: "Coming soon",
+    features: ["Everything in Pro", "Shared review templates", "Optional manager verification", "Review-cycle packets", "Organization analytics", "Centralized billing"],
+    cta: "Join Team waitlist",
+    href: "mailto:hello@bragstack.app?subject=BragStack%20Team%20waitlist",
+  },
+  {
+    name: "Enterprise",
+    price: "Custom",
+    tagline: "Security and governance for larger organizations",
+    features: ["Everything in Team", "SSO / SCIM", "Audit logs", "Retention controls", "Advanced admin policies", "Custom integrations and support"],
+    cta: "Contact us",
+    href: "mailto:hello@bragstack.app?subject=BragStack%20Enterprise",
+  },
 ];
 
 function LandingPage() {
   return (
     <main className="landing-page">
       <header className="landing-nav">
-        <a className="landing-logo" href="/">
-          BragStack
-        </a>
-
+        <a className="landing-logo" href="/">BragStack</a>
         <nav className="landing-nav-links" aria-label="Main navigation">
           <a href="#use-cases">Use cases</a>
           <a href="#how-it-works">How it works</a>
           <a href="#pricing">Pricing</a>
         </nav>
-
         <div className="landing-nav-actions">
-          <a className="landing-login-link" href="/login">
-            Log in
-          </a>
-
-          <a className="landing-btn landing-btn-small" href="/register">
-            Start free
-          </a>
+          <a className="landing-login-link" href="/login">Log in</a>
+          <a className="landing-btn landing-btn-small" href="/register">Start free</a>
         </div>
       </header>
 
       <section className="landing-hero">
         <div className="landing-hero-copy">
-          <div className="landing-eyebrow">
-            <Sparkles size={15} />
-            Career proof, organized
-          </div>
-
-          <h1>
-            Your work deserves
-            <span> receipts.</span>
-          </h1>
-
+          <div className="landing-eyebrow"><Sparkles size={15} />Career proof, organized</div>
+          <h1>Your work deserves<span> receipts.</span></h1>
           <p className="landing-hero-description">
-            BragStack turns everyday wins, progress, and results into organized
-            proof you can use for promotions, interviews, performance reviews,
-            1:1s, client updates, and more.
+            BragStack turns everyday wins into career evidence you can actually use — for promotions, reviews, interviews, résumés, public proof, and the next opportunity you have not even planned for yet.
           </p>
-
           <div className="landing-hero-actions">
-            <a className="landing-btn" href="/register">
-              Start building proof
-              <ArrowRight size={18} />
-            </a>
-
-            <a
-              className="landing-btn landing-btn-secondary"
-              href="#how-it-works"
-            >
-              See how it works
-            </a>
+            <a className="landing-btn" href="/register">Start building proof <ArrowRight size={18} /></a>
+            <a className="landing-btn landing-btn-secondary" href="#how-it-works">See the career system</a>
           </div>
-
-          <p className="landing-trust-line">
-            Free to start
-            <span>•</span>
-            No credit card required
-            <span>•</span>
-            Private by default
-          </p>
+          <p className="landing-trust-line">Free to start <span>•</span> No credit card required <span>•</span> Private by default</p>
         </div>
 
         <div className="landing-proof-preview">
           <div className="preview-glow" />
-
           <article className="proof-preview-card">
-            <div className="proof-preview-header">
-              <div>
-                <p>Recent proof</p>
-                <span>Public entry</span>
-              </div>
-
-              <div className="proof-preview-avatar">T</div>
-            </div>
-
-            <div className="proof-preview-meta">
-              Docker Support · July 2026
-            </div>
-
-            <h2>Reduced customer setup time by 35%</h2>
-
-            <p>
-              Created a repeatable troubleshooting workflow that helped
-              customers identify container networking problems faster.
-            </p>
-
-            <div className="proof-preview-result">
-              <span>Impact</span>
-              <strong>
-                Faster resolutions and a reusable process for the support team.
-              </strong>
-            </div>
-
-            <div className="proof-preview-tags">
-              <span>Docker</span>
-              <span>Networking</span>
-              <span>Support</span>
-            </div>
+            <div className="proof-preview-header"><div><p>Impact Receipt</p><span>Evidence-linked</span></div><div className="proof-preview-avatar">T</div></div>
+            <div className="proof-preview-meta">Platform Engineering · August 2026</div>
+            <h2>Reduced repeat Docker escalations by 30%</h2>
+            <p>Identified common networking failure patterns, documented diagnostics, and standardized the troubleshooting path.</p>
+            <div className="proof-preview-result"><span>Result</span><strong>Faster resolution paths and less repeated escalation work.</strong></div>
+            <div className="proof-preview-tags"><span>Docker</span><span>Reliability</span><span>Leadership</span></div>
           </article>
-
-          <div className="floating-proof-card floating-proof-top">
-            <span>Weekly proof</span>
-            <strong>7 wins captured</strong>
-          </div>
-
-          <div className="floating-proof-card floating-proof-bottom">
-            <span>Top skill</span>
-            <strong>Problem solving</strong>
-          </div>
+          <div className="floating-proof-card floating-proof-top"><span>Evidence coverage</span><strong>84%</strong></div>
+          <div className="floating-proof-card floating-proof-bottom"><span>Career signal</span><strong>Platform ownership ↑</strong></div>
         </div>
       </section>
 
       <section className="landing-use-strip" aria-label="Popular use cases">
-        <span>Promotions</span>
-        <span>Interviews</span>
-        <span>1:1s</span>
-        <span>Reviews</span>
-        <span>Clients</span>
-        <span>Coaching</span>
-        <span>Portfolios</span>
+        <span>Promotions</span><span>Interviews</span><span>1:1s</span><span>Reviews</span><span>Clients</span><span>Portfolios</span><span>Career analytics</span>
       </section>
 
       <section className="landing-problem-section">
         <div className="landing-section-heading">
-          <p>THE PROBLEM</p>
-          <h2>Great work is surprisingly easy to forget.</h2>
-          <span>
-            Projects move on, tickets close, meetings end, and months later
-            you’re expected to explain everything you accomplished.
-          </span>
+          <p>THE PROBLEM</p><h2>Your career is happening faster than your memory can track it.</h2>
+          <span>Tickets close. Projects ship. Praise disappears into Slack. Six months later, someone asks what you accomplished — and your strongest evidence is scattered everywhere.</span>
         </div>
-
         <div className="problem-card-grid">
-          <article className="problem-card">
-            <span>01</span>
-            <h3>“I know I did a lot…”</h3>
-            <p>
-              The work happened, but the details and measurable results are
-              already fading.
-            </p>
-          </article>
-
-          <article className="problem-card">
-            <span>02</span>
-            <h3>“My résumé sounds generic.”</h3>
-            <p>
-              Your strongest examples are scattered across tickets, messages,
-              notes, and memory.
-            </p>
-          </article>
-
-          <article className="problem-card">
-            <span>03</span>
-            <h3>“My review is next week.”</h3>
-            <p>
-              Now you’re rebuilding an entire year of accomplishments in one
-              stressful sitting.
-            </p>
-          </article>
+          <article className="problem-card"><span>01</span><h3>“I know I did a lot…”</h3><p>The work happened, but the details, numbers, and context are already fading.</p></article>
+          <article className="problem-card"><span>02</span><h3>“My résumé sounds generic.”</h3><p>Your strongest examples are trapped across tickets, notes, messages, and memory.</p></article>
+          <article className="problem-card"><span>03</span><h3>“My review is next week.”</h3><p>Now you are rebuilding an entire year of impact in one stressful sitting.</p></article>
         </div>
       </section>
 
       <section className="landing-use-cases" id="use-cases">
-        <div className="landing-section-heading">
-          <p>BUILT FOR REAL LIFE</p>
-          <h2>Useful whenever progress needs to be proven.</h2>
-          <span>
-            BragStack is not only for job searches. It helps people document
-            growth, value, outcomes, and momentum.
-          </span>
-        </div>
-
-        <div className="use-case-grid">
-          {useCases.map(({ icon: Icon, title, description }) => (
-            <article className="use-case-card" key={title}>
-              <div className="use-case-icon">
-                <Icon size={21} />
-              </div>
-
-              <h3>{title}</h3>
-              <p>{description}</p>
-            </article>
-          ))}
-        </div>
+        <div className="landing-section-heading"><p>BUILT FOR REAL LIFE</p><h2>Useful whenever progress needs to be proven.</h2><span>BragStack is not a diary. It is an evidence system for the moments when your work needs to speak clearly.</span></div>
+        <div className="use-case-grid">{useCases.map(({ icon: Icon, title, description }) => <article className="use-case-card" key={title}><div className="use-case-icon"><Icon size={21} /></div><h3>{title}</h3><p>{description}</p></article>)}</div>
       </section>
 
-      <section className="landing-workflow" id="how-it-works">
-        <div className="landing-section-heading">
-          <p>HOW IT WORKS</p>
-          <h2>From daily work to reusable proof.</h2>
-          <span>
-            A lightweight habit today becomes an advantage when the next
-            opportunity appears.
-          </span>
+      <section className="landing-workflow premium-workflow" id="how-it-works">
+        <div className="landing-section-heading"><p>HOW IT WORKS</p><h2>Capture once. Turn it into career leverage again and again.</h2><span>BragStack connects the daily work you are already doing to the career artifacts you usually scramble to create later.</span></div>
+
+        <div className="career-flow" aria-label="BragStack career proof workflow">
+          <span>Daily work</span><ArrowRight size={18} /><span>Proof entries</span><ArrowRight size={18} /><span>Impact Receipts</span><ArrowRight size={18} /><span>Career analytics</span><ArrowRight size={18} /><span>Reviews · promotions · interviews</span>
         </div>
 
-        <div className="workflow-grid">
-          {workflowSteps.map((step) => (
-            <article className="workflow-card" key={step.number}>
-              <span className="workflow-number">{step.number}</span>
-              <h3>{step.title}</h3>
-              <p>{step.description}</p>
-            </article>
-          ))}
+        <div className="premium-workflow-grid">{workflowSteps.map((step) => <article className="workflow-card premium-workflow-card" key={step.number}><span className="workflow-number">{step.number}</span><h3>{step.title}</h3><p>{step.description}</p></article>)}</div>
+
+        <div className="career-intelligence-demo">
+          <div className="career-intelligence-copy">
+            <p className="landing-mini-label">CAREER INTELLIGENCE</p>
+            <h2>Your accomplishments become a story you can see.</h2>
+            <p>Instead of a flat list of tasks, BragStack can surface patterns in the proof you have already captured: where your impact is concentrated, which skills keep showing up, and how much of your work has evidence behind it.</p>
+            <div className="career-output-list">
+              <span><BarChart3 size={18} /> Career activity and skill trends</span>
+              <span><ReceiptText size={18} /> Evidence and Impact Receipt coverage</span>
+              <span><FileText size={18} /> Review and promotion-ready packaging</span>
+              <span><ShieldCheck size={18} /> Private-by-default visibility controls</span>
+            </div>
+          </div>
+          <div className="mock-analytics-panel">
+            <div className="mock-analytics-header"><span>Illustrative career dashboard</span><strong>Last 6 months</strong></div>
+            <div className="mock-stat-row"><div><span>Proof captured</span><strong>38</strong></div><div><span>Impact Receipts</span><strong>24</strong></div><div><span>Skills demonstrated</span><strong>17</strong></div></div>
+            <div className="mock-chart">
+              {[38, 55, 46, 72, 64, 92].map((height, index) => <div key={height + index}><span style={{ height: `${height}%` }} /><small>{["Mar", "Apr", "May", "Jun", "Jul", "Aug"][index]}</small></div>)}
+            </div>
+            <div className="mock-signal"><span>Strongest documented signal</span><strong>Platform ownership</strong><em>Based on your captured proof</em></div>
+          </div>
+        </div>
+
+        <div className="pro-output-grid">
+          <article><LockKeyhole size={20} /><small>PRO</small><h3>Performance Review Builder</h3><p>Turn months of entries into a structured review without starting from a blank page.</p></article>
+          <article><LockKeyhole size={20} /><small>PRO</small><h3>Promotion Packet</h3><p>Organize evidence around ownership, impact, leadership, execution, and growth.</p></article>
+          <article><LockKeyhole size={20} /><small>PRO</small><h3>Advanced Analytics</h3><p>See accomplishment activity, category strength, skills, and evidence coverage over time.</p></article>
+          <article><LockKeyhole size={20} /><small>PRO</small><h3>Integrations</h3><p>Bring work signals from tools like GitHub into BragStack as suggestions you control.</p></article>
         </div>
       </section>
 
       <section className="landing-feature-section">
-        <div className="landing-feature-copy">
-          <p className="landing-mini-label">YOUR PROOF LIBRARY</p>
-
-          <h2>Remember what you did — and why it mattered.</h2>
-
-          <p>
-            BragStack helps you capture more than a task title. Each entry
-            records the context, your action, the impact, what you learned, and
-            the skills you demonstrated.
-          </p>
-
-          <div className="landing-feature-list">
-            <div>
-              <Check size={17} />
-              Structured accomplishment entries
-            </div>
-
-            <div>
-              <Check size={17} />
-              Résumé-ready impact statements
-            </div>
-
-            <div>
-              <Check size={17} />
-              Public or private visibility controls
-            </div>
-
-            <div>
-              <Check size={17} />
-              Skill and progress tracking
-            </div>
-          </div>
-        </div>
-
-        <div className="feature-dashboard-preview">
-          <div className="feature-preview-header">
-            <div>
-              <span>Weekly entries</span>
-              <strong>12</strong>
-            </div>
-
-            <div>
-              <span>Skills tracked</span>
-              <strong>18</strong>
-            </div>
-          </div>
-
-          <div className="feature-preview-entry">
-            <div>
-              <span className="feature-preview-badge">Public</span>
-              <small>Customer Support · Current Job</small>
-            </div>
-
-            <h3>Improved escalation response process</h3>
-
-            <p>
-              Reduced repeated troubleshooting and gave the team a clearer path
-              for complex customer cases.
-            </p>
-
-            <div className="feature-preview-tags">
-              <span>Leadership</span>
-              <span>Communication</span>
-              <span>Process</span>
-            </div>
-          </div>
-        </div>
+        <div className="landing-feature-copy"><p className="landing-mini-label">YOUR PROOF LIBRARY</p><h2>Remember what you did — and why it mattered.</h2><p>Each entry captures context, action, impact, lessons, and skills. Important accomplishments can become richer Impact Receipts with evidence, shared credit, and trust signals.</p><div className="landing-feature-list"><div><Check size={17} /> Structured accomplishment entries</div><div><Check size={17} /> Evidence-backed Impact Receipts</div><div><Check size={17} /> Public or private visibility controls</div><div><Check size={17} /> Skill and progress analytics</div></div></div>
+        <div className="feature-dashboard-preview"><div className="feature-preview-header"><div><span>Entries this quarter</span><strong>12</strong></div><div><span>Evidence coverage</span><strong>83%</strong></div></div><div className="feature-preview-entry"><div><span className="feature-preview-badge">Impact Receipt</span><small>Reliability · Current Job</small></div><h3>Improved escalation response process</h3><p>Reduced repeated troubleshooting and gave the team a clearer path for complex customer cases.</p><div className="feature-preview-tags"><span>Leadership</span><span>Communication</span><span>Process</span></div></div></div>
       </section>
 
       <section className="landing-pricing" id="pricing">
-        <div className="landing-section-heading">
-          <p>SIMPLE PRICING</p>
-          <h2>Start free. Upgrade when your proof grows.</h2>
-          <span>
-            Build the habit first, then unlock more tools when you need them.
-          </span>
-        </div>
-
-        <div className="pricing-grid">
-          <article className="pricing-card">
-            <div className="pricing-card-header">
-              <div>
-                <p>Free</p>
-                <h3>$0</h3>
-              </div>
-
-              <span>Build your proof</span>
-            </div>
-
-            <ul>
-              {freeFeatures.map((feature) => (
-                <li key={feature}>
-                  <Check size={17} />
-                  {feature}
-                </li>
-              ))}
-            </ul>
-
-            <a
-              className="landing-btn landing-btn-secondary pricing-button"
-              href="/register"
-            >
-              Start free
-            </a>
-          </article>
-
-          <article className="pricing-card pricing-card-featured">
-            <div className="pricing-popular-label">Founding plan</div>
-
-            <div className="pricing-card-header">
-              <div>
-                <p>Pro</p>
-
-                <h3>
-                  $6
-                  <span>/month</span>
-                </h3>
-              </div>
-
-              <span>Use your proof everywhere</span>
-            </div>
-
-            <ul>
-              {proFeatures.map((feature) => (
-                <li key={feature}>
-                  <Check size={17} />
-                  {feature}
-                </li>
-              ))}
-            </ul>
-
-            <a className="landing-btn pricing-button" href="/register">
-              Start with Pro
-              <ArrowRight size={17} />
-            </a>
-          </article>
-        </div>
+        <div className="landing-section-heading"><p>PRICING</p><h2>Start with proof. Upgrade when you want leverage.</h2><span>Free lets you experience the workflow. Pro unlocks the tools designed to turn a growing work history into reviews, promotion evidence, analytics, exports, and integrations.</span></div>
+        <div className="pricing-grid pricing-grid-four">{plans.map((plan) => <article className={`pricing-card ${plan.featured ? "pricing-card-featured pricing-card-pro" : ""}`} key={plan.name}>{plan.badge && <div className="pricing-popular-label">{plan.badge}</div>}<div className="pricing-card-header"><div><p>{plan.name}</p><h3>{plan.price}{plan.suffix && <span>{plan.suffix}</span>}</h3></div></div><p className="pricing-tagline">{plan.tagline}</p><ul>{plan.features.map((feature) => <li key={feature}><Check size={17} />{feature}</li>)}</ul><a className={`landing-btn pricing-button ${plan.featured ? "" : "landing-btn-secondary"}`} href={plan.href}>{plan.cta}{plan.featured && <ArrowRight size={17} />}</a></article>)}</div>
+        <div className="pricing-conversion-note"><Zap size={20} /><div><strong>Free proves the habit. Pro turns the habit into a career system.</strong><span>Your existing proof stays yours. Upgrade when you are ready to do more with it.</span></div></div>
       </section>
 
-      <section className="landing-final-cta">
-        <div>
-          <p>YOUR NEXT OPPORTUNITY WILL ASK WHAT YOU’VE DONE.</p>
-          <h2>Make sure you have the proof.</h2>
-          <span>
-            Start capturing the wins, growth, and results that deserve to be
-            remembered.
-          </span>
+      <section className="landing-final-cta"><div><p>YOUR NEXT OPPORTUNITY WILL ASK WHAT YOU HAVE DONE.</p><h2>Make sure you have the proof — not just the memory.</h2><span>Start capturing the work now. When review season, an interview, a promotion conversation, or an unexpected opportunity arrives, your evidence is already waiting.</span></div><a className="landing-btn landing-final-button" href="/register">Build my BragStack <ArrowRight size={18} /></a></section>
+
+      <footer className="mega-footer">
+        <div className="mega-footer-brand"><a className="landing-logo" href="/">BragStack</a><p>Turn everyday work into career proof you can use when it matters.</p><a className="footer-cta" href="/register">Start building proof <ArrowRight size={15} /></a></div>
+        <div className="mega-footer-columns">
+          <div><h3>Product</h3><a href="#how-it-works">Impact Receipts</a><a href="#how-it-works">Career Analytics</a><a href="#how-it-works">Reports</a><a href="#how-it-works">Public Proof Profiles</a><a href="#pricing">Pricing</a></div>
+          <div><h3>Solutions</h3><a href="#use-cases">Performance Reviews</a><a href="#use-cases">Promotions</a><a href="#use-cases">Interviews</a><a href="#use-cases">Freelancers</a><a href="#pricing">Teams</a></div>
+          <div><h3>Resources</h3><a href="#how-it-works">How it works</a><a href="#use-cases">Use cases</a><a href="/login">Sign in</a><a href="/register">Create account</a><span>Docs · coming soon</span></div>
+          <div><h3>Company</h3><a href="mailto:hello@bragstack.app">Contact</a><a href="mailto:hello@bragstack.app?subject=BragStack%20Team%20waitlist">Team waitlist</a><a href="mailto:hello@bragstack.app?subject=BragStack%20Enterprise">Enterprise</a><span>Changelog · coming soon</span><span>Security · coming soon</span></div>
         </div>
-
-        <a className="landing-btn landing-final-button" href="/register">
-          Build my BragStack
-          <ArrowRight size={18} />
-        </a>
-      </section>
-
-      <footer className="landing-footer">
-        <a className="landing-logo" href="/">
-          BragStack
-        </a>
-
-        <p>Turn everyday progress into undeniable proof.</p>
-
-        <div>
-          <a href="/login">Log in</a>
-          <a href="/register">Create account</a>
-        </div>
+        <div className="mega-footer-bottom"><span>© 2026 BragStack</span><span>Private by default · Your proof stays yours.</span><div><a href="/login">Log in</a><a href="/register">Start free</a></div></div>
       </footer>
     </main>
   );

--- a/frontend/src/LandingPageMonetization.css
+++ b/frontend/src/LandingPageMonetization.css
@@ -1,0 +1,435 @@
+.premium-workflow {
+  padding-top: 7rem;
+}
+
+.career-flow {
+  margin: 2.5rem 0 1.4rem;
+  padding: 1rem;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 0.7rem;
+  border: 1px solid var(--landing-border);
+  border-radius: 22px;
+  background: rgba(13, 21, 38, 0.7);
+}
+
+.career-flow span {
+  padding: 0.65rem 0.85rem;
+  border: 1px solid rgba(166, 220, 255, 0.18);
+  border-radius: 999px;
+  background: rgba(20, 32, 52, 0.9);
+  font-size: 0.8rem;
+  font-weight: 850;
+}
+
+.career-flow svg {
+  color: var(--landing-purple);
+}
+
+.premium-workflow-grid {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 0.85rem;
+}
+
+.premium-workflow-card {
+  min-height: 300px;
+}
+
+.premium-workflow-card h3 {
+  margin-top: 3.5rem;
+}
+
+.career-intelligence-demo {
+  margin-top: 2rem;
+  padding: 2rem;
+  display: grid;
+  grid-template-columns: minmax(0, 0.85fr) minmax(420px, 1.15fr);
+  gap: 2rem;
+  border: 1px solid rgba(173, 145, 255, 0.32);
+  border-radius: 30px;
+  background:
+    radial-gradient(circle at 90% 10%, rgba(173, 145, 255, 0.15), transparent 24rem),
+    rgba(11, 18, 33, 0.92);
+}
+
+.career-intelligence-copy h2 {
+  margin: 0;
+  font-size: clamp(2rem, 4vw, 3.6rem);
+  line-height: 1.03;
+  letter-spacing: -0.055em;
+}
+
+.career-intelligence-copy > p:not(.landing-mini-label) {
+  color: var(--landing-muted);
+  line-height: 1.7;
+}
+
+.career-output-list {
+  margin-top: 1.4rem;
+  display: grid;
+  gap: 0.85rem;
+}
+
+.career-output-list span {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+  font-weight: 750;
+}
+
+.career-output-list svg {
+  color: var(--landing-blue);
+}
+
+.mock-analytics-panel {
+  padding: 1rem;
+  border: 1px solid rgba(166, 220, 255, 0.18);
+  border-radius: 24px;
+  background: rgba(5, 10, 20, 0.78);
+  box-shadow: 0 30px 70px rgba(0, 0, 0, 0.32);
+}
+
+.mock-analytics-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.6rem;
+  color: var(--landing-muted);
+  font-size: 0.74rem;
+  text-transform: uppercase;
+}
+
+.mock-analytics-header strong {
+  color: var(--landing-blue);
+}
+
+.mock-stat-row {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.65rem;
+}
+
+.mock-stat-row > div {
+  padding: 0.9rem;
+  border: 1px solid var(--landing-border);
+  border-radius: 16px;
+  background: rgba(19, 30, 51, 0.74);
+}
+
+.mock-stat-row span,
+.mock-signal span {
+  display: block;
+  color: var(--landing-muted);
+  font-size: 0.7rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.mock-stat-row strong {
+  display: block;
+  margin-top: 0.45rem;
+  font-size: 1.7rem;
+}
+
+.mock-chart {
+  height: 220px;
+  margin-top: 0.8rem;
+  padding: 1rem 1rem 0.7rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  align-items: end;
+  gap: 0.65rem;
+  border: 1px solid var(--landing-border);
+  border-radius: 18px;
+  background: rgba(12, 20, 36, 0.7);
+}
+
+.mock-chart > div {
+  height: 100%;
+  display: grid;
+  grid-template-rows: 1fr auto;
+  align-items: end;
+  gap: 0.45rem;
+  text-align: center;
+}
+
+.mock-chart > div > span {
+  width: 100%;
+  min-height: 16px;
+  align-self: end;
+  border-radius: 8px 8px 3px 3px;
+  background: linear-gradient(180deg, var(--landing-purple), var(--landing-blue));
+  box-shadow: 0 10px 24px rgba(134, 151, 255, 0.15);
+}
+
+.mock-chart small {
+  color: #8190a7;
+  font-size: 0.68rem;
+}
+
+.mock-signal {
+  margin-top: 0.8rem;
+  padding: 1rem;
+  border: 1px solid rgba(105, 228, 246, 0.18);
+  border-radius: 16px;
+  background: rgba(39, 117, 158, 0.08);
+}
+
+.mock-signal strong,
+.mock-signal em {
+  display: block;
+  margin-top: 0.35rem;
+}
+
+.mock-signal em {
+  color: var(--landing-muted);
+  font-size: 0.74rem;
+}
+
+.pro-output-grid {
+  margin-top: 1rem;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.8rem;
+}
+
+.pro-output-grid article {
+  min-height: 220px;
+  padding: 1.2rem;
+  border: 1px solid rgba(173, 145, 255, 0.2);
+  border-radius: 20px;
+  background: linear-gradient(145deg, rgba(24, 30, 55, 0.88), rgba(10, 17, 31, 0.88));
+}
+
+.pro-output-grid svg {
+  color: var(--landing-purple);
+}
+
+.pro-output-grid small {
+  display: block;
+  margin-top: 1rem;
+  color: var(--landing-purple);
+  font-weight: 950;
+  letter-spacing: 0.12em;
+}
+
+.pro-output-grid h3 {
+  margin: 0.6rem 0;
+}
+
+.pro-output-grid p {
+  margin: 0;
+  color: var(--landing-muted);
+  line-height: 1.6;
+}
+
+.pricing-grid-four {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  align-items: stretch;
+}
+
+.pricing-grid-four .pricing-card {
+  display: flex;
+  flex-direction: column;
+}
+
+.pricing-grid-four .pricing-card-header {
+  min-height: 84px;
+  align-items: flex-end;
+}
+
+.pricing-grid-four .pricing-card-header h3 {
+  font-size: 2.25rem;
+}
+
+.pricing-grid-four .pricing-card-header h3 span {
+  display: block;
+  margin-top: 0.2rem;
+}
+
+.pricing-tagline {
+  min-height: 48px;
+  margin: 0.9rem 0 0;
+  color: var(--landing-muted);
+  line-height: 1.45;
+}
+
+.pricing-grid-four .pricing-card ul {
+  flex: 1;
+  margin-top: 1.4rem;
+}
+
+.pricing-card-pro {
+  transform: translateY(-10px);
+  box-shadow: 0 28px 70px rgba(116, 101, 255, 0.18);
+}
+
+.pricing-conversion-note {
+  margin-top: 1rem;
+  padding: 1rem 1.2rem;
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+  border: 1px solid rgba(166, 220, 255, 0.2);
+  border-radius: 18px;
+  background: rgba(13, 21, 38, 0.72);
+}
+
+.pricing-conversion-note svg {
+  flex: 0 0 auto;
+  color: var(--landing-blue);
+}
+
+.pricing-conversion-note strong,
+.pricing-conversion-note span {
+  display: block;
+}
+
+.pricing-conversion-note span {
+  margin-top: 0.25rem;
+  color: var(--landing-muted);
+  font-size: 0.85rem;
+}
+
+.mega-footer {
+  width: min(1180px, calc(100% - 2rem));
+  margin: 6rem auto 0;
+  padding: 3rem 0 2rem;
+  border-top: 1px solid var(--landing-border);
+}
+
+.mega-footer-brand {
+  padding-bottom: 2rem;
+  display: grid;
+  grid-template-columns: 1fr 2fr auto;
+  align-items: center;
+  gap: 2rem;
+  border-bottom: 1px solid var(--landing-border);
+}
+
+.mega-footer-brand p {
+  margin: 0;
+  color: var(--landing-muted);
+  line-height: 1.6;
+}
+
+.footer-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  color: var(--landing-blue) !important;
+  font-weight: 850;
+}
+
+.mega-footer-columns {
+  padding: 2.4rem 0;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 2rem;
+}
+
+.mega-footer-columns > div {
+  display: grid;
+  align-content: start;
+  gap: 0.75rem;
+}
+
+.mega-footer-columns h3 {
+  margin: 0 0 0.35rem;
+  font-size: 0.84rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.mega-footer-columns a,
+.mega-footer-columns span {
+  color: var(--landing-muted);
+  font-size: 0.86rem;
+}
+
+.mega-footer-columns a:hover {
+  color: var(--landing-text);
+}
+
+.mega-footer-columns span {
+  opacity: 0.58;
+}
+
+.mega-footer-bottom {
+  padding-top: 1.4rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  border-top: 1px solid var(--landing-border);
+  color: #7f8ca0;
+  font-size: 0.78rem;
+}
+
+.mega-footer-bottom > div {
+  display: flex;
+  gap: 1rem;
+}
+
+@media (max-width: 1080px) {
+  .premium-workflow-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .pricing-grid-four,
+  .pro-output-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .career-intelligence-demo {
+    grid-template-columns: 1fr;
+  }
+
+  .pricing-card-pro {
+    transform: none;
+  }
+}
+
+@media (max-width: 720px) {
+  .career-flow svg {
+    transform: rotate(90deg);
+  }
+
+  .career-flow {
+    flex-direction: column;
+  }
+
+  .premium-workflow-grid,
+  .pricing-grid-four,
+  .pro-output-grid,
+  .mega-footer-columns,
+  .mock-stat-row {
+    grid-template-columns: 1fr;
+  }
+
+  .career-intelligence-demo {
+    padding: 1rem;
+  }
+
+  .mock-chart {
+    height: 180px;
+    gap: 0.35rem;
+  }
+
+  .mega-footer {
+    width: calc(100% - 1.25rem);
+  }
+
+  .mega-footer-brand {
+    grid-template-columns: 1fr;
+  }
+
+  .mega-footer-bottom {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+}

--- a/frontend/src/LandingPageMotion.css
+++ b/frontend/src/LandingPageMotion.css
@@ -1,0 +1,190 @@
+/* Lightweight, CSS-only motion for the marketing page. */
+
+@keyframes bragstack-fade-up {
+  from {
+    opacity: 0;
+    transform: translate3d(0, 18px, 0);
+  }
+  to {
+    opacity: 1;
+    transform: translate3d(0, 0, 0);
+  }
+}
+
+@keyframes bragstack-float {
+  0%, 100% {
+    transform: translate3d(0, 0, 0);
+  }
+  50% {
+    transform: translate3d(0, -8px, 0);
+  }
+}
+
+@keyframes bragstack-glow-drift {
+  0%, 100% {
+    transform: translate3d(-3%, -2%, 0) scale(0.98);
+    opacity: 0.72;
+  }
+  50% {
+    transform: translate3d(4%, 3%, 0) scale(1.05);
+    opacity: 1;
+  }
+}
+
+@keyframes bragstack-bar-rise {
+  from {
+    transform: scaleY(0.08);
+    opacity: 0.25;
+  }
+  to {
+    transform: scaleY(1);
+    opacity: 1;
+  }
+}
+
+@keyframes bragstack-sheen {
+  0% {
+    transform: translateX(-140%) skewX(-18deg);
+  }
+  55%, 100% {
+    transform: translateX(240%) skewX(-18deg);
+  }
+}
+
+.landing-hero-copy,
+.landing-proof-preview,
+.landing-use-strip,
+.landing-problem-section,
+.landing-use-cases,
+.landing-workflow,
+.landing-feature-section,
+.landing-pricing,
+.landing-final-cta,
+.mega-footer {
+  animation: bragstack-fade-up 640ms cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+.landing-proof-preview { animation-delay: 70ms; }
+.landing-use-strip { animation-delay: 110ms; }
+.landing-problem-section { animation-delay: 140ms; }
+.landing-use-cases { animation-delay: 170ms; }
+.landing-workflow { animation-delay: 200ms; }
+.landing-feature-section { animation-delay: 230ms; }
+.landing-pricing { animation-delay: 260ms; }
+.landing-final-cta { animation-delay: 290ms; }
+.mega-footer { animation-delay: 320ms; }
+
+.preview-glow {
+  animation: bragstack-glow-drift 8s ease-in-out infinite;
+  will-change: transform, opacity;
+}
+
+.floating-proof-card {
+  animation: bragstack-float 5.4s ease-in-out infinite;
+  will-change: transform;
+}
+
+.floating-proof-bottom {
+  animation-delay: -2.7s;
+}
+
+.proof-preview-card,
+.workflow-card,
+.use-case-card,
+.pro-output-grid article,
+.pricing-card,
+.feature-dashboard-preview,
+.mock-analytics-panel {
+  transition:
+    transform 180ms ease,
+    border-color 180ms ease,
+    box-shadow 180ms ease,
+    background-color 180ms ease;
+}
+
+.proof-preview-card:hover,
+.feature-dashboard-preview:hover,
+.mock-analytics-panel:hover {
+  transform: translate3d(0, -4px, 0);
+  border-color: rgba(166, 220, 255, 0.34);
+  box-shadow: 0 28px 70px rgba(0, 0, 0, 0.3);
+}
+
+.workflow-card:hover,
+.use-case-card:hover,
+.pro-output-grid article:hover,
+.pricing-card:hover {
+  transform: translate3d(0, -5px, 0);
+  border-color: rgba(173, 145, 255, 0.34);
+}
+
+.pricing-card-pro:hover {
+  transform: translate3d(0, -14px, 0);
+}
+
+.landing-btn,
+.sidebar-add {
+  position: relative;
+  overflow: hidden;
+  isolation: isolate;
+}
+
+.landing-btn::after {
+  content: "";
+  position: absolute;
+  inset: -30% auto -30% -25%;
+  width: 34%;
+  pointer-events: none;
+  background: linear-gradient(90deg, transparent, rgba(255,255,255,0.3), transparent);
+  animation: bragstack-sheen 5.8s ease-in-out infinite;
+}
+
+.mock-chart > div > span {
+  transform-origin: bottom;
+  animation: bragstack-bar-rise 720ms cubic-bezier(0.22, 1, 0.36, 1) both;
+  will-change: transform;
+}
+
+.mock-chart > div:nth-child(2) > span { animation-delay: 60ms; }
+.mock-chart > div:nth-child(3) > span { animation-delay: 120ms; }
+.mock-chart > div:nth-child(4) > span { animation-delay: 180ms; }
+.mock-chart > div:nth-child(5) > span { animation-delay: 240ms; }
+.mock-chart > div:nth-child(6) > span { animation-delay: 300ms; }
+
+.career-flow span,
+.proof-preview-tags span,
+.feature-preview-tags span {
+  transition: transform 160ms ease, border-color 160ms ease, background 160ms ease;
+}
+
+.career-flow span:hover,
+.proof-preview-tags span:hover,
+.feature-preview-tags span:hover {
+  transform: translate3d(0, -2px, 0);
+  border-color: rgba(166, 220, 255, 0.35);
+}
+
+.mega-footer-columns a {
+  transition: color 150ms ease, transform 150ms ease;
+}
+
+.mega-footer-columns a:hover {
+  transform: translateX(3px);
+}
+
+@media (max-width: 1080px) {
+  .pricing-card-pro:hover {
+    transform: translate3d(0, -5px, 0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+  }
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,3 +1,5 @@
+@import "./LandingPageMotion.css";
+
 :root {
   font-family:
     Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,


### PR DESCRIPTION
## What changed

- introduces plan/entitlement foundations for Free, Pro, Team, and Enterprise
- keeps Free intentionally useful while creating clear upgrade paths for advanced career tooling
- updates the landing page around BragStack's own product model: Proof Entries, Impact Receipts, career analytics, review/promotion outputs, and integrations
- adds four-tier pricing with Team marked coming soon and Enterprise as contact-led
- adds a BragStack-specific multi-column product footer
- adds a richer How It Works / Career Intelligence section with illustrative charts and Pro previews
- adds lightweight CSS-only motion: staggered reveals, floating proof cards, animated demo chart bars, hover depth, CTA sheen, and subtle glow movement
- respects prefers-reduced-motion
- avoids animation libraries, video backgrounds, and heavy marketing assets

## Performance intent

Motion is limited to transform/opacity-oriented CSS animations and simple pseudo-elements. No animation runtime or large media dependency is introduced, so the landing experience should remain fast while feeling substantially more premium.

## Validation

Preview in Codespaces on desktop and mobile widths, verify reduced-motion behavior, run frontend lint/build, and confirm plan/entitlement responses before merging.