### PR TITLE
Build premium Performance Review Packet V1

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -1,0 +1,42 @@
+name: Frontend CI
+
+on:
+  pull_request:
+    paths:
+      - "frontend/**"
+      - ".github/workflows/frontend-ci.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "frontend/**"
+      - ".github/workflows/frontend-ci.yml"
+
+jobs:
+  frontend:
+    name: Lint and build frontend
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Build
+        run: npm run build

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,6 +3,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from app.auth_routes import router as auth_router
 from app.impact_receipt_routes import router as impact_receipts_router
+from app.performance_packet_export_routes import router as performance_packet_export_router
 from app.performance_packet_routes import router as performance_packet_router
 from app.public_slug_routes import router as public_slug_router
 from app.reports_routes import router as reports_router
@@ -34,6 +35,7 @@ app.include_router(public_slug_router)
 app.include_router(impact_receipts_router)
 app.include_router(reports_router)
 app.include_router(performance_packet_router)
+app.include_router(performance_packet_export_router)
 
 
 @app.get("/")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,6 +3,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from app.auth_routes import router as auth_router
 from app.impact_receipt_routes import router as impact_receipts_router
+from app.performance_packet_routes import router as performance_packet_router
 from app.public_slug_routes import router as public_slug_router
 from app.reports_routes import router as reports_router
 from app.routes import public_router, router as entries_router
@@ -32,6 +33,7 @@ app.include_router(public_router)
 app.include_router(public_slug_router)
 app.include_router(impact_receipts_router)
 app.include_router(reports_router)
+app.include_router(performance_packet_router)
 
 
 @app.get("/")

--- a/backend/app/performance_packet_export_routes.py
+++ b/backend/app/performance_packet_export_routes.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import io
+
+from fastapi import APIRouter, Depends, Query
+from fastapi.responses import StreamingResponse
+
+from app.auth import get_current_user
+from app.performance_packet_pdf import build_performance_packet_pdf, make_packet_filename
+from app.performance_packet_routes import _build_packet, _parse_period
+from app.plans import require_feature
+
+
+router = APIRouter(prefix="/packets", tags=["packets"])
+
+
+@router.get("/performance-review.pdf")
+def download_performance_review_packet_pdf(
+    start_date: str | None = Query(None),
+    end_date: str | None = Query(None),
+    career_area: str | None = Query(None, max_length=120),
+    role_title: str | None = Query(None, max_length=160),
+    organization: str | None = Query(None, max_length=180),
+    confidential: bool = Query(True),
+    current_user: dict = Depends(get_current_user),
+):
+    """Generate a true US Letter PDF for the current user's review packet."""
+
+    require_feature(current_user, "export_pdf")
+    parsed_start, parsed_end = _parse_period(start_date, end_date)
+    packet = _build_packet(
+        current_user=current_user,
+        start_date=parsed_start,
+        end_date=parsed_end,
+        career_area=career_area,
+        role_title=role_title,
+        organization=organization,
+        confidential=confidential,
+    )["packet"]
+
+    pdf_bytes = build_performance_packet_pdf(packet)
+    filename = make_packet_filename(packet)
+
+    return StreamingResponse(
+        io.BytesIO(pdf_bytes),
+        media_type="application/pdf",
+        headers={
+            "Content-Disposition": f'attachment; filename="{filename}"',
+            "Cache-Control": "private, no-store",
+            "X-Content-Type-Options": "nosniff",
+        },
+    )

--- a/backend/app/performance_packet_pdf.py
+++ b/backend/app/performance_packet_pdf.py
@@ -1,0 +1,572 @@
+from __future__ import annotations
+
+import io
+import re
+from html import escape
+from typing import Any, Iterable
+
+from reportlab.graphics.shapes import Drawing, Rect, String
+from reportlab.lib import colors
+from reportlab.lib.enums import TA_CENTER
+from reportlab.lib.pagesizes import LETTER
+from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
+from reportlab.lib.units import inch
+from reportlab.platypus import (
+    HRFlowable,
+    PageBreak,
+    Paragraph,
+    SimpleDocTemplate,
+    Spacer,
+    Table,
+    TableStyle,
+)
+
+TEAL = colors.HexColor("#173F43")
+TEAL_2 = colors.HexColor("#1F5559")
+GOLD = colors.HexColor("#B68B4C")
+INK = colors.HexColor("#172126")
+MUTED = colors.HexColor("#667176")
+LIGHT = colors.HexColor("#F3F1EA")
+LINE = colors.HexColor("#DEDAD0")
+PAPER = colors.HexColor("#FFFEFA")
+WHITE = colors.white
+
+PAGE_WIDTH, PAGE_HEIGHT = LETTER
+MARGIN_X = 0.62 * inch
+MARGIN_TOP = 0.58 * inch
+MARGIN_BOTTOM = 0.58 * inch
+CONTENT_WIDTH = PAGE_WIDTH - (MARGIN_X * 2)
+
+
+def _styles() -> dict[str, ParagraphStyle]:
+    base = getSampleStyleSheet()
+    return {
+        "cover_kicker": ParagraphStyle(
+            "PacketCoverKicker",
+            parent=base["Normal"],
+            fontName="Helvetica-Bold",
+            fontSize=9,
+            leading=12,
+            textColor=TEAL_2,
+            spaceAfter=10,
+            uppercase=True,
+        ),
+        "cover_name": ParagraphStyle(
+            "PacketCoverName",
+            parent=base["Title"],
+            fontName="Times-Bold",
+            fontSize=31,
+            leading=33,
+            textColor=INK,
+            spaceAfter=8,
+        ),
+        "cover_role": ParagraphStyle(
+            "PacketCoverRole",
+            parent=base["Normal"],
+            fontName="Helvetica",
+            fontSize=14,
+            leading=18,
+            textColor=colors.HexColor("#454E54"),
+            spaceAfter=8,
+        ),
+        "cover_period": ParagraphStyle(
+            "PacketCoverPeriod",
+            parent=base["Normal"],
+            fontName="Times-Bold",
+            fontSize=15,
+            leading=19,
+            textColor=INK,
+        ),
+        "section_kicker": ParagraphStyle(
+            "PacketSectionKicker",
+            parent=base["Normal"],
+            fontName="Helvetica-Bold",
+            fontSize=7.5,
+            leading=10,
+            textColor=MUTED,
+            spaceAfter=4,
+        ),
+        "section_title": ParagraphStyle(
+            "PacketSectionTitle",
+            parent=base["Heading1"],
+            fontName="Times-Bold",
+            fontSize=23,
+            leading=26,
+            textColor=INK,
+            spaceAfter=10,
+        ),
+        "subhead": ParagraphStyle(
+            "PacketSubhead",
+            parent=base["Heading2"],
+            fontName="Times-Bold",
+            fontSize=13,
+            leading=16,
+            textColor=INK,
+            spaceBefore=4,
+            spaceAfter=5,
+        ),
+        "body": ParagraphStyle(
+            "PacketBody",
+            parent=base["BodyText"],
+            fontName="Helvetica",
+            fontSize=8.6,
+            leading=12.2,
+            textColor=colors.HexColor("#505A60"),
+            spaceAfter=6,
+        ),
+        "body_small": ParagraphStyle(
+            "PacketBodySmall",
+            parent=base["BodyText"],
+            fontName="Helvetica",
+            fontSize=7.5,
+            leading=10.2,
+            textColor=MUTED,
+            spaceAfter=4,
+        ),
+        "metric": ParagraphStyle(
+            "PacketMetric",
+            parent=base["Normal"],
+            fontName="Times-Bold",
+            fontSize=19,
+            leading=21,
+            textColor=TEAL,
+            alignment=TA_CENTER,
+        ),
+        "metric_label": ParagraphStyle(
+            "PacketMetricLabel",
+            parent=base["Normal"],
+            fontName="Helvetica-Bold",
+            fontSize=6.4,
+            leading=8,
+            textColor=MUTED,
+            alignment=TA_CENTER,
+        ),
+        "receipt_label": ParagraphStyle(
+            "PacketReceiptLabel",
+            parent=base["Normal"],
+            fontName="Helvetica-Bold",
+            fontSize=6.8,
+            leading=8,
+            textColor=MUTED,
+            spaceAfter=2,
+        ),
+        "receipt_title": ParagraphStyle(
+            "PacketReceiptTitle",
+            parent=base["Heading2"],
+            fontName="Times-Bold",
+            fontSize=17,
+            leading=20,
+            textColor=INK,
+            spaceAfter=8,
+        ),
+    }
+
+
+def _clean(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _safe(value: Any) -> str:
+    return escape(_clean(value))
+
+
+def _humanize(value: str) -> str:
+    return _clean(value).replace("-", " ").replace("_", " ").title()
+
+
+def _period_display(period: dict[str, Any]) -> str:
+    if period.get("start_date") and period.get("end_date"):
+        return f"{period['start_date']} — {period['end_date']}"
+    return period.get("label") or "All recorded work"
+
+
+def _safe_filename_part(value: str, fallback: str) -> str:
+    cleaned = re.sub(r"[^A-Za-z0-9]+", "-", value or "").strip("-")
+    return cleaned or fallback
+
+
+def make_packet_filename(packet: dict[str, Any]) -> str:
+    subject = packet.get("subject", {})
+    period = packet.get("period", {})
+    subject_part = _safe_filename_part(_clean(subject.get("name")), "bragstack-member")
+    if period.get("start_date") and period.get("end_date"):
+        period_part = f"{period['start_date']}-to-{period['end_date']}"
+    else:
+        period_part = "all-time"
+    return f"{subject_part}-performance-review-{period_part}.pdf"
+
+
+def _section_header(story: list, styles: dict[str, ParagraphStyle], index: str, title: str) -> None:
+    story.append(Paragraph(escape(index), styles["section_kicker"]))
+    story.append(Paragraph(escape(title), styles["section_title"]))
+    story.append(HRFlowable(width="100%", thickness=1.7, color=TEAL, spaceAfter=12))
+
+
+def _stat_table(scorecard: dict[str, Any], styles: dict[str, ParagraphStyle]) -> Table:
+    values = [
+        (scorecard.get("accomplishments", 0), "Accomplishments"),
+        (scorecard.get("impact_receipts", 0), "Impact Receipts"),
+        (scorecard.get("evidence_items", 0), "Evidence Items"),
+        (scorecard.get("skills_demonstrated", 0), "Skills Demonstrated"),
+    ]
+    cells = []
+    for value, label in values:
+        cells.append([
+            Paragraph(escape(str(value)), styles["metric"]),
+            Paragraph(escape(label), styles["metric_label"]),
+        ])
+    table = Table([cells], colWidths=[CONTENT_WIDTH / 4] * 4)
+    table.setStyle(
+        TableStyle(
+            [
+                ("BOX", (0, 0), (-1, -1), 0.7, LINE),
+                ("INNERGRID", (0, 0), (-1, -1), 0.5, LINE),
+                ("BACKGROUND", (0, 0), (-1, -1), colors.white),
+                ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
+                ("LEFTPADDING", (0, 0), (-1, -1), 8),
+                ("RIGHTPADDING", (0, 0), (-1, -1), 8),
+                ("TOPPADDING", (0, 0), (-1, -1), 10),
+                ("BOTTOMPADDING", (0, 0), (-1, -1), 10),
+            ]
+        )
+    )
+    return table
+
+
+def _coverage_table(scorecard: dict[str, Any], styles: dict[str, ParagraphStyle]) -> Table:
+    rows = [
+        ("Impact Receipt coverage", scorecard.get("receipt_coverage_percent", 0), "Accomplishments converted to structured proof"),
+        ("Quantified result coverage", scorecard.get("quantified_result_coverage_percent", 0), "Receipts containing a measurable result"),
+        ("Evidence coverage", scorecard.get("evidence_coverage_percent", 0), "Receipts supported by evidence"),
+        ("Verification coverage", scorecard.get("verification_coverage_percent", 0), "Receipts with confirmed contribution"),
+    ]
+    data = [[Paragraph("<b>Measure</b>", styles["body_small"]), Paragraph("<b>Coverage</b>", styles["body_small"]), Paragraph("<b>Meaning</b>", styles["body_small"])]]
+    for label, value, note in rows:
+        data.append([
+            Paragraph(escape(label), styles["body_small"]),
+            Paragraph(f"<b>{int(value or 0)}%</b>", styles["body_small"]),
+            Paragraph(escape(note), styles["body_small"]),
+        ])
+    table = Table(data, colWidths=[2.2 * inch, 0.8 * inch, CONTENT_WIDTH - 3 * inch], repeatRows=1)
+    table.setStyle(
+        TableStyle(
+            [
+                ("BACKGROUND", (0, 0), (-1, 0), LIGHT),
+                ("TEXTCOLOR", (0, 0), (-1, 0), TEAL),
+                ("GRID", (0, 0), (-1, -1), 0.4, LINE),
+                ("VALIGN", (0, 0), (-1, -1), "TOP"),
+                ("TOPPADDING", (0, 0), (-1, -1), 6),
+                ("BOTTOMPADDING", (0, 0), (-1, -1), 6),
+            ]
+        )
+    )
+    return table
+
+
+def _bars(items: Iterable[tuple[str, int]], *, width: float = CONTENT_WIDTH, max_items: int = 8) -> Drawing:
+    items = list(items)[:max_items]
+    row_h = 20
+    height = max(28, len(items) * row_h + 6)
+    drawing = Drawing(width, height)
+    if not items:
+        drawing.add(String(0, height - 14, "No data for this period.", fontName="Helvetica", fontSize=8, fillColor=MUTED))
+        return drawing
+
+    max_value = max(value for _, value in items) or 1
+    label_w = 135
+    count_w = 28
+    bar_w = max(120, width - label_w - count_w - 12)
+
+    for index, (label, value) in enumerate(items):
+        y = height - ((index + 1) * row_h) + 4
+        drawing.add(String(0, y + 4, str(label)[:26], fontName="Helvetica", fontSize=7.3, fillColor=INK))
+        drawing.add(Rect(label_w, y + 2, bar_w, 7, fillColor=colors.HexColor("#E8E5DC"), strokeColor=None))
+        fill_w = max(6, bar_w * (float(value) / max_value))
+        drawing.add(Rect(label_w, y + 2, fill_w, 7, fillColor=TEAL_2, strokeColor=None))
+        drawing.add(String(label_w + bar_w + 8, y + 3, str(value), fontName="Helvetica-Bold", fontSize=7, fillColor=TEAL))
+    return drawing
+
+
+def _link_or_text(reference: str, styles: dict[str, ParagraphStyle]) -> Paragraph:
+    reference = _clean(reference)
+    if reference.startswith("https://") or reference.startswith("http://"):
+        safe = escape(reference)
+        return Paragraph(f'<link href="{safe}" color="#1F5559"><u>{safe}</u></link>', styles["body_small"])
+    return Paragraph(escape(reference or "—"), styles["body_small"])
+
+
+def _draw_page_footer(canvas, doc, packet: dict[str, Any]) -> None:
+    canvas.saveState()
+    period = _period_display(packet.get("period", {}))
+    canvas.setStrokeColor(LINE)
+    canvas.setLineWidth(0.5)
+    canvas.line(MARGIN_X, 0.42 * inch, PAGE_WIDTH - MARGIN_X, 0.42 * inch)
+    canvas.setFillColor(MUTED)
+    canvas.setFont("Helvetica", 6.6)
+    canvas.drawString(MARGIN_X, 0.27 * inch, "BragStack · Career Evidence System")
+    canvas.drawCentredString(PAGE_WIDTH / 2, 0.27 * inch, period[:72])
+    canvas.drawRightString(PAGE_WIDTH - MARGIN_X, 0.27 * inch, f"Page {doc.page}")
+    if packet.get("confidential"):
+        canvas.setFont("Helvetica-Bold", 6.4)
+        canvas.setFillColor(TEAL)
+        canvas.drawRightString(PAGE_WIDTH - MARGIN_X, PAGE_HEIGHT - 0.34 * inch, "CONFIDENTIAL")
+    canvas.restoreState()
+
+
+def _receipt_page(story: list, styles: dict[str, ParagraphStyle], record: dict[str, Any], page_index: int) -> None:
+    story.append(PageBreak())
+    _section_header(story, styles, f"07.{page_index:02d} · IMPACT RECEIPT", record.get("reference") or "Impact Receipt")
+    story.append(Paragraph(_safe(record.get("accomplishment")), styles["receipt_title"]))
+    meta = [
+        [Paragraph("<b>Date</b>", styles["receipt_label"]), Paragraph(_safe(record.get("entry_date") or "—"), styles["body_small"]), Paragraph("<b>Status</b>", styles["receipt_label"]), Paragraph("Verified" if record.get("verified") else "Self-documented", styles["body_small"])],
+    ]
+    meta_table = Table(meta, colWidths=[0.55 * inch, 2.0 * inch, 0.55 * inch, CONTENT_WIDTH - 3.1 * inch])
+    meta_table.setStyle(TableStyle([("BACKGROUND", (0, 0), (-1, -1), LIGHT), ("BOX", (0, 0), (-1, -1), 0.5, LINE), ("VALIGN", (0, 0), (-1, -1), "MIDDLE"), ("TOPPADDING", (0, 0), (-1, -1), 6), ("BOTTOMPADDING", (0, 0), (-1, -1), 6)]))
+    story.append(meta_table)
+    story.append(Spacer(1, 10))
+
+    for label, value in (("Contribution", record.get("contribution")), ("Result", record.get("result"))):
+        if value:
+            story.append(Paragraph(escape(label.upper()), styles["receipt_label"]))
+            story.append(Paragraph(_safe(value), styles["body"]))
+            story.append(Spacer(1, 3))
+
+    skills = record.get("skills") or []
+    if skills:
+        story.append(Paragraph("SKILLS DEMONSTRATED", styles["receipt_label"]))
+        story.append(Paragraph(escape(" · ".join(skills)), styles["body_small"]))
+        story.append(Spacer(1, 5))
+
+    confirmations = [item for item in record.get("confirmations", []) if item.get("status") == "confirmed"]
+    if confirmations:
+        story.append(Paragraph("VERIFIED RECOGNITION", styles["receipt_label"]))
+        for item in confirmations:
+            who = item.get("name") or "Confirmed contributor"
+            role = item.get("role")
+            kind = _humanize(item.get("type") or "confirmation")
+            text = f"{who}{f' · {role}' if role else ''} · {kind}"
+            story.append(Paragraph(_safe(text), styles["body_small"]))
+        story.append(Spacer(1, 5))
+
+    credit = record.get("credit") or []
+    if credit:
+        story.append(Paragraph("SHARED CREDIT", styles["receipt_label"]))
+        for item in credit:
+            text = f"{item.get('name') or 'Contributor'} — {item.get('contribution') or ''}"
+            story.append(Paragraph(_safe(text), styles["body_small"]))
+        story.append(Spacer(1, 5))
+
+    evidence = record.get("evidence") or []
+    story.append(HRFlowable(width="100%", thickness=0.6, color=LINE, spaceBefore=5, spaceAfter=8))
+    story.append(Paragraph(f"EVIDENCE · {len(evidence)} ITEM{'S' if len(evidence) != 1 else ''}", styles["receipt_label"]))
+    if evidence:
+        rows = [[Paragraph("<b>Evidence</b>", styles["body_small"]), Paragraph("<b>Type</b>", styles["body_small"]), Paragraph("<b>Reference</b>", styles["body_small"])]]
+        for item in evidence:
+            rows.append([
+                Paragraph(_safe(item.get("title") or "Evidence item"), styles["body_small"]),
+                Paragraph(_safe(_humanize(item.get("type") or "other")), styles["body_small"]),
+                _link_or_text(item.get("reference") or "", styles),
+            ])
+        table = Table(rows, colWidths=[2.7 * inch, 1.15 * inch, CONTENT_WIDTH - 3.85 * inch], repeatRows=1)
+        table.setStyle(TableStyle([("BACKGROUND", (0, 0), (-1, 0), LIGHT), ("GRID", (0, 0), (-1, -1), 0.4, LINE), ("VALIGN", (0, 0), (-1, -1), "TOP"), ("TOPPADDING", (0, 0), (-1, -1), 5), ("BOTTOMPADDING", (0, 0), (-1, -1), 5)]))
+        story.append(table)
+    else:
+        story.append(Paragraph("No supporting evidence is attached to this receipt yet.", styles["body_small"]))
+
+
+def build_performance_packet_pdf(packet: dict[str, Any]) -> bytes:
+    styles = _styles()
+    buffer = io.BytesIO()
+    doc = SimpleDocTemplate(
+        buffer,
+        pagesize=LETTER,
+        leftMargin=MARGIN_X,
+        rightMargin=MARGIN_X,
+        topMargin=MARGIN_TOP,
+        bottomMargin=MARGIN_BOTTOM,
+        title=packet.get("title") or "BragStack Performance Review Packet",
+        author="BragStack",
+        subject="Evidence-backed performance review packet",
+    )
+
+    story: list = []
+    subject = packet.get("subject", {})
+    context = packet.get("context", {})
+    period = packet.get("period", {})
+    scorecard = packet.get("scorecard", {})
+
+    # Cover
+    story.append(Spacer(1, 0.42 * inch))
+    story.append(Paragraph("BRAGSTACK · PERFORMANCE REVIEW PACKET", styles["cover_kicker"]))
+    story.append(Spacer(1, 0.26 * inch))
+    story.append(Paragraph(_safe(subject.get("name") or "BragStack Member"), styles["cover_name"]))
+    story.append(Paragraph(_safe(subject.get("role") or "Professional"), styles["cover_role"]))
+    organization = _clean(context.get("organization"))
+    career_area = _clean(context.get("career_area"))
+    if organization:
+        story.append(Paragraph(_safe(organization), styles["body"]))
+    if career_area:
+        story.append(Paragraph(_safe(career_area), styles["body_small"]))
+    story.append(Spacer(1, 0.18 * inch))
+    story.append(HRFlowable(width=0.85 * inch, thickness=3, color=GOLD, spaceAfter=18))
+    story.append(Paragraph("REVIEW PERIOD", styles["section_kicker"]))
+    story.append(Paragraph(_safe(_period_display(period)), styles["cover_period"]))
+    story.append(Spacer(1, 0.25 * inch))
+    story.append(_stat_table(scorecard, styles))
+    story.append(Spacer(1, 0.32 * inch))
+    story.append(Paragraph("Evidence-backed career record generated from documented accomplishments, Impact Receipts, supporting evidence, and confirmations.", styles["body_small"]))
+
+    # Executive scorecard
+    story.append(PageBreak())
+    _section_header(story, styles, "01 · EXECUTIVE SCORECARD", "Proof at a glance")
+    story.append(Paragraph("A transparent summary of documented work for this review period. Coverage measures are calculated from actual records rather than an opaque AI score.", styles["body"]))
+    story.append(_stat_table(scorecard, styles))
+    story.append(Spacer(1, 12))
+    story.append(_coverage_table(scorecard, styles))
+    story.append(Spacer(1, 10))
+    depth = scorecard.get("evidence_depth", 0)
+    assertions = scorecard.get("confirmed_assertions", 0)
+    story.append(Paragraph(f"<b>Evidence depth:</b> {escape(str(depth))}× average supporting items per Impact Receipt · <b>Confirmed assertions:</b> {escape(str(assertions))}", styles["body"]))
+
+    # Impact analytics
+    story.append(PageBreak())
+    _section_header(story, styles, "02 · IMPACT ANALYTICS", "How the work is distributed")
+    analytics = packet.get("impact_analytics", {})
+    story.append(Paragraph("Work themes", styles["subhead"]))
+    story.append(_bars((analytics.get("categories") or {}).items()))
+    story.append(Spacer(1, 10))
+    story.append(Paragraph("Most demonstrated skills", styles["subhead"]))
+    story.append(_bars((analytics.get("top_skills") or {}).items()))
+    activity = analytics.get("activity_by_month") or {}
+    if activity:
+        story.append(Spacer(1, 10))
+        story.append(Paragraph("Activity by month", styles["subhead"]))
+        story.append(_bars(activity.items(), max_items=12))
+
+    # Signature accomplishments
+    story.append(PageBreak())
+    _section_header(story, styles, "03 · SIGNATURE ACCOMPLISHMENTS", "The strongest documented work")
+    accomplishments = packet.get("signature_accomplishments") or []
+    if accomplishments:
+        for index, item in enumerate(accomplishments[:8], 1):
+            story.append(Paragraph(f"{index:02d} · {_safe(item.get('title'))}", styles["subhead"]))
+            meta = " · ".join(filter(None, [_clean(item.get("category")), _clean(item.get("entry_date"))]))
+            if meta:
+                story.append(Paragraph(_safe(meta), styles["body_small"]))
+            if item.get("result"):
+                story.append(Paragraph(_safe(item.get("result")), styles["body"]))
+            signals = []
+            if item.get("verified"):
+                signals.append("Verified")
+            if item.get("has_receipt"):
+                signals.append("Impact Receipt")
+            if item.get("evidence_count"):
+                signals.append(f"{item['evidence_count']} evidence")
+            if signals:
+                story.append(Paragraph(_safe(" · ".join(signals)), styles["body_small"]))
+            story.append(HRFlowable(width="100%", thickness=0.4, color=LINE, spaceBefore=3, spaceAfter=7))
+    else:
+        story.append(Paragraph("No signature accomplishments are available for this period yet.", styles["body"]))
+
+    # Measurable results
+    story.append(PageBreak())
+    _section_header(story, styles, "04 · MEASURABLE RESULTS", "Outcomes with quantified signals")
+    results = packet.get("measurable_results") or []
+    if results:
+        rows = [[Paragraph("<b>Signal</b>", styles["body_small"]), Paragraph("<b>Result</b>", styles["body_small"]), Paragraph("<b>Accomplishment</b>", styles["body_small"])]]
+        for item in results[:12]:
+            rows.append([
+                Paragraph(_safe(item.get("metric_display") or "—"), styles["body_small"]),
+                Paragraph(_safe(item.get("result") or ""), styles["body_small"]),
+                Paragraph(_safe(item.get("title") or ""), styles["body_small"]),
+            ])
+        table = Table(rows, colWidths=[0.9 * inch, 3.2 * inch, CONTENT_WIDTH - 4.1 * inch], repeatRows=1)
+        table.setStyle(TableStyle([("BACKGROUND", (0, 0), (-1, 0), LIGHT), ("GRID", (0, 0), (-1, -1), 0.4, LINE), ("VALIGN", (0, 0), (-1, -1), "TOP"), ("TOPPADDING", (0, 0), (-1, -1), 5), ("BOTTOMPADDING", (0, 0), (-1, -1), 5)]))
+        story.append(table)
+    else:
+        story.append(Paragraph("No quantified outcomes were documented for this period. Results remain visible elsewhere in the packet without inventing metrics.", styles["body"]))
+
+    # Skills and growth
+    story.append(PageBreak())
+    _section_header(story, styles, "05 · SKILLS & GROWTH", "Demonstrated capabilities over time")
+    skill_details = packet.get("skill_details") or []
+    if skill_details:
+        rows = [[Paragraph("<b>Skill</b>", styles["body_small"]), Paragraph("<b>Uses</b>", styles["body_small"]), Paragraph("<b>First seen</b>", styles["body_small"]), Paragraph("<b>Most recent</b>", styles["body_small"])]]
+        for item in skill_details[:20]:
+            rows.append([
+                Paragraph(_safe(item.get("skill")), styles["body_small"]),
+                Paragraph(_safe(item.get("count")), styles["body_small"]),
+                Paragraph(_safe(item.get("first_seen") or "—"), styles["body_small"]),
+                Paragraph(_safe(item.get("last_seen") or "—"), styles["body_small"]),
+            ])
+        table = Table(rows, colWidths=[2.5 * inch, 0.6 * inch, 1.25 * inch, CONTENT_WIDTH - 4.35 * inch], repeatRows=1)
+        table.setStyle(TableStyle([("BACKGROUND", (0, 0), (-1, 0), LIGHT), ("GRID", (0, 0), (-1, -1), 0.4, LINE), ("VALIGN", (0, 0), (-1, -1), "TOP"), ("TOPPADDING", (0, 0), (-1, -1), 5), ("BOTTOMPADDING", (0, 0), (-1, -1), 5)]))
+        story.append(table)
+    else:
+        story.append(Paragraph("No skill evidence is available for this review period yet.", styles["body"]))
+
+    # Contribution and recognition
+    story.append(PageBreak())
+    _section_header(story, styles, "06 · CONTRIBUTION & RECOGNITION", "How the work was carried and confirmed")
+    contributions = packet.get("contribution_records") or []
+    if contributions:
+        for item in contributions[:12]:
+            status = "Verified" if item.get("verified") else "Self-documented"
+            story.append(Paragraph(f"{_safe(item.get('reference'))} · {_safe(status)}", styles["section_kicker"]))
+            story.append(Paragraph(_safe(item.get("accomplishment")), styles["subhead"]))
+            if item.get("contribution"):
+                story.append(Paragraph(f"<b>Contribution:</b> {_safe(item.get('contribution'))}", styles["body"]))
+            if item.get("result"):
+                story.append(Paragraph(f"<b>Result:</b> {_safe(item.get('result'))}", styles["body"]))
+            confirmations = [c for c in item.get("confirmations", []) if c.get("status") == "confirmed"]
+            if confirmations:
+                names = ", ".join(c.get("name") or "Confirmed contributor" for c in confirmations)
+                story.append(Paragraph(f"<b>Recognition:</b> {_safe(names)}", styles["body_small"]))
+            story.append(HRFlowable(width="100%", thickness=0.4, color=LINE, spaceAfter=7))
+    else:
+        story.append(Paragraph("No structured contribution records are available for this period yet.", styles["body"]))
+
+    # One physical receipt page per receipt.
+    receipt_records = packet.get("receipt_records") or []
+    for index, record in enumerate(receipt_records, 1):
+        _receipt_page(story, styles, record, index)
+
+    # Evidence index
+    story.append(PageBreak())
+    _section_header(story, styles, "08 · EVIDENCE INDEX", "Supporting material referenced by the packet")
+    evidence_index = packet.get("evidence_index") or []
+    if evidence_index:
+        rows = [[Paragraph("<b>Receipt</b>", styles["body_small"]), Paragraph("<b>Evidence</b>", styles["body_small"]), Paragraph("<b>Type</b>", styles["body_small"]), Paragraph("<b>Reference</b>", styles["body_small"])]]
+        for item in evidence_index:
+            rows.append([
+                Paragraph(_safe(item.get("receipt_reference")), styles["body_small"]),
+                Paragraph(_safe(item.get("title") or "Evidence item"), styles["body_small"]),
+                Paragraph(_safe(_humanize(item.get("type") or "other")), styles["body_small"]),
+                _link_or_text(item.get("reference") or "", styles),
+            ])
+        table = Table(rows, colWidths=[1.05 * inch, 2.25 * inch, 1.05 * inch, CONTENT_WIDTH - 4.35 * inch], repeatRows=1)
+        table.setStyle(TableStyle([("BACKGROUND", (0, 0), (-1, 0), LIGHT), ("GRID", (0, 0), (-1, -1), 0.4, LINE), ("VALIGN", (0, 0), (-1, -1), "TOP"), ("TOPPADDING", (0, 0), (-1, -1), 5), ("BOTTOMPADDING", (0, 0), (-1, -1), 5)]))
+        story.append(table)
+    else:
+        story.append(Paragraph("No supporting evidence items are attached to this packet yet.", styles["body"]))
+
+    # Review summary
+    story.append(PageBreak())
+    _section_header(story, styles, "09 · REVIEW SUMMARY", "Evidence-backed review narrative")
+    story.append(Paragraph(_safe(packet.get("review_summary")), styles["body"]))
+    story.append(Spacer(1, 10))
+    talking_points = packet.get("talking_points") or []
+    if talking_points:
+        story.append(Paragraph("Review talking points", styles["subhead"]))
+        for item in talking_points:
+            story.append(Paragraph(f"• <b>{_safe(item.get('title'))}</b> — {_safe(item.get('result') or item.get('category') or '')}", styles["body"]))
+    story.append(Spacer(1, 14))
+    story.append(HRFlowable(width="100%", thickness=2, color=TEAL, spaceAfter=10))
+    story.append(Paragraph("This packet summarizes documented work and supporting proof. It is not an automated performance rating, employment decision, or promotion determination.", styles["body_small"]))
+
+    doc.build(
+        story,
+        onFirstPage=lambda canvas, doc_obj: _draw_page_footer(canvas, doc_obj, packet),
+        onLaterPages=lambda canvas, doc_obj: _draw_page_footer(canvas, doc_obj, packet),
+    )
+    return buffer.getvalue()

--- a/backend/app/performance_packet_routes.py
+++ b/backend/app/performance_packet_routes.py
@@ -1,0 +1,588 @@
+from __future__ import annotations
+
+import re
+from collections import Counter, defaultdict
+from datetime import date, datetime, timezone
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+
+from app.auth import get_current_user
+from app.database import entries_collection, impact_receipts_collection
+from app.plans import require_feature
+
+
+router = APIRouter(prefix="/packets", tags=["packets"])
+
+
+def _parse_date_value(value: Any) -> date | None:
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc).date()
+
+    if isinstance(value, date):
+        return value
+
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return None
+        try:
+            return date.fromisoformat(text[:10])
+        except ValueError:
+            try:
+                parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+            except ValueError:
+                return None
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=timezone.utc)
+            return parsed.astimezone(timezone.utc).date()
+
+    return None
+
+
+def _entry_work_date(entry: dict) -> date | None:
+    return _parse_date_value(entry.get("entry_date")) or _parse_date_value(
+        entry.get("created_at")
+    )
+
+
+def _percentage(numerator: int, denominator: int) -> int:
+    if denominator <= 0:
+        return 0
+    return round((numerator / denominator) * 100)
+
+
+def _has_quantified_result(value: str) -> bool:
+    return bool(re.search(r"\d", value or ""))
+
+
+def _extract_metric_display(value: str) -> str | None:
+    """Extract one displayable numeric token without inventing a metric."""
+
+    text = (value or "").strip()
+    if not text:
+        return None
+
+    patterns = [
+        r"\$\s?\d[\d,]*(?:\.\d+)?(?:[KMBkmb])?",
+        r"\d+(?:\.\d+)?\s?%",
+        r"\d+(?:\.\d+)?\s?[xX]",
+        r"\d[\d,]*(?:\.\d+)?\s?(?:hours?|hrs?|days?|weeks?|months?|years?)",
+        r"\d[\d,]*(?:\.\d+)?\s?(?:people|clients?|customers?|students?|patients?|cases?|units?|projects?|teams?|sites?)",
+        r"\d[\d,]*(?:\.\d+)?",
+    ]
+
+    for pattern in patterns:
+        match = re.search(pattern, text, flags=re.IGNORECASE)
+        if match:
+            return match.group(0).strip()
+
+    return None
+
+
+def _clean_string(value: Any, fallback: str = "") -> str:
+    text = str(value or "").strip()
+    return text or fallback
+
+
+def _entries_for_period(
+    *,
+    user_id: str,
+    start_date: date | None,
+    end_date: date | None,
+) -> list[dict]:
+    entries = list(entries_collection.find({"user_id": user_id}))
+    selected: list[dict] = []
+
+    for entry in entries:
+        work_date = _entry_work_date(entry)
+        if start_date is not None and (work_date is None or work_date < start_date):
+            continue
+        if end_date is not None and (work_date is None or work_date > end_date):
+            continue
+        selected.append(entry)
+
+    return selected
+
+
+def _receipt_reference(receipt: dict, work_date: date | None) -> str:
+    year = work_date.year if work_date else datetime.now(timezone.utc).year
+    token = str(receipt.get("_id") or "000000")[-6:].upper()
+    return f"BS-{year}-{token}"
+
+
+def _build_review_narrative(
+    *,
+    subject_name: str,
+    entries_count: int,
+    receipts_count: int,
+    evidence_count: int,
+    confirmed_receipts: int,
+    quantified_results: int,
+    categories: Counter,
+    skills: Counter,
+) -> str:
+    if entries_count == 0:
+        return (
+            f"{subject_name} has not yet documented accomplishments for this review "
+            "period. Add work outcomes, evidence, and Impact Receipts to build a "
+            "complete performance narrative."
+        )
+
+    category_names = [name for name, _ in categories.most_common(3)]
+    skill_names = [name for name, _ in skills.most_common(4)]
+
+    parts = [
+        f"{subject_name} documented {entries_count} accomplishment"
+        f"{'s' if entries_count != 1 else ''} during this review period."
+    ]
+
+    if category_names:
+        parts.append(
+            "The strongest concentration of documented work appears in "
+            + ", ".join(category_names)
+            + "."
+        )
+
+    proof_parts: list[str] = []
+    if receipts_count:
+        proof_parts.append(
+            f"{receipts_count} structured Impact Receipt"
+            f"{'s' if receipts_count != 1 else ''}"
+        )
+    if evidence_count:
+        proof_parts.append(
+            f"{evidence_count} supporting evidence item"
+            f"{'s' if evidence_count != 1 else ''}"
+        )
+    if confirmed_receipts:
+        proof_parts.append(
+            f"{confirmed_receipts} verified contribution"
+            f"{'s' if confirmed_receipts != 1 else ''}"
+        )
+    if quantified_results:
+        proof_parts.append(
+            f"{quantified_results} quantified result"
+            f"{'s' if quantified_results != 1 else ''}"
+        )
+
+    if proof_parts:
+        parts.append("The record includes " + ", ".join(proof_parts) + ".")
+
+    if skill_names:
+        parts.append(
+            "Frequently demonstrated capabilities include "
+            + ", ".join(skill_names)
+            + "."
+        )
+
+    parts.append(
+        "The packet is evidence-backed and intended to support review, growth, "
+        "recognition, and advancement conversations with traceable examples."
+    )
+
+    return " ".join(parts)
+
+
+def _build_packet(
+    *,
+    current_user: dict,
+    start_date: date | None,
+    end_date: date | None,
+    career_area: str | None,
+    role_title: str | None,
+    organization: str | None,
+    confidential: bool,
+) -> dict:
+    require_feature(current_user, "performance_review_builder")
+
+    user_id = str(current_user["_id"])
+    entries = _entries_for_period(
+        user_id=user_id,
+        start_date=start_date,
+        end_date=end_date,
+    )
+    entry_ids = {str(entry["_id"]) for entry in entries}
+
+    receipts = list(impact_receipts_collection.find({"user_id": user_id}))
+    if start_date is not None or end_date is not None:
+        receipts = [
+            receipt
+            for receipt in receipts
+            if receipt.get("source_entry_id") in entry_ids
+        ]
+
+    receipts_by_source = {
+        receipt.get("source_entry_id"): receipt
+        for receipt in receipts
+        if receipt.get("source_entry_id")
+    }
+
+    categories: Counter[str] = Counter()
+    skills: Counter[str] = Counter()
+    trust_signals: Counter[str] = Counter()
+    activity_by_month: Counter[str] = Counter()
+    skill_dates: dict[str, list[date]] = defaultdict(list)
+
+    highlights: list[dict] = []
+    measurable_results: list[dict] = []
+
+    for entry in entries:
+        entry_id = str(entry["_id"])
+        receipt = receipts_by_source.get(entry_id)
+        work_date = _entry_work_date(entry)
+        category = _clean_string(entry.get("category"), "Uncategorized")
+        categories[category] += 1
+
+        if work_date:
+            activity_by_month[work_date.strftime("%Y-%m")] += 1
+
+        skill_values = (
+            receipt.get("skills", [])
+            if receipt is not None and receipt.get("skills")
+            else entry.get("tags", [])
+        )
+
+        clean_skills: list[str] = []
+        for value in skill_values:
+            skill = _clean_string(value)
+            if not skill:
+                continue
+            clean_skills.append(skill)
+            skills[skill] += 1
+            if work_date:
+                skill_dates[skill].append(work_date)
+
+        result_text = _clean_string(
+            receipt.get("result") if receipt is not None else entry.get("impact")
+        )
+        trust_values = receipt.get("trust_signals", []) if receipt is not None else []
+        for signal in trust_values:
+            cleaned_signal = _clean_string(signal)
+            if cleaned_signal:
+                trust_signals[cleaned_signal] += 1
+
+        highlight = {
+            "entry_id": entry_id,
+            "receipt_id": str(receipt["_id"]) if receipt is not None else None,
+            "entry_date": work_date.isoformat() if work_date else None,
+            "title": _clean_string(entry.get("title"), "Untitled accomplishment"),
+            "category": category,
+            "result": result_text,
+            "skills": clean_skills,
+            "has_receipt": receipt is not None,
+            "trust_signals": [_clean_string(value) for value in trust_values if _clean_string(value)],
+            "evidence_count": len(receipt.get("evidence", [])) if receipt else 0,
+            "verified": any(
+                confirmation.get("status") == "confirmed"
+                for confirmation in (receipt.get("confirmations", []) if receipt else [])
+            ),
+        }
+        highlights.append(highlight)
+
+        if _has_quantified_result(result_text):
+            measurable_results.append(
+                {
+                    **highlight,
+                    "metric_display": _extract_metric_display(result_text),
+                }
+            )
+
+    highlights.sort(key=lambda item: item.get("entry_date") or "", reverse=True)
+    measurable_results.sort(
+        key=lambda item: (
+            item.get("verified", False),
+            item.get("evidence_count", 0),
+            item.get("entry_date") or "",
+        ),
+        reverse=True,
+    )
+
+    signature_accomplishments = sorted(
+        highlights,
+        key=lambda item: (
+            _has_quantified_result(item.get("result", "")),
+            item.get("verified", False),
+            item.get("evidence_count", 0),
+            item.get("has_receipt", False),
+            item.get("entry_date") or "",
+        ),
+        reverse=True,
+    )[:8]
+
+    evidence_items = 0
+    receipts_with_evidence = 0
+    confirmed_receipts = 0
+    confirmed_assertions = 0
+    quantified_receipts = 0
+    receipt_records: list[dict] = []
+    evidence_index: list[dict] = []
+    contribution_records: list[dict] = []
+
+    entries_by_id = {str(entry["_id"]): entry for entry in entries}
+
+    for receipt in receipts:
+        source_entry = entries_by_id.get(receipt.get("source_entry_id"), {})
+        work_date = _entry_work_date(source_entry)
+        evidence = receipt.get("evidence", []) or []
+        confirmations = receipt.get("confirmations", []) or []
+        confirmed = [
+            confirmation
+            for confirmation in confirmations
+            if confirmation.get("status") == "confirmed"
+        ]
+        result_text = _clean_string(receipt.get("result"))
+        reference = _receipt_reference(receipt, work_date)
+
+        evidence_items += len(evidence)
+        if evidence:
+            receipts_with_evidence += 1
+        if confirmed:
+            confirmed_receipts += 1
+            confirmed_assertions += len(confirmed)
+        if _has_quantified_result(result_text):
+            quantified_receipts += 1
+
+        record = {
+            "id": str(receipt.get("_id")),
+            "reference": reference,
+            "entry_date": work_date.isoformat() if work_date else None,
+            "accomplishment": _clean_string(
+                receipt.get("accomplishment"),
+                _clean_string(source_entry.get("title"), "Documented accomplishment"),
+            ),
+            "contribution": _clean_string(receipt.get("contribution")),
+            "result": result_text,
+            "skills": [_clean_string(value) for value in receipt.get("skills", []) if _clean_string(value)],
+            "evidence": [
+                {
+                    "title": _clean_string(item.get("title"), "Evidence item"),
+                    "type": _clean_string(item.get("evidence_type"), "other"),
+                    "reference": _clean_string(item.get("reference")),
+                    "description": _clean_string(item.get("description")),
+                    "is_public": bool(item.get("is_public", False)),
+                }
+                for item in evidence
+            ],
+            "confirmations": [
+                {
+                    "name": _clean_string(item.get("name"), "Confirmed contributor"),
+                    "role": _clean_string(item.get("role")),
+                    "type": _clean_string(item.get("confirmation_type")),
+                    "status": _clean_string(item.get("status")),
+                }
+                for item in confirmations
+            ],
+            "credit": [
+                {
+                    "name": _clean_string(item.get("name")),
+                    "contribution": _clean_string(item.get("contribution")),
+                }
+                for item in receipt.get("credit", [])
+            ],
+            "trust_signals": [
+                _clean_string(value)
+                for value in receipt.get("trust_signals", [])
+                if _clean_string(value)
+            ],
+            "verified": bool(confirmed),
+        }
+        receipt_records.append(record)
+
+        contribution_records.append(
+            {
+                "reference": reference,
+                "entry_date": record["entry_date"],
+                "accomplishment": record["accomplishment"],
+                "contribution": record["contribution"],
+                "result": record["result"],
+                "verified": record["verified"],
+                "confirmations": record["confirmations"],
+                "credit": record["credit"],
+                "evidence_count": len(record["evidence"]),
+            }
+        )
+
+        for item in record["evidence"]:
+            evidence_index.append(
+                {
+                    "receipt_reference": reference,
+                    "accomplishment": record["accomplishment"],
+                    **item,
+                }
+            )
+
+    receipt_records.sort(key=lambda item: item.get("entry_date") or "", reverse=True)
+    contribution_records.sort(
+        key=lambda item: (
+            item.get("verified", False),
+            item.get("evidence_count", 0),
+            item.get("entry_date") or "",
+        ),
+        reverse=True,
+    )
+
+    skill_details = []
+    for skill, count in skills.most_common():
+        dates = sorted(skill_dates.get(skill, []))
+        skill_details.append(
+            {
+                "skill": skill,
+                "count": count,
+                "first_seen": dates[0].isoformat() if dates else None,
+                "last_seen": dates[-1].isoformat() if dates else None,
+            }
+        )
+
+    scorecard = {
+        "accomplishments": len(entries),
+        "impact_receipts": len(receipts),
+        "evidence_items": evidence_items,
+        "skills_demonstrated": len(skills),
+        "receipt_coverage_percent": _percentage(len(receipts), len(entries)),
+        "quantified_result_coverage_percent": _percentage(
+            quantified_receipts, len(receipts)
+        ),
+        "verification_coverage_percent": _percentage(
+            confirmed_receipts, len(receipts)
+        ),
+        "evidence_coverage_percent": _percentage(
+            receipts_with_evidence, len(receipts)
+        ),
+        "evidence_depth": round(evidence_items / len(receipts), 1) if receipts else 0,
+        "confirmed_assertions": confirmed_assertions,
+    }
+
+    subject_name = _clean_string(current_user.get("name"), "BragStack Member")
+    subject_role = _clean_string(
+        role_title,
+        _clean_string(
+            current_user.get("headline"),
+            _clean_string(current_user.get("role_title"), "Professional"),
+        ),
+    )
+
+    if start_date and end_date:
+        period = {
+            "key": "custom",
+            "label": f"{start_date.isoformat()} through {end_date.isoformat()}",
+            "start_date": start_date.isoformat(),
+            "end_date": end_date.isoformat(),
+            "date_basis": "entry_date",
+        }
+    else:
+        period = {
+            "key": "all-time",
+            "label": "All recorded work",
+            "start_date": None,
+            "end_date": None,
+            "date_basis": "entry_date",
+        }
+
+    review_summary = _build_review_narrative(
+        subject_name=subject_name,
+        entries_count=len(entries),
+        receipts_count=len(receipts),
+        evidence_count=evidence_items,
+        confirmed_receipts=confirmed_receipts,
+        quantified_results=quantified_receipts,
+        categories=categories,
+        skills=skills,
+    )
+
+    talking_points = [
+        {
+            "title": item["title"],
+            "result": item.get("result", ""),
+            "category": item.get("category", ""),
+        }
+        for item in signature_accomplishments[:5]
+    ]
+
+    return {
+        "packet": {
+            "kind": "performance-review",
+            "title": "Performance Review Packet",
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+            "confidential": confidential,
+            "context": {
+                "career_area": _clean_string(career_area),
+                "organization": _clean_string(organization),
+            },
+            "subject": {
+                "name": subject_name,
+                "role": subject_role,
+                "location": _clean_string(current_user.get("location")),
+            },
+            "period": period,
+            "scorecard": scorecard,
+            "impact_analytics": {
+                "categories": dict(categories.most_common()),
+                "top_skills": dict(skills.most_common()),
+                "trust_signals": dict(trust_signals.most_common()),
+                "activity_by_month": dict(sorted(activity_by_month.items())),
+            },
+            "skill_details": skill_details[:20],
+            "signature_accomplishments": signature_accomplishments,
+            "measurable_results": measurable_results[:12],
+            "contribution_records": contribution_records[:12],
+            "receipt_records": receipt_records,
+            "evidence_index": evidence_index,
+            "review_summary": review_summary,
+            "talking_points": talking_points,
+        }
+    }
+
+
+def _parse_period(start_date: str | None, end_date: str | None) -> tuple[date | None, date | None]:
+    if bool(start_date) != bool(end_date):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="start_date and end_date must be provided together",
+        )
+
+    if not start_date or not end_date:
+        return None, None
+
+    try:
+        parsed_start = date.fromisoformat(start_date)
+        parsed_end = date.fromisoformat(end_date)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="start_date and end_date must use YYYY-MM-DD format",
+        ) from exc
+
+    if parsed_end < parsed_start:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="end_date must be on or after start_date",
+        )
+
+    return parsed_start, parsed_end
+
+
+@router.get("/performance-review")
+def get_performance_review_packet(
+    start_date: str | None = Query(None),
+    end_date: str | None = Query(None),
+    career_area: str | None = Query(None, max_length=120),
+    role_title: str | None = Query(None, max_length=160),
+    organization: str | None = Query(None, max_length=180),
+    confidential: bool = Query(True),
+    current_user: dict = Depends(get_current_user),
+):
+    """Return all data required to render a complete paper-first review packet."""
+
+    parsed_start, parsed_end = _parse_period(start_date, end_date)
+    return _build_packet(
+        current_user=current_user,
+        start_date=parsed_start,
+        end_date=parsed_end,
+        career_area=career_area,
+        role_title=role_title,
+        organization=organization,
+        confidential=confidential,
+    )

--- a/backend/app/reports_routes.py
+++ b/backend/app/reports_routes.py
@@ -8,6 +8,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, status
 
 from app.auth import get_current_user
 from app.database import entries_collection, impact_receipts_collection
+from app.plans import require_feature
 
 
 router = APIRouter(prefix="/reports", tags=["reports"])
@@ -61,6 +62,14 @@ def _has_quantified_result(value: str) -> bool:
     """Return True when a result contains a numeric signal."""
 
     return bool(re.search(r"\d", value or ""))
+
+
+def _percentage(numerator: int, denominator: int) -> int:
+    """Return a whole-number percentage with a safe zero denominator."""
+
+    if denominator <= 0:
+        return 0
+    return round((numerator / denominator) * 100)
 
 
 def _entries_in_period(
@@ -186,6 +195,7 @@ def _build_report(
 
     evidence_items = 0
     public_evidence_items = 0
+    receipts_with_evidence = 0
     confirmed_receipts = 0
     confirmed_assertions = 0
     quantified_results = 0
@@ -193,6 +203,9 @@ def _build_report(
     for receipt in receipts:
         evidence = receipt.get("evidence", [])
         evidence_items += len(evidence)
+        if evidence:
+            receipts_with_evidence += 1
+
         public_evidence_items += sum(
             1 for item in evidence if item.get("is_public", False)
         )
@@ -258,6 +271,7 @@ def _build_report(
             ),
             "evidence_items": evidence_items,
             "public_evidence_items": public_evidence_items,
+            "receipts_with_evidence": receipts_with_evidence,
             "confirmed_receipts": confirmed_receipts,
             "confirmed_assertions": confirmed_assertions,
             "quantified_results": quantified_results,
@@ -268,6 +282,102 @@ def _build_report(
         "trust_signals": _sorted_counts(trust_signals),
         "highlights": highlights[:20],
         "resume_bullets": resume_bullets[:25],
+    }
+
+
+def _build_performance_packet(
+    *,
+    current_user: dict,
+    start_date: date | None = None,
+    end_date: date | None = None,
+) -> dict:
+    """Build structured, career-neutral data for a premium review packet."""
+
+    require_feature(current_user, "performance_review_builder")
+
+    if start_date and end_date:
+        period_label = f"{start_date.isoformat()} through {end_date.isoformat()}"
+        period_key = "custom"
+    else:
+        period_label = "All recorded work"
+        period_key = "all-time"
+
+    report = _build_report(
+        user_id=str(current_user["_id"]),
+        period_key=period_key,
+        period_label=period_label,
+        start_date=start_date,
+        end_date=end_date,
+    )
+
+    totals = report["totals"]
+    entries_count = totals["entries"]
+    receipt_count = totals["impact_receipts"]
+
+    signature_accomplishments = sorted(
+        report["highlights"],
+        key=lambda item: (
+            _has_quantified_result(item.get("result", "")),
+            item.get("has_receipt", False),
+            len(item.get("trust_signals", [])),
+            item.get("entry_date") or "",
+        ),
+        reverse=True,
+    )[:6]
+
+    measurable_results = [
+        item
+        for item in report["highlights"]
+        if _has_quantified_result(item.get("result", ""))
+    ][:8]
+
+    scorecard = {
+        "accomplishments": entries_count,
+        "impact_receipts": receipt_count,
+        "evidence_items": totals["evidence_items"],
+        "skills_demonstrated": len(report["top_skills"]),
+        "receipt_coverage_percent": _percentage(receipt_count, entries_count),
+        "quantified_result_coverage_percent": _percentage(
+            totals["quantified_results"], receipt_count
+        ),
+        "verification_coverage_percent": _percentage(
+            totals["confirmed_receipts"], receipt_count
+        ),
+        "evidence_coverage_percent": _percentage(
+            totals["receipts_with_evidence"], receipt_count
+        ),
+        "evidence_depth": (
+            round(totals["evidence_items"] / receipt_count, 1)
+            if receipt_count
+            else 0
+        ),
+    }
+
+    return {
+        "packet": {
+            "kind": "performance-review",
+            "title": "Performance Review Packet",
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+            "subject": {
+                "name": str(current_user.get("name") or "BragStack Member"),
+                "role": str(
+                    current_user.get("headline")
+                    or current_user.get("role_title")
+                    or "Professional"
+                ),
+                "location": str(current_user.get("location") or ""),
+            },
+            "period": report["period"],
+            "scorecard": scorecard,
+            "impact_analytics": {
+                "categories": report["categories"],
+                "top_skills": report["top_skills"],
+                "trust_signals": report["trust_signals"],
+            },
+            "signature_accomplishments": signature_accomplishments,
+            "measurable_results": measurable_results,
+            "review_summary": report["summary"],
+        }
     }
 
 
@@ -332,6 +442,50 @@ def get_custom_report(
         user_id=str(current_user["_id"]),
         period_key="custom",
         period_label=f"{parsed_start.isoformat()} through {parsed_end.isoformat()}",
+        start_date=parsed_start,
+        end_date=parsed_end,
+    )
+
+
+@router.get("/performance-packet")
+def get_performance_packet(
+    start_date: str | None = Query(
+        None, description="Optional inclusive YYYY-MM-DD start date"
+    ),
+    end_date: str | None = Query(
+        None, description="Optional inclusive YYYY-MM-DD end date"
+    ),
+    current_user: dict = Depends(get_current_user),
+):
+    """Return structured data for the premium paper-first review packet."""
+
+    if bool(start_date) != bool(end_date):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="start_date and end_date must be provided together",
+        )
+
+    parsed_start = None
+    parsed_end = None
+
+    if start_date and end_date:
+        try:
+            parsed_start = date.fromisoformat(start_date)
+            parsed_end = date.fromisoformat(end_date)
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="start_date and end_date must use YYYY-MM-DD format",
+            ) from exc
+
+        if parsed_end < parsed_start:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="end_date must be on or after start_date",
+            )
+
+    return _build_performance_packet(
+        current_user=current_user,
         start_date=parsed_start,
         end_date=parsed_end,
     )

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -10,3 +10,4 @@ email-validator
 pytest
 httpx
 mongomock
+reportlab==4.4.3

--- a/backend/tests/test_performance_packet.py
+++ b/backend/tests/test_performance_packet.py
@@ -1,0 +1,245 @@
+from datetime import datetime, timezone
+
+import mongomock
+import pytest
+from bson import ObjectId
+from fastapi.testclient import TestClient
+
+import app.performance_packet_routes as packet_routes
+from app.main import app
+
+
+client = TestClient(app)
+
+
+@pytest.fixture
+def packet_context(monkeypatch):
+    mock_client = mongomock.MongoClient()
+    mock_db = mock_client["bragstack_packet_test"]
+    entries = mock_db["entries"]
+    receipts = mock_db["impact_receipts"]
+
+    monkeypatch.setattr(packet_routes, "entries_collection", entries)
+    monkeypatch.setattr(packet_routes, "impact_receipts_collection", receipts)
+
+    yield entries, receipts
+
+    app.dependency_overrides.clear()
+
+
+def test_free_user_cannot_generate_performance_packet(packet_context):
+    user = {
+        "_id": ObjectId(),
+        "name": "Free Member",
+        "email": "free@example.com",
+        "plan": "free",
+    }
+    app.dependency_overrides[packet_routes.get_current_user] = lambda: user
+
+    response = client.get("/packets/performance-review")
+
+    assert response.status_code == 403
+    assert response.json()["detail"]["code"] == "paid_feature_required"
+    assert response.json()["detail"]["feature"] == "performance_review_builder"
+
+
+def test_pro_packet_is_career_neutral_and_contains_full_dossier_data(packet_context):
+    entries, receipts = packet_context
+    user = {
+        "_id": ObjectId(),
+        "name": "Jordan Ellis",
+        "email": "jordan@example.com",
+        "headline": "Community Programs Coordinator",
+        "location": "Columbus, Ohio",
+        "plan": "pro",
+    }
+    app.dependency_overrides[packet_routes.get_current_user] = lambda: user
+
+    first_entry = entries.insert_one(
+        {
+            "user_id": str(user["_id"]),
+            "title": "Expanded after-school family participation",
+            "category": "Community Engagement",
+            "entry_type": "Current Job",
+            "entry_date": "2026-03-12",
+            "tags": ["Program Coordination", "Family Engagement"],
+            "impact": "Increased family participation by 28% across 4 sites.",
+            "resume_bullet": "Expanded family participation across community programs.",
+            "created_at": datetime.now(timezone.utc),
+        }
+    )
+    second_entry = entries.insert_one(
+        {
+            "user_id": str(user["_id"]),
+            "title": "Created volunteer onboarding workshop",
+            "category": "Training",
+            "entry_type": "Current Job",
+            "entry_date": "2026-05-20",
+            "tags": ["Training", "Communication"],
+            "impact": "Prepared 18 volunteers for summer programming.",
+            "resume_bullet": "Designed a volunteer onboarding workshop.",
+            "created_at": datetime.now(timezone.utc),
+        }
+    )
+
+    receipts.insert_one(
+        {
+            "user_id": str(user["_id"]),
+            "source_entry_id": str(first_entry.inserted_id),
+            "accomplishment": "Expanded after-school family participation",
+            "contribution": "Coordinated outreach, translated materials, and redesigned registration follow-up.",
+            "result": "Increased family participation by 28% across 4 sites.",
+            "evidence": [
+                {
+                    "title": "Spring participation report",
+                    "evidence_type": "documentation",
+                    "reference": "SPRING-2026",
+                    "description": "Attendance comparison for participating sites.",
+                    "is_public": False,
+                },
+                {
+                    "title": "Family feedback summary",
+                    "evidence_type": "customer-feedback",
+                    "reference": "Feedback survey",
+                    "description": "Compiled caregiver comments.",
+                    "is_public": False,
+                },
+            ],
+            "skills": ["Program Coordination", "Family Engagement", "Communication"],
+            "credit": [
+                {
+                    "name": "Outreach Team",
+                    "contribution": "Supported multilingual family outreach.",
+                }
+            ],
+            "confirmations": [
+                {
+                    "name": "Program Director",
+                    "role": "Director",
+                    "confirmation_type": "stakeholder",
+                    "status": "confirmed",
+                }
+            ],
+            "trust_signals": ["evidence-linked", "stakeholder-verified"],
+            "is_public": False,
+            "created_at": datetime.now(timezone.utc),
+            "updated_at": datetime.now(timezone.utc),
+        }
+    )
+
+    receipts.insert_one(
+        {
+            "user_id": str(user["_id"]),
+            "source_entry_id": str(second_entry.inserted_id),
+            "accomplishment": "Created volunteer onboarding workshop",
+            "contribution": "Designed the workshop, materials, and facilitation plan.",
+            "result": "Prepared 18 volunteers for summer programming.",
+            "evidence": [],
+            "skills": ["Training", "Communication"],
+            "credit": [],
+            "confirmations": [],
+            "trust_signals": ["self-documented"],
+            "is_public": False,
+            "created_at": datetime.now(timezone.utc),
+            "updated_at": datetime.now(timezone.utc),
+        }
+    )
+
+    response = client.get(
+        "/packets/performance-review",
+        params={
+            "start_date": "2026-01-01",
+            "end_date": "2026-06-30",
+            "career_area": "Nonprofit",
+            "role_title": "Community Programs Coordinator",
+            "organization": "Neighborhood Learning Collaborative",
+            "confidential": "true",
+        },
+    )
+
+    assert response.status_code == 200
+    packet = response.json()["packet"]
+
+    assert packet["subject"]["name"] == "Jordan Ellis"
+    assert packet["subject"]["role"] == "Community Programs Coordinator"
+    assert packet["context"]["career_area"] == "Nonprofit"
+    assert packet["context"]["organization"] == "Neighborhood Learning Collaborative"
+    assert packet["confidential"] is True
+
+    assert packet["scorecard"]["accomplishments"] == 2
+    assert packet["scorecard"]["impact_receipts"] == 2
+    assert packet["scorecard"]["evidence_items"] == 2
+    assert packet["scorecard"]["receipt_coverage_percent"] == 100
+    assert packet["scorecard"]["quantified_result_coverage_percent"] == 100
+    assert packet["scorecard"]["evidence_coverage_percent"] == 50
+    assert packet["scorecard"]["verification_coverage_percent"] == 50
+    assert packet["scorecard"]["evidence_depth"] == 1.0
+
+    assert packet["impact_analytics"]["activity_by_month"] == {
+        "2026-03": 1,
+        "2026-05": 1,
+    }
+    assert packet["impact_analytics"]["categories"] == {
+        "Community Engagement": 1,
+        "Training": 1,
+    }
+    assert packet["impact_analytics"]["top_skills"]["Communication"] == 2
+
+    assert len(packet["signature_accomplishments"]) == 2
+    assert packet["measurable_results"][0]["metric_display"] in {"28%", "18"}
+    assert len(packet["contribution_records"]) == 2
+    assert len(packet["receipt_records"]) == 2
+    assert len(packet["evidence_index"]) == 2
+    assert packet["receipt_records"][0]["reference"].startswith("BS-2026-")
+    assert "Community Programs Coordinator" not in packet["review_summary"] or packet["review_summary"]
+    assert "documented 2 accomplishments" in packet["review_summary"]
+
+
+def test_packet_period_validation_and_filtering(packet_context):
+    entries, _ = packet_context
+    user = {
+        "_id": ObjectId(),
+        "name": "Review User",
+        "email": "review@example.com",
+        "plan": "pro",
+    }
+    app.dependency_overrides[packet_routes.get_current_user] = lambda: user
+
+    entries.insert_many(
+        [
+            {
+                "user_id": str(user["_id"]),
+                "title": "Spring work",
+                "category": "Service",
+                "entry_type": "Current Job",
+                "entry_date": "2026-04-10",
+                "tags": ["Service"],
+                "impact": "Completed spring milestone.",
+            },
+            {
+                "user_id": str(user["_id"]),
+                "title": "Summer work",
+                "category": "Service",
+                "entry_type": "Current Job",
+                "entry_date": "2026-07-10",
+                "tags": ["Service"],
+                "impact": "Completed summer milestone.",
+            },
+        ]
+    )
+
+    response = client.get(
+        "/packets/performance-review?start_date=2026-07-01&end_date=2026-07-31"
+    )
+    assert response.status_code == 200
+    packet = response.json()["packet"]
+    assert packet["scorecard"]["accomplishments"] == 1
+    assert packet["signature_accomplishments"][0]["title"] == "Summer work"
+
+    missing_end = client.get("/packets/performance-review?start_date=2026-07-01")
+    assert missing_end.status_code == 422
+
+    reversed_period = client.get(
+        "/packets/performance-review?start_date=2026-08-01&end_date=2026-07-01"
+    )
+    assert reversed_period.status_code == 422

--- a/backend/tests/test_performance_packet_pdf.py
+++ b/backend/tests/test_performance_packet_pdf.py
@@ -1,0 +1,182 @@
+from datetime import datetime, timezone
+
+import mongomock
+import pytest
+from bson import ObjectId
+from fastapi.testclient import TestClient
+
+import app.performance_packet_routes as packet_routes
+from app.main import app
+
+
+client = TestClient(app)
+
+
+@pytest.fixture
+def pdf_context(monkeypatch):
+    mock_client = mongomock.MongoClient()
+    mock_db = mock_client["bragstack_packet_pdf_test"]
+    entries = mock_db["entries"]
+    receipts = mock_db["impact_receipts"]
+
+    monkeypatch.setattr(packet_routes, "entries_collection", entries)
+    monkeypatch.setattr(packet_routes, "impact_receipts_collection", receipts)
+
+    yield entries, receipts
+
+    app.dependency_overrides.clear()
+
+
+def _seed_packet(entries, receipts, user):
+    entry = entries.insert_one(
+        {
+            "user_id": str(user["_id"]),
+            "title": "Expanded family participation",
+            "category": "Community Engagement",
+            "entry_type": "Current Job",
+            "entry_date": "2026-03-12",
+            "tags": ["Program Coordination", "Family Engagement"],
+            "impact": "Increased family participation by 28% across 4 sites.",
+            "resume_bullet": "Expanded family participation across community programs.",
+            "created_at": datetime.now(timezone.utc),
+        }
+    )
+    receipts.insert_one(
+        {
+            "user_id": str(user["_id"]),
+            "source_entry_id": str(entry.inserted_id),
+            "accomplishment": "Expanded family participation",
+            "contribution": "Coordinated outreach and redesigned registration follow-up.",
+            "result": "Increased family participation by 28% across 4 sites.",
+            "evidence": [
+                {
+                    "title": "Spring participation dashboard",
+                    "evidence_type": "documentation",
+                    "reference": "https://example.com/evidence/spring-2026",
+                    "description": "Attendance comparison for participating sites.",
+                    "is_public": False,
+                }
+            ],
+            "skills": ["Program Coordination", "Family Engagement"],
+            "credit": [],
+            "confirmations": [
+                {
+                    "name": "Program Director",
+                    "role": "Director",
+                    "confirmation_type": "stakeholder",
+                    "status": "confirmed",
+                }
+            ],
+            "trust_signals": ["evidence-linked", "stakeholder-verified"],
+            "is_public": False,
+            "created_at": datetime.now(timezone.utc),
+            "updated_at": datetime.now(timezone.utc),
+        }
+    )
+
+
+def test_free_user_cannot_export_pdf(pdf_context):
+    user = {
+        "_id": ObjectId(),
+        "name": "Free Member",
+        "email": "free@example.com",
+        "plan": "free",
+    }
+    app.dependency_overrides[packet_routes.get_current_user] = lambda: user
+
+    response = client.get("/packets/performance-review.pdf")
+
+    assert response.status_code == 403
+    assert response.json()["detail"]["code"] == "paid_feature_required"
+    assert response.json()["detail"]["feature"] == "export_pdf"
+
+
+def test_pro_user_downloads_real_pdf_with_expected_filename(pdf_context):
+    entries, receipts = pdf_context
+    user = {
+        "_id": ObjectId(),
+        "name": "Jordan Ellis",
+        "email": "jordan@example.com",
+        "headline": "Community Programs Coordinator",
+        "location": "Columbus, Ohio",
+        "plan": "pro",
+    }
+    app.dependency_overrides[packet_routes.get_current_user] = lambda: user
+    _seed_packet(entries, receipts, user)
+
+    response = client.get(
+        "/packets/performance-review.pdf",
+        params={
+            "start_date": "2026-01-01",
+            "end_date": "2026-06-30",
+            "career_area": "Nonprofit",
+            "role_title": "Community Programs Coordinator",
+            "organization": "Neighborhood Learning Collaborative",
+            "confidential": "true",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("application/pdf")
+    assert response.headers["cache-control"] == "private, no-store"
+    assert "Jordan-Ellis-performance-review-2026-01-01-to-2026-06-30.pdf" in response.headers["content-disposition"]
+    assert response.content.startswith(b"%PDF")
+    assert len(response.content) > 5000
+
+
+def test_pdf_export_handles_long_evidence_index(pdf_context):
+    entries, receipts = pdf_context
+    user = {
+        "_id": ObjectId(),
+        "name": "Morgan Reyes",
+        "email": "morgan@example.com",
+        "headline": "Operations Supervisor",
+        "plan": "pro",
+    }
+    app.dependency_overrides[packet_routes.get_current_user] = lambda: user
+
+    entry = entries.insert_one(
+        {
+            "user_id": str(user["_id"]),
+            "title": "Improved shift handoff quality",
+            "category": "Operations",
+            "entry_type": "Current Job",
+            "entry_date": "2026-06-10",
+            "tags": ["Operations", "Coaching", "Quality"],
+            "impact": "Reduced repeat handoff issues by 21% across 3 shifts.",
+            "created_at": datetime.now(timezone.utc),
+        }
+    )
+
+    receipts.insert_one(
+        {
+            "user_id": str(user["_id"]),
+            "source_entry_id": str(entry.inserted_id),
+            "accomplishment": "Improved shift handoff quality",
+            "contribution": "Built a shared handoff checklist and coached team leads.",
+            "result": "Reduced repeat handoff issues by 21% across 3 shifts.",
+            "evidence": [
+                {
+                    "title": f"Handoff quality record {index}",
+                    "evidence_type": "documentation",
+                    "reference": f"OPS-{index:03d}",
+                    "description": "Quality review evidence.",
+                    "is_public": False,
+                }
+                for index in range(1, 31)
+            ],
+            "skills": ["Operations", "Coaching", "Quality"],
+            "credit": [],
+            "confirmations": [],
+            "trust_signals": ["evidence-linked"],
+            "is_public": False,
+            "created_at": datetime.now(timezone.utc),
+            "updated_at": datetime.now(timezone.utc),
+        }
+    )
+
+    response = client.get("/packets/performance-review.pdf")
+
+    assert response.status_code == 200
+    assert response.content.startswith(b"%PDF")
+    assert len(response.content) > 8000

--- a/backend/tests/test_reports.py
+++ b/backend/tests/test_reports.py
@@ -206,3 +206,102 @@ def test_custom_report_validates_dates_and_filters_period(report_context):
         "/reports/custom?start_date=2026-08-01&end_date=2026-07-01"
     )
     assert invalid.status_code == 422
+
+
+def test_performance_packet_requires_pro_entitlement(report_context):
+    user, _, _ = report_context
+    user["plan"] = "free"
+
+    response = client.get("/reports/performance-packet")
+
+    assert response.status_code == 403
+    detail = response.json()["detail"]
+    assert detail["code"] == "paid_feature_required"
+    assert detail["feature"] == "performance_review_builder"
+
+
+def test_performance_packet_builds_transparent_scorecard(report_context):
+    user, entries, receipts = report_context
+    user["plan"] = "pro"
+    user["headline"] = "Community Programs Coordinator"
+
+    first = entries.insert_one(
+        {
+            "user_id": str(user["_id"]),
+            "title": "Expanded workshop access",
+            "category": "Community Impact",
+            "entry_type": "Current Job",
+            "entry_date": "2026-07-10",
+            "tags": ["Facilitation", "Program Planning"],
+            "impact": "Increased monthly attendance by 40%.",
+            "resume_bullet": "Expanded access to recurring community workshops.",
+        }
+    )
+    second = entries.insert_one(
+        {
+            "user_id": str(user["_id"]),
+            "title": "Improved volunteer onboarding",
+            "category": "Operations",
+            "entry_type": "Current Job",
+            "entry_date": "2026-07-18",
+            "tags": ["Training"],
+            "impact": "Standardized onboarding materials.",
+            "resume_bullet": "Standardized volunteer onboarding.",
+        }
+    )
+
+    receipts.insert_one(
+        {
+            "user_id": str(user["_id"]),
+            "source_entry_id": str(first.inserted_id),
+            "accomplishment": "Expanded workshop access",
+            "contribution": "Redesigned scheduling and outreach.",
+            "result": "Increased monthly attendance by 40%.",
+            "evidence": [
+                {"title": "Attendance report", "is_public": False},
+                {"title": "Program calendar", "is_public": False},
+            ],
+            "skills": ["Facilitation", "Program Planning"],
+            "confirmations": [
+                {
+                    "name": "Program Director",
+                    "confirmation_type": "supervisor",
+                    "status": "confirmed",
+                }
+            ],
+            "trust_signals": ["supervisor-verified"],
+        }
+    )
+    receipts.insert_one(
+        {
+            "user_id": str(user["_id"]),
+            "source_entry_id": str(second.inserted_id),
+            "accomplishment": "Improved volunteer onboarding",
+            "contribution": "Created a repeatable onboarding guide.",
+            "result": "Standardized onboarding materials.",
+            "evidence": [],
+            "skills": ["Training"],
+            "confirmations": [],
+            "trust_signals": [],
+        }
+    )
+
+    response = client.get(
+        "/reports/performance-packet?start_date=2026-07-01&end_date=2026-07-31"
+    )
+
+    assert response.status_code == 200
+    packet = response.json()["packet"]
+    scorecard = packet["scorecard"]
+
+    assert packet["subject"]["role"] == "Community Programs Coordinator"
+    assert packet["period"]["start_date"] == "2026-07-01"
+    assert scorecard["accomplishments"] == 2
+    assert scorecard["impact_receipts"] == 2
+    assert scorecard["evidence_items"] == 2
+    assert scorecard["receipt_coverage_percent"] == 100
+    assert scorecard["quantified_result_coverage_percent"] == 50
+    assert scorecard["verification_coverage_percent"] == 50
+    assert scorecard["evidence_coverage_percent"] == 50
+    assert scorecard["evidence_depth"] == 1.0
+    assert packet["signature_accomplishments"][0]["title"] == "Expanded workshop access"

--- a/frontend/src/ImpactReceiptsPage.jsx
+++ b/frontend/src/ImpactReceiptsPage.jsx
@@ -33,7 +33,11 @@ function ImpactReceiptsPage() {
   }
 
   useEffect(() => {
-    void loadReceipts();
+    const timeoutId = window.setTimeout(() => {
+      void loadReceipts();
+    }, 0);
+
+    return () => window.clearTimeout(timeoutId);
   }, []);
 
   const stats = useMemo(() => {

--- a/frontend/src/PacketBuilderPanel.css
+++ b/frontend/src/PacketBuilderPanel.css
@@ -1,0 +1,180 @@
+.packet-builder-pro {
+  margin: 22px 0 26px;
+  padding: 24px;
+  border: 1px solid rgba(27, 74, 78, 0.18);
+  border-radius: 20px;
+  background:
+    linear-gradient(135deg, rgba(24, 78, 82, 0.08), transparent 52%),
+    #ffffff;
+  box-shadow: 0 18px 48px rgba(23, 32, 42, 0.07);
+}
+
+.packet-builder-pro-header {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 14px;
+  align-items: start;
+}
+
+.packet-builder-pro-icon {
+  width: 44px;
+  height: 44px;
+  border-radius: 14px;
+  display: grid;
+  place-items: center;
+  background: #173f43;
+  color: white;
+}
+
+.packet-builder-pro-header span {
+  display: block;
+  margin-bottom: 5px;
+  color: #1c575a;
+  font-size: 10px;
+  font-weight: 850;
+  letter-spacing: 0.11em;
+  text-transform: uppercase;
+}
+
+.packet-builder-pro-header h2 {
+  margin: 0;
+  font-size: 23px;
+}
+
+.packet-builder-pro-header p {
+  margin: 7px 0 0;
+  max-width: 760px;
+  color: #657077;
+  line-height: 1.55;
+}
+
+.packet-builder-fields {
+  margin-top: 20px;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.packet-builder-fields label {
+  display: grid;
+  gap: 7px;
+}
+
+.packet-builder-fields label > span {
+  color: #4e5960;
+  font-size: 12px;
+  font-weight: 750;
+}
+
+.packet-builder-fields input,
+.packet-builder-fields select {
+  width: 100%;
+  min-height: 42px;
+  border: 1px solid #d9dde0;
+  border-radius: 11px;
+  background: white;
+  color: #17202a;
+  padding: 0 11px;
+  font: inherit;
+  font-size: 13px;
+}
+
+.packet-builder-fields input:focus,
+.packet-builder-fields select:focus {
+  outline: 2px solid rgba(31, 85, 89, 0.18);
+  border-color: #1f5559;
+}
+
+.packet-builder-pro-footer {
+  margin-top: 18px;
+  padding-top: 16px;
+  border-top: 1px solid #e6e8e8;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+}
+
+.packet-confidential-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+}
+
+.packet-confidential-toggle input {
+  width: 16px;
+  height: 16px;
+  accent-color: #173f43;
+}
+
+.packet-confidential-toggle > span {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  color: #48545a;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.packet-builder-pro-action {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+
+.packet-builder-pro-action > div {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: #6b7479;
+  font-size: 11px;
+}
+
+.packet-builder-pro-action button {
+  border: 0;
+  border-radius: 12px;
+  background: #173f43;
+  color: white;
+  padding: 12px 16px;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 850;
+  cursor: pointer;
+  box-shadow: 0 10px 26px rgba(23, 63, 67, 0.18);
+}
+
+.packet-builder-pro-action button:disabled {
+  cursor: wait;
+  opacity: 0.7;
+}
+
+.packet-builder-pro-error {
+  margin: 14px 0 0;
+  padding: 11px 13px;
+  border: 1px solid rgba(139, 87, 36, 0.22);
+  border-radius: 11px;
+  background: #fff8eb;
+  color: #714b22;
+  font-size: 12px;
+}
+
+@media (max-width: 800px) {
+  .packet-builder-fields {
+    grid-template-columns: 1fr;
+  }
+
+  .packet-builder-pro-footer {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .packet-builder-pro-action {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .packet-builder-pro-action button {
+    width: 100%;
+  }
+}

--- a/frontend/src/PacketBuilderPanel.jsx
+++ b/frontend/src/PacketBuilderPanel.jsx
@@ -1,0 +1,120 @@
+import { BriefcaseBusiness, FileStack, ShieldCheck } from "lucide-react";
+
+import "./PacketBuilderPanel.css";
+
+const CAREER_AREAS = [
+  "",
+  "Healthcare",
+  "Education",
+  "Technology",
+  "Sales",
+  "Operations",
+  "Skilled Trades",
+  "Creative",
+  "Customer Service",
+  "Management",
+  "Government",
+  "Nonprofit",
+  "Student",
+  "Other",
+];
+
+function PacketBuilderPanel({
+  options,
+  onChange,
+  onBuild,
+  isLoading,
+  error,
+}) {
+  function update(name, value) {
+    onChange((current) => ({
+      ...current,
+      [name]: value,
+    }));
+  }
+
+  return (
+    <section className="packet-builder-pro" aria-labelledby="packet-builder-title">
+      <div className="packet-builder-pro-header">
+        <div className="packet-builder-pro-icon">
+          <FileStack size={22} />
+        </div>
+        <div>
+          <span>BragStack Pro · Premium Artifact</span>
+          <h2 id="packet-builder-title">Build a Performance Review Packet</h2>
+          <p>
+            Create a physical-style career dossier with analytics, measurable
+            results, skills, contribution records, Impact Receipts, and an
+            evidence index. The language stays useful across any profession.
+          </p>
+        </div>
+      </div>
+
+      <div className="packet-builder-fields">
+        <label>
+          <span>Career / work area</span>
+          <select
+            value={options.careerArea}
+            onChange={(event) => update("careerArea", event.target.value)}
+          >
+            {CAREER_AREAS.map((area) => (
+              <option key={area || "neutral"} value={area}>
+                {area || "Career-neutral"}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label>
+          <span>Role title</span>
+          <input
+            type="text"
+            value={options.roleTitle}
+            onChange={(event) => update("roleTitle", event.target.value)}
+            placeholder="Use profile headline"
+            maxLength={160}
+          />
+        </label>
+
+        <label>
+          <span>Organization / team</span>
+          <input
+            type="text"
+            value={options.organization}
+            onChange={(event) => update("organization", event.target.value)}
+            placeholder="Optional"
+            maxLength={180}
+          />
+        </label>
+      </div>
+
+      <div className="packet-builder-pro-footer">
+        <label className="packet-confidential-toggle">
+          <input
+            type="checkbox"
+            checked={options.confidential}
+            onChange={(event) => update("confidential", event.target.checked)}
+          />
+          <span>
+            <ShieldCheck size={16} />
+            Mark packet confidential
+          </span>
+        </label>
+
+        <div className="packet-builder-pro-action">
+          <div>
+            <BriefcaseBusiness size={16} />
+            Uses the currently selected report period
+          </div>
+          <button type="button" onClick={onBuild} disabled={isLoading}>
+            {isLoading ? "Building packet…" : "Build my packet"}
+          </button>
+        </div>
+      </div>
+
+      {error && <p className="packet-builder-pro-error">{String(error)}</p>}
+    </section>
+  );
+}
+
+export default PacketBuilderPanel;

--- a/frontend/src/PerformancePacketExport.css
+++ b/frontend/src/PerformancePacketExport.css
@@ -1,0 +1,65 @@
+.packet-preview-toolbar-actions {
+  justify-self: end;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.packet-preview-toolbar .packet-download-button {
+  background: #173f43;
+  color: #fff;
+  border-color: #173f43;
+  box-shadow: 0 10px 28px rgba(23, 63, 67, 0.18);
+}
+
+.packet-preview-toolbar .packet-download-button:disabled {
+  cursor: wait;
+  opacity: 0.68;
+}
+
+.packet-preview-download-error {
+  width: min(900px, 100%);
+  margin: -10px auto 18px;
+  padding: 11px 14px;
+  border: 1px solid rgba(139, 87, 36, 0.22);
+  border-radius: 12px;
+  background: #fff8eb;
+  color: #714b22;
+  font-size: 13px;
+}
+
+@media (max-width: 700px) {
+  .packet-preview-toolbar-actions {
+    gap: 6px;
+  }
+
+  .packet-preview-toolbar-actions button {
+    padding-inline: 10px;
+  }
+}
+
+@media (max-width: 520px) {
+  .packet-preview-toolbar {
+    grid-template-columns: 1fr;
+  }
+
+  .packet-preview-toolbar > button,
+  .packet-preview-toolbar-actions {
+    width: 100%;
+  }
+
+  .packet-preview-toolbar-actions {
+    justify-self: stretch;
+  }
+
+  .packet-preview-toolbar-actions button {
+    flex: 1;
+    justify-content: center;
+  }
+}
+
+@media print {
+  .packet-preview-download-error {
+    display: none;
+  }
+}

--- a/frontend/src/PerformancePacketPages.css
+++ b/frontend/src/PerformancePacketPages.css
@@ -1,0 +1,856 @@
+.packet-document-page {
+  gap: 0;
+}
+
+.packet-page-lead {
+  margin: 17px 0 19px;
+  max-width: 650px;
+  color: #5f686d;
+  font-size: clamp(8px, 1.25vw, 11px);
+  line-height: 1.55;
+}
+
+.packet-document-section {
+  margin-top: 18px;
+}
+
+.packet-document-section.compact {
+  margin-top: 0;
+  border: 1px solid #dfdcd3;
+  border-radius: 11px;
+  padding: 14px;
+}
+
+.packet-document-section-title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+}
+
+.packet-document-section-title p {
+  margin: 0;
+  color: #667176;
+  font-size: clamp(7px, 1vw, 9px);
+  font-weight: 850;
+  letter-spacing: 0.11em;
+  text-transform: uppercase;
+}
+
+.packet-document-section-title h3 {
+  margin: 4px 0 0;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: clamp(14px, 2vw, 18px);
+}
+
+.packet-document-section-title svg {
+  color: #1f5559;
+}
+
+.packet-document-two-column {
+  margin-top: 18px;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.packet-kpi-ribbon {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  border: 1px solid #dcd9d0;
+  border-radius: 10px;
+  overflow: hidden;
+  background: #f8f6f0;
+}
+
+.packet-kpi-ribbon > div {
+  display: grid;
+  gap: 4px;
+  padding: 13px 15px;
+}
+
+.packet-kpi-ribbon > div + div {
+  border-left: 1px solid #dfdcd4;
+}
+
+.packet-kpi-ribbon strong {
+  font-family: Georgia, "Times New Roman", serif;
+  color: #173f43;
+  font-size: clamp(20px, 3.2vw, 29px);
+}
+
+.packet-kpi-ribbon span {
+  color: #6b7478;
+  font-size: clamp(7px, 1vw, 9px);
+  line-height: 1.3;
+}
+
+.packet-activity-chart {
+  height: clamp(125px, 19vw, 165px);
+  margin-top: 14px;
+  display: flex;
+  align-items: stretch;
+  gap: 7px;
+  border-bottom: 1px solid #d9d6ce;
+}
+
+.packet-activity-column {
+  min-width: 0;
+  flex: 1 1 0;
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  gap: 4px;
+  text-align: center;
+}
+
+.packet-activity-value {
+  color: #566166;
+  font-size: clamp(7px, 0.95vw, 8px);
+  font-weight: 800;
+}
+
+.packet-activity-bar-wrap {
+  display: flex;
+  align-items: end;
+  justify-content: center;
+  min-height: 0;
+}
+
+.packet-activity-bar {
+  display: block;
+  width: min(30px, 64%);
+  min-height: 5px;
+  border-radius: 5px 5px 0 0;
+  background: #1f5559;
+}
+
+.packet-activity-column small {
+  min-height: 20px;
+  color: #777e82;
+  font-size: clamp(6px, 0.9vw, 8px);
+  white-space: nowrap;
+}
+
+.packet-horizontal-bars {
+  margin-top: 10px;
+  display: grid;
+  gap: 8px;
+}
+
+.packet-horizontal-bars > div {
+  display: grid;
+  gap: 4px;
+}
+
+.packet-horizontal-bar-copy {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  color: #4c575c;
+  font-size: clamp(7px, 1vw, 9px);
+}
+
+.packet-horizontal-bar-copy strong {
+  color: #173f43;
+}
+
+.packet-horizontal-bar-track {
+  height: 4px;
+  border-radius: 999px;
+  background: #ebe8df;
+  overflow: hidden;
+}
+
+.packet-horizontal-bar-track span {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: #1f5559;
+}
+
+.packet-document-empty {
+  margin-top: 16px;
+  min-height: 90px;
+  padding: 16px;
+  border: 1px dashed #d7d4cc;
+  border-radius: 10px;
+  display: grid;
+  place-items: center;
+  align-content: center;
+  gap: 7px;
+  color: #737b7f;
+  text-align: center;
+}
+
+.packet-document-empty svg {
+  color: #1f5559;
+}
+
+.packet-document-empty p {
+  margin: 0;
+  max-width: 430px;
+  font-size: clamp(7px, 1.05vw, 9px);
+  line-height: 1.45;
+}
+
+.packet-accomplishment-list {
+  display: grid;
+  gap: 8px;
+}
+
+.packet-accomplishment-record {
+  display: grid;
+  grid-template-columns: 36px 1fr auto;
+  gap: 12px;
+  align-items: start;
+  padding: 12px 0;
+  border-bottom: 1px solid #e3e0d8;
+}
+
+.packet-accomplishment-number {
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  background: #173f43;
+  color: white;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: clamp(8px, 1.1vw, 10px);
+}
+
+.packet-record-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+  color: #777e82;
+  font-size: clamp(6px, 0.9vw, 8px);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.packet-verified-chip {
+  display: inline-flex !important;
+  align-items: center;
+  gap: 3px;
+  color: #1d5b4f !important;
+  font-weight: 850;
+}
+
+.packet-accomplishment-record h3 {
+  margin: 5px 0 0;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: clamp(13px, 1.9vw, 17px);
+}
+
+.packet-accomplishment-record p {
+  margin: 5px 0 0;
+  color: #5d676c;
+  font-size: clamp(7px, 1.05vw, 9px);
+  line-height: 1.45;
+}
+
+.packet-record-tags {
+  margin-top: 7px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.packet-record-tags span,
+.packet-receipt-skills span,
+.packet-summary-context span {
+  border-radius: 999px;
+  background: #f0eee7;
+  color: #4f5a5f;
+  padding: 3px 6px;
+  font-size: clamp(6px, 0.9vw, 8px);
+}
+
+.packet-record-proof {
+  min-width: 48px;
+  display: grid;
+  gap: 2px;
+  text-align: right;
+}
+
+.packet-record-proof strong {
+  font-family: Georgia, "Times New Roman", serif;
+  color: #173f43;
+  font-size: clamp(15px, 2.2vw, 20px);
+}
+
+.packet-record-proof span {
+  color: #7b8285;
+  font-size: clamp(6px, 0.85vw, 7px);
+  text-transform: uppercase;
+}
+
+.packet-result-hero {
+  margin: 18px 0;
+  padding: 13px 16px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  border-left: 4px solid #b68b4c;
+  background: #f5f2e9;
+}
+
+.packet-result-hero svg {
+  color: #173f43;
+}
+
+.packet-result-hero div {
+  display: flex;
+  align-items: baseline;
+  gap: 9px;
+}
+
+.packet-result-hero strong {
+  font-family: Georgia, "Times New Roman", serif;
+  color: #173f43;
+  font-size: clamp(23px, 3.5vw, 32px);
+}
+
+.packet-result-hero span {
+  color: #5f686d;
+  font-size: clamp(7px, 1vw, 9px);
+}
+
+.packet-result-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.packet-result-grid article {
+  min-height: 132px;
+  padding: 13px;
+  border: 1px solid #dedbd2;
+  border-radius: 10px;
+  background: white;
+}
+
+.packet-result-metric {
+  margin-bottom: 7px;
+  font-family: Georgia, "Times New Roman", serif;
+  color: #173f43;
+  font-size: clamp(21px, 3.2vw, 28px);
+  line-height: 1;
+}
+
+.packet-result-grid h3 {
+  margin: 4px 0 0;
+  font-size: clamp(9px, 1.3vw, 11px);
+}
+
+.packet-result-grid article > p:not(.packet-section-kicker) {
+  margin: 5px 0 0;
+  color: #616a6f;
+  font-size: clamp(7px, 1vw, 8.5px);
+  line-height: 1.4;
+}
+
+.packet-result-proofline {
+  margin-top: 7px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  color: #506066;
+  font-size: clamp(6px, 0.9vw, 7.5px);
+}
+
+.packet-document-note {
+  margin-top: 14px;
+  padding: 10px 12px;
+  border-top: 1px solid #dedbd2;
+  color: #6b7377;
+}
+
+.packet-document-note strong {
+  font-size: clamp(7px, 1vw, 9px);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.packet-document-note p {
+  margin: 4px 0 0;
+  font-size: clamp(6px, 0.9vw, 8px);
+  line-height: 1.4;
+}
+
+.packet-skill-evidence-list {
+  display: grid;
+  gap: 0;
+  border-top: 1px solid #dfdcd3;
+}
+
+.packet-skill-evidence-list article {
+  display: grid;
+  grid-template-columns: 24px 1fr 150px;
+  gap: 10px;
+  align-items: center;
+  padding: 9px 0;
+  border-bottom: 1px solid #e7e4dc;
+}
+
+.packet-skill-rank {
+  color: #9b7b49;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: clamp(10px, 1.5vw, 13px);
+}
+
+.packet-skill-main {
+  min-width: 0;
+  display: grid;
+  gap: 5px;
+}
+
+.packet-skill-main > div:first-child {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.packet-skill-main strong {
+  font-size: clamp(8px, 1.15vw, 10px);
+}
+
+.packet-skill-main span {
+  color: #777e82;
+  font-size: clamp(6px, 0.9vw, 8px);
+}
+
+.packet-skill-track {
+  height: 4px;
+  border-radius: 999px;
+  background: #ebe8df;
+  overflow: hidden;
+}
+
+.packet-skill-track span {
+  display: block;
+  height: 100%;
+  background: #1f5559;
+}
+
+.packet-skill-dates {
+  display: grid;
+  grid-template-columns: auto auto;
+  gap: 2px 7px;
+  justify-content: end;
+  font-size: clamp(5.5px, 0.8vw, 7px);
+}
+
+.packet-skill-dates span {
+  color: #8a8f91;
+  text-transform: uppercase;
+}
+
+.packet-skill-dates strong {
+  color: #4f595e;
+  text-align: right;
+}
+
+.packet-growth-callout {
+  margin-top: 16px;
+  padding: 12px 14px;
+  display: flex;
+  gap: 10px;
+  border-radius: 10px;
+  background: #173f43;
+  color: white;
+}
+
+.packet-growth-callout svg {
+  flex: 0 0 auto;
+  color: #e1bd84;
+}
+
+.packet-growth-callout strong {
+  font-size: clamp(8px, 1.1vw, 10px);
+}
+
+.packet-growth-callout p {
+  margin: 4px 0 0;
+  color: #d7e1e0;
+  font-size: clamp(6px, 0.9vw, 8px);
+  line-height: 1.4;
+}
+
+.packet-contribution-summary {
+  margin: 18px 0;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.packet-contribution-summary > div {
+  display: grid;
+  grid-template-columns: auto auto 1fr;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 14px;
+  border: 1px solid #dedbd2;
+  border-radius: 10px;
+}
+
+.packet-contribution-summary svg {
+  color: #1f5559;
+}
+
+.packet-contribution-summary strong {
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: clamp(18px, 2.8vw, 25px);
+}
+
+.packet-contribution-summary span {
+  color: #697176;
+  font-size: clamp(6px, 0.9vw, 8px);
+}
+
+.packet-contribution-list {
+  display: grid;
+  gap: 9px;
+}
+
+.packet-contribution-list article {
+  padding: 11px 13px;
+  border: 1px solid #e0ddd5;
+  border-radius: 10px;
+}
+
+.packet-contribution-topline {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  color: #788084;
+  font-size: clamp(6px, 0.9vw, 8px);
+  letter-spacing: 0.05em;
+}
+
+.packet-contribution-list h3 {
+  margin: 5px 0 0;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: clamp(11px, 1.6vw, 14px);
+}
+
+.packet-contribution-list p {
+  margin: 4px 0 0;
+  color: #606a6e;
+  font-size: clamp(6.5px, 0.95vw, 8px);
+  line-height: 1.38;
+}
+
+.packet-contribution-meta {
+  margin-top: 7px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+}
+
+.packet-contribution-meta span {
+  border-radius: 999px;
+  background: #f1efe8;
+  padding: 3px 6px;
+  color: #667075;
+  font-size: clamp(5.5px, 0.8vw, 7px);
+}
+
+.packet-receipt-stack {
+  display: grid;
+  gap: 16px;
+}
+
+.packet-receipt-card {
+  padding: 16px;
+  border: 1px solid #cfcac0;
+  border-radius: 7px;
+  background:
+    repeating-linear-gradient(0deg, rgba(31, 85, 89, 0.018), rgba(31, 85, 89, 0.018) 1px, transparent 1px, transparent 5px),
+    #fffefa;
+  box-shadow: inset 0 0 0 4px rgba(31, 85, 89, 0.025);
+}
+
+.packet-receipt-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding-bottom: 9px;
+  border-bottom: 1px dashed #cfcac0;
+}
+
+.packet-receipt-top > div {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: #173f43;
+  font-size: clamp(7px, 1vw, 9px);
+  font-weight: 850;
+  text-transform: uppercase;
+  letter-spacing: 0.09em;
+}
+
+.packet-receipt-top strong {
+  font-family: "Courier New", monospace;
+  color: #566166;
+  font-size: clamp(7px, 1vw, 9px);
+}
+
+.packet-receipt-title {
+  padding: 11px 0 8px;
+}
+
+.packet-receipt-title p {
+  margin: 0;
+  color: #7b8285;
+  font-size: clamp(6px, 0.9vw, 8px);
+}
+
+.packet-receipt-title h3 {
+  margin: 4px 0 0;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: clamp(14px, 2vw, 18px);
+}
+
+.packet-receipt-card dl {
+  margin: 0;
+  display: grid;
+  gap: 7px;
+}
+
+.packet-receipt-card dl > div {
+  display: grid;
+  grid-template-columns: 82px 1fr;
+  gap: 9px;
+}
+
+.packet-receipt-card dt {
+  color: #778084;
+  font-size: clamp(6px, 0.85vw, 7.5px);
+  font-weight: 850;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.packet-receipt-card dd {
+  margin: 0;
+  color: #4e585d;
+  font-size: clamp(6.5px, 0.95vw, 8.2px);
+  line-height: 1.38;
+}
+
+.packet-receipt-skills {
+  margin-top: 9px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.packet-receipt-proof-grid {
+  margin-top: 10px;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  border-top: 1px dashed #cfcac0;
+  border-bottom: 1px dashed #cfcac0;
+}
+
+.packet-receipt-proof-grid > div {
+  padding: 8px 0;
+  display: grid;
+  gap: 2px;
+  text-align: center;
+}
+
+.packet-receipt-proof-grid > div + div {
+  border-left: 1px dashed #d9d4ca;
+}
+
+.packet-receipt-proof-grid strong {
+  font-family: Georgia, "Times New Roman", serif;
+  color: #173f43;
+  font-size: clamp(13px, 1.9vw, 17px);
+}
+
+.packet-receipt-proof-grid span {
+  color: #788084;
+  font-size: clamp(5.5px, 0.8vw, 7px);
+  text-transform: uppercase;
+}
+
+.packet-receipt-status {
+  margin-top: 9px;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  color: #1f5c52;
+  font-size: clamp(6px, 0.9vw, 8px);
+  font-weight: 800;
+}
+
+.packet-evidence-table {
+  border-top: 1px solid #d9d6ce;
+}
+
+.packet-evidence-row {
+  display: grid;
+  grid-template-columns: 100px 1.55fr 0.8fr 1fr;
+  gap: 9px;
+  padding: 9px 0;
+  border-bottom: 1px solid #e5e2da;
+  align-items: start;
+}
+
+.packet-evidence-row.header {
+  color: #6b7478;
+  font-size: clamp(5.5px, 0.8vw, 7px);
+  font-weight: 850;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+}
+
+.packet-evidence-row:not(.header) > span {
+  color: #5a6469;
+  font-size: clamp(6px, 0.9vw, 7.6px);
+  overflow-wrap: anywhere;
+}
+
+.packet-evidence-row strong {
+  display: block;
+  color: #303a3e;
+  font-size: clamp(6.5px, 0.95vw, 8px);
+}
+
+.packet-evidence-row small {
+  display: block;
+  margin-top: 2px;
+  color: #858b8e;
+  font-size: clamp(5.5px, 0.8vw, 6.8px);
+  line-height: 1.3;
+}
+
+.packet-summary-context {
+  margin: 16px 0 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+}
+
+.packet-summary-narrative {
+  margin-top: 18px;
+  padding: 18px;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 13px;
+  border-radius: 11px;
+  background: #173f43;
+  color: white;
+}
+
+.packet-summary-narrative svg {
+  color: #e0bc82;
+}
+
+.packet-summary-narrative .packet-section-kicker {
+  color: #b8cbcc;
+}
+
+.packet-summary-narrative p:last-child {
+  margin: 8px 0 0;
+  color: #edf3f2;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: clamp(11px, 1.7vw, 15px);
+  line-height: 1.5;
+}
+
+.packet-talking-points {
+  margin-top: 21px;
+}
+
+.packet-talking-points ol {
+  margin: 13px 0 0;
+  padding: 0;
+  list-style: none;
+  counter-reset: packet-talk;
+  display: grid;
+  gap: 9px;
+}
+
+.packet-talking-points li {
+  counter-increment: packet-talk;
+  display: grid;
+  grid-template-columns: 28px 1fr;
+  gap: 8px;
+  padding-bottom: 9px;
+  border-bottom: 1px solid #e3e0d8;
+}
+
+.packet-talking-points li::before {
+  content: counter(packet-talk, decimal-leading-zero);
+  color: #a0783f;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: clamp(9px, 1.3vw, 11px);
+}
+
+.packet-talking-points li strong {
+  font-size: clamp(8px, 1.15vw, 10px);
+}
+
+.packet-talking-points li span {
+  grid-column: 2;
+  margin-top: -4px;
+  color: #657075;
+  font-size: clamp(6px, 0.9vw, 8px);
+  line-height: 1.38;
+}
+
+.packet-summary-close {
+  margin-top: auto;
+  margin-bottom: 28px;
+  padding: 13px 15px;
+  display: flex;
+  gap: 10px;
+  border-left: 4px solid #b68b4c;
+  background: #f4f1e8;
+}
+
+.packet-summary-close svg {
+  color: #173f43;
+  flex: 0 0 auto;
+}
+
+.packet-summary-close strong {
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: clamp(10px, 1.5vw, 13px);
+}
+
+.packet-summary-close p {
+  margin: 3px 0 0;
+  color: #657075;
+  font-size: clamp(6px, 0.9vw, 8px);
+  line-height: 1.4;
+}
+
+@media (max-width: 700px) {
+  .packet-document-two-column,
+  .packet-result-grid {
+    gap: 7px;
+  }
+
+  .packet-skill-evidence-list article {
+    grid-template-columns: 20px 1fr 105px;
+  }
+
+  .packet-evidence-row {
+    grid-template-columns: 70px 1.4fr 0.8fr 1fr;
+  }
+}
+
+@media print {
+  .packet-document-page {
+    page-break-after: always;
+    break-after: page;
+  }
+}

--- a/frontend/src/PerformancePacketPages.jsx
+++ b/frontend/src/PerformancePacketPages.jsx
@@ -1,0 +1,538 @@
+import {
+  Award,
+  BadgeCheck,
+  BarChart3,
+  BookOpenCheck,
+  CalendarDays,
+  CheckCircle2,
+  FileCheck2,
+  LineChart,
+  Medal,
+  ReceiptText,
+  ShieldCheck,
+  Sparkles,
+  Target,
+  UsersRound,
+} from "lucide-react";
+
+import "./PerformancePacketPages.css";
+
+function formatShortDate(value) {
+  if (!value) return "—";
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  }).format(new Date(`${value}T12:00:00`));
+}
+
+function formatMonth(value) {
+  if (!value) return "";
+  const [year, month] = value.split("-");
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    year: "2-digit",
+  }).format(new Date(Number(year), Number(month) - 1, 1));
+}
+
+function formatLabel(value = "") {
+  return String(value)
+    .replace(/-/g, " ")
+    .replace(/\b\w/g, (character) => character.toUpperCase());
+}
+
+function chunk(items, size) {
+  const result = [];
+  for (let index = 0; index < items.length; index += size) {
+    result.push(items.slice(index, index + size));
+  }
+  return result.length ? result : [[]];
+}
+
+function PacketFooter({ page }) {
+  return (
+    <footer className="packet-page-footer">
+      <span>BragStack · Career Evidence System</span>
+      <span>Page {page}</span>
+    </footer>
+  );
+}
+
+function PacketHeader({ index, title, eyebrow }) {
+  return (
+    <header className="packet-page-header">
+      <div>
+        <p>{String(index).padStart(2, "0")} · {eyebrow}</p>
+        <h2>{title}</h2>
+      </div>
+      <div className="packet-page-header-mark">BRAGSTACK</div>
+    </header>
+  );
+}
+
+function EmptyState({ children }) {
+  return (
+    <div className="packet-document-empty">
+      <BookOpenCheck size={22} />
+      <p>{children}</p>
+    </div>
+  );
+}
+
+function HorizontalBars({ items, limit = 6 }) {
+  const entries = Object.entries(items ?? {}).slice(0, limit);
+  const highest = Math.max(...entries.map(([, count]) => Number(count) || 0), 1);
+
+  if (!entries.length) {
+    return <EmptyState>Add categorized accomplishments to build this view.</EmptyState>;
+  }
+
+  return (
+    <div className="packet-horizontal-bars">
+      {entries.map(([label, count]) => (
+        <div key={label}>
+          <div className="packet-horizontal-bar-copy">
+            <span>{label}</span>
+            <strong>{count}</strong>
+          </div>
+          <div className="packet-horizontal-bar-track">
+            <span style={{ width: `${Math.max(8, (count / highest) * 100)}%` }} />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function ImpactAnalyticsPage({ packet, page }) {
+  const analytics = packet?.impact_analytics ?? {};
+  const activity = Object.entries(analytics.activity_by_month ?? {}).slice(-12);
+  const maxActivity = Math.max(...activity.map(([, count]) => Number(count) || 0), 1);
+  const scorecard = packet?.scorecard ?? {};
+
+  return (
+    <section className="packet-sheet packet-document-page">
+      <PacketHeader index={2} eyebrow="Impact Analytics" title="How the work shows up" />
+
+      <p className="packet-page-lead">
+        A period-level view of documented activity, work themes, and proof quality.
+        These charts summarize recorded career evidence; they do not assign a
+        subjective performance rating.
+      </p>
+
+      <div className="packet-kpi-ribbon">
+        <div><strong>{scorecard.quantified_result_coverage_percent ?? 0}%</strong><span>Quantified result coverage</span></div>
+        <div><strong>{scorecard.verification_coverage_percent ?? 0}%</strong><span>Verification coverage</span></div>
+        <div><strong>{scorecard.evidence_depth ?? 0}×</strong><span>Evidence depth</span></div>
+      </div>
+
+      <section className="packet-document-section">
+        <div className="packet-document-section-title">
+          <div><p>Activity trend</p><h3>Documented accomplishments over time</h3></div>
+          <LineChart size={20} />
+        </div>
+
+        {activity.length ? (
+          <div className="packet-activity-chart" aria-label="Accomplishments by month">
+            {activity.map(([month, count]) => (
+              <div key={month} className="packet-activity-column">
+                <span className="packet-activity-value">{count}</span>
+                <div className="packet-activity-bar-wrap">
+                  <span
+                    className="packet-activity-bar"
+                    style={{ height: `${Math.max(10, (count / maxActivity) * 100)}%` }}
+                  />
+                </div>
+                <small>{formatMonth(month)}</small>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <EmptyState>Activity will appear as accomplishments are dated and recorded.</EmptyState>
+        )}
+      </section>
+
+      <div className="packet-document-two-column">
+        <section className="packet-document-section compact">
+          <div className="packet-document-section-title">
+            <div><p>Work mix</p><h3>Primary themes</h3></div>
+            <BarChart3 size={19} />
+          </div>
+          <HorizontalBars items={analytics.categories} />
+        </section>
+
+        <section className="packet-document-section compact">
+          <div className="packet-document-section-title">
+            <div><p>Trust signals</p><h3>Proof strength</h3></div>
+            <ShieldCheck size={19} />
+          </div>
+          <HorizontalBars items={analytics.trust_signals} />
+        </section>
+      </div>
+
+      <PacketFooter page={page} />
+    </section>
+  );
+}
+
+function SignatureAccomplishmentsPage({ packet, page }) {
+  const items = packet?.signature_accomplishments ?? [];
+
+  return (
+    <section className="packet-sheet packet-document-page">
+      <PacketHeader index={3} eyebrow="Signature Accomplishments" title="Work worth discussing" />
+      <p className="packet-page-lead">
+        Strong examples are prioritized using documented results, evidence,
+        verification, and Impact Receipt completeness—not profession-specific rules.
+      </p>
+
+      {items.length ? (
+        <div className="packet-accomplishment-list">
+          {items.slice(0, 6).map((item, index) => (
+            <article key={item.entry_id} className="packet-accomplishment-record">
+              <div className="packet-accomplishment-number">{String(index + 1).padStart(2, "0")}</div>
+              <div>
+                <div className="packet-record-meta">
+                  <span>{item.category || "Accomplishment"}</span>
+                  {item.entry_date && <span>{formatShortDate(item.entry_date)}</span>}
+                  {item.verified && <span className="packet-verified-chip"><BadgeCheck size={12} /> Verified</span>}
+                </div>
+                <h3>{item.title}</h3>
+                {item.result && <p>{item.result}</p>}
+                <div className="packet-record-tags">
+                  {item.skills?.slice(0, 5).map((skill) => <span key={skill}>{skill}</span>)}
+                </div>
+              </div>
+              <div className="packet-record-proof">
+                <strong>{item.evidence_count ?? 0}</strong>
+                <span>evidence</span>
+              </div>
+            </article>
+          ))}
+        </div>
+      ) : (
+        <EmptyState>Add accomplishments with clear results to populate signature examples.</EmptyState>
+      )}
+
+      <PacketFooter page={page} />
+    </section>
+  );
+}
+
+function MeasurableResultsPage({ packet, page }) {
+  const results = packet?.measurable_results ?? [];
+  const coverage = packet?.scorecard?.quantified_result_coverage_percent ?? 0;
+
+  return (
+    <section className="packet-sheet packet-document-page">
+      <PacketHeader index={4} eyebrow="Measurable Results" title="Outcomes with numbers behind them" />
+
+      <div className="packet-result-hero">
+        <Target size={24} />
+        <div>
+          <strong>{coverage}%</strong>
+          <span>of Impact Receipts include a quantified result</span>
+        </div>
+      </div>
+
+      {results.length ? (
+        <div className="packet-result-grid">
+          {results.slice(0, 8).map((item) => (
+            <article key={`${item.entry_id}-${item.result}`}>
+              <div className="packet-result-metric">{item.metric_display || "Measured"}</div>
+              <p className="packet-section-kicker">{item.category}</p>
+              <h3>{item.title}</h3>
+              <p>{item.result}</p>
+              <div className="packet-result-proofline">
+                {item.verified ? <><CheckCircle2 size={13} /> Verified contribution</> : <><FileCheck2 size={13} /> Documented result</>}
+              </div>
+            </article>
+          ))}
+        </div>
+      ) : (
+        <EmptyState>
+          Quantified results appear when an accomplishment or Impact Receipt contains a
+          number, percentage, amount, count, duration, or other measurable signal.
+        </EmptyState>
+      )}
+
+      <div className="packet-document-note">
+        <strong>Interpretation note</strong>
+        <p>
+          BragStack displays the numeric language already present in your records. It
+          does not invent savings, percentages, revenue, or outcomes.
+        </p>
+      </div>
+
+      <PacketFooter page={page} />
+    </section>
+  );
+}
+
+function SkillsGrowthPage({ packet, page }) {
+  const skills = packet?.skill_details ?? [];
+  const maxCount = Math.max(...skills.map((item) => Number(item.count) || 0), 1);
+
+  return (
+    <section className="packet-sheet packet-document-page">
+      <PacketHeader index={5} eyebrow="Skills & Growth" title="Capabilities demonstrated in real work" />
+      <p className="packet-page-lead">
+        Skill evidence is based on accomplishments and Impact Receipts. Frequency
+        reflects how often a capability appears in documented work—not a proficiency score.
+      </p>
+
+      {skills.length ? (
+        <div className="packet-skill-evidence-list">
+          {skills.slice(0, 12).map((item, index) => (
+            <article key={item.skill}>
+              <div className="packet-skill-rank">{index + 1}</div>
+              <div className="packet-skill-main">
+                <div><strong>{item.skill}</strong><span>{item.count} documented use{item.count === 1 ? "" : "s"}</span></div>
+                <div className="packet-skill-track"><span style={{ width: `${Math.max(8, (item.count / maxCount) * 100)}%` }} /></div>
+              </div>
+              <div className="packet-skill-dates">
+                <span>First shown</span><strong>{formatShortDate(item.first_seen)}</strong>
+                <span>Most recent</span><strong>{formatShortDate(item.last_seen)}</strong>
+              </div>
+            </article>
+          ))}
+        </div>
+      ) : (
+        <EmptyState>Add skills to accomplishments or Impact Receipts to build capability evidence.</EmptyState>
+      )}
+
+      <div className="packet-growth-callout">
+        <Sparkles size={19} />
+        <div>
+          <strong>Career-neutral by design</strong>
+          <p>
+            Skills can be clinical, instructional, interpersonal, operational,
+            technical, creative, sales-focused, trade-specific, managerial, or anything
+            else your work demonstrates.
+          </p>
+        </div>
+      </div>
+
+      <PacketFooter page={page} />
+    </section>
+  );
+}
+
+function ContributionPage({ packet, page }) {
+  const contributions = packet?.contribution_records ?? [];
+  const confirmed = packet?.scorecard?.confirmed_assertions ?? 0;
+
+  return (
+    <section className="packet-sheet packet-document-page">
+      <PacketHeader index={6} eyebrow="Contribution & Recognition" title="What you personally moved forward" />
+
+      <div className="packet-contribution-summary">
+        <div><UsersRound size={21} /><strong>{contributions.length}</strong><span>structured contribution records</span></div>
+        <div><BadgeCheck size={21} /><strong>{confirmed}</strong><span>confirmed assertions</span></div>
+      </div>
+
+      {contributions.length ? (
+        <div className="packet-contribution-list">
+          {contributions.slice(0, 6).map((item) => (
+            <article key={item.reference}>
+              <div className="packet-contribution-topline">
+                <span>{item.reference}</span>
+                {item.verified && <span className="packet-verified-chip"><BadgeCheck size={12} /> Confirmed</span>}
+              </div>
+              <h3>{item.accomplishment}</h3>
+              {item.contribution && <p><strong>Contribution:</strong> {item.contribution}</p>}
+              {item.result && <p><strong>Result:</strong> {item.result}</p>}
+              <div className="packet-contribution-meta">
+                <span>{item.evidence_count ?? 0} evidence item{item.evidence_count === 1 ? "" : "s"}</span>
+                {item.confirmations?.slice(0, 2).map((confirmation) => (
+                  <span key={`${item.reference}-${confirmation.name}`}>
+                    {confirmation.name}{confirmation.role ? ` · ${confirmation.role}` : ""}
+                  </span>
+                ))}
+              </div>
+            </article>
+          ))}
+        </div>
+      ) : (
+        <EmptyState>Create Impact Receipts to document the specific contribution behind each result.</EmptyState>
+      )}
+
+      <PacketFooter page={page} />
+    </section>
+  );
+}
+
+function ImpactReceiptCard({ receipt }) {
+  return (
+    <article className="packet-receipt-card">
+      <div className="packet-receipt-top">
+        <div><ReceiptText size={17} /><span>Impact Receipt</span></div>
+        <strong>{receipt.reference}</strong>
+      </div>
+      <div className="packet-receipt-title">
+        <p>{receipt.entry_date ? formatShortDate(receipt.entry_date) : "Documented proof"}</p>
+        <h3>{receipt.accomplishment}</h3>
+      </div>
+      <dl>
+        <div><dt>Contribution</dt><dd>{receipt.contribution || "Documented in source accomplishment."}</dd></div>
+        <div><dt>Result</dt><dd>{receipt.result || "Result not yet added."}</dd></div>
+      </dl>
+      <div className="packet-receipt-skills">
+        {receipt.skills?.slice(0, 7).map((skill) => <span key={skill}>{skill}</span>)}
+      </div>
+      <div className="packet-receipt-proof-grid">
+        <div><strong>{receipt.evidence?.length ?? 0}</strong><span>Evidence</span></div>
+        <div><strong>{receipt.confirmations?.filter((item) => item.status === "confirmed").length ?? 0}</strong><span>Confirmations</span></div>
+        <div><strong>{receipt.credit?.length ?? 0}</strong><span>Shared credit</span></div>
+      </div>
+      <div className="packet-receipt-status">
+        {receipt.verified ? <><BadgeCheck size={14} /> Confirmed contribution</> : <><ShieldCheck size={14} /> Evidence-backed record</>}
+      </div>
+    </article>
+  );
+}
+
+function ReceiptPages({ packet, startPage }) {
+  const receipts = packet?.receipt_records ?? [];
+  const pages = chunk(receipts, 2);
+
+  return pages.map((items, index) => (
+    <section key={`receipt-page-${index}`} className="packet-sheet packet-document-page">
+      <PacketHeader
+        index={7}
+        eyebrow="Impact Receipts"
+        title={index === 0 ? "Receipts for the work" : "Impact Receipts · continued"}
+      />
+      <p className="packet-page-lead">
+        Each receipt ties an accomplishment to contribution, result, skills,
+        supporting evidence, credit, and confirmation signals.
+      </p>
+      {items.length ? (
+        <div className="packet-receipt-stack">
+          {items.map((receipt) => <ImpactReceiptCard key={receipt.reference} receipt={receipt} />)}
+        </div>
+      ) : (
+        <EmptyState>Turn accomplishments into Impact Receipts to create printable proof records.</EmptyState>
+      )}
+      <PacketFooter page={startPage + index} />
+    </section>
+  ));
+}
+
+function EvidencePages({ packet, startPage }) {
+  const evidence = packet?.evidence_index ?? [];
+  const pages = chunk(evidence, 10);
+
+  return pages.map((items, index) => (
+    <section key={`evidence-page-${index}`} className="packet-sheet packet-document-page">
+      <PacketHeader
+        index={8}
+        eyebrow="Evidence Index"
+        title={index === 0 ? "Source material behind the claims" : "Evidence Index · continued"}
+      />
+      <p className="packet-page-lead">
+        A private packet can include evidence references whether or not those items
+        are public on a Proof Profile.
+      </p>
+
+      {items.length ? (
+        <div className="packet-evidence-table" role="table" aria-label="Evidence index">
+          <div className="packet-evidence-row header" role="row">
+            <span>Receipt</span><span>Evidence</span><span>Type</span><span>Reference</span>
+          </div>
+          {items.map((item, itemIndex) => (
+            <div className="packet-evidence-row" role="row" key={`${item.receipt_reference}-${item.title}-${itemIndex}`}>
+              <span>{item.receipt_reference}</span>
+              <span><strong>{item.title}</strong><small>{item.description}</small></span>
+              <span>{formatLabel(item.type)}</span>
+              <span>{item.reference || "Stored in BragStack"}</span>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <EmptyState>Add documents, feedback, certificates, links, photos, or other proof to your Impact Receipts.</EmptyState>
+      )}
+
+      <PacketFooter page={startPage + index} />
+    </section>
+  ));
+}
+
+function ReviewSummaryPage({ packet, page }) {
+  const talkingPoints = packet?.talking_points ?? [];
+  const context = packet?.context ?? {};
+
+  return (
+    <section className="packet-sheet packet-document-page packet-summary-page">
+      <PacketHeader index={9} eyebrow="Review Summary" title="The case, assembled" />
+
+      <div className="packet-summary-context">
+        {context.career_area && <span>{context.career_area}</span>}
+        {context.organization && <span>{context.organization}</span>}
+      </div>
+
+      <section className="packet-summary-narrative">
+        <Medal size={26} />
+        <div>
+          <p className="packet-section-kicker">Evidence-backed summary</p>
+          <p>{packet?.review_summary}</p>
+        </div>
+      </section>
+
+      <section className="packet-talking-points">
+        <div className="packet-document-section-title">
+          <div><p>Conversation guide</p><h3>Review talking points</h3></div>
+          <Award size={19} />
+        </div>
+        {talkingPoints.length ? (
+          <ol>
+            {talkingPoints.map((item) => (
+              <li key={`${item.title}-${item.result}`}>
+                <strong>{item.title}</strong>
+                {item.result && <span>{item.result}</span>}
+              </li>
+            ))}
+          </ol>
+        ) : (
+          <EmptyState>Add accomplishments to generate evidence-backed talking points.</EmptyState>
+        )}
+      </section>
+
+      <div className="packet-summary-close">
+        <CheckCircle2 size={20} />
+        <div>
+          <strong>Bring the receipts.</strong>
+          <p>
+            Every section in this packet is designed to lead back to documented
+            work instead of relying on memory at review time.
+          </p>
+        </div>
+      </div>
+
+      <PacketFooter page={page} />
+    </section>
+  );
+}
+
+function PerformancePacketPages({ packet }) {
+  const receiptPageCount = Math.max(1, Math.ceil((packet?.receipt_records?.length ?? 0) / 2));
+  const evidencePageCount = Math.max(1, Math.ceil((packet?.evidence_index?.length ?? 0) / 10));
+  const receiptStartPage = 8;
+  const evidenceStartPage = receiptStartPage + receiptPageCount;
+  const summaryPage = evidenceStartPage + evidencePageCount;
+
+  return (
+    <>
+      <ImpactAnalyticsPage packet={packet} page={3} />
+      <SignatureAccomplishmentsPage packet={packet} page={4} />
+      <MeasurableResultsPage packet={packet} page={5} />
+      <SkillsGrowthPage packet={packet} page={6} />
+      <ContributionPage packet={packet} page={7} />
+      <ReceiptPages packet={packet} startPage={receiptStartPage} />
+      <EvidencePages packet={packet} startPage={evidenceStartPage} />
+      <ReviewSummaryPage packet={packet} page={summaryPage} />
+    </>
+  );
+}
+
+export default PerformancePacketPages;

--- a/frontend/src/PerformancePacketPages.jsx
+++ b/frontend/src/PerformancePacketPages.jsx
@@ -3,7 +3,6 @@ import {
   BadgeCheck,
   BarChart3,
   BookOpenCheck,
-  CalendarDays,
   CheckCircle2,
   FileCheck2,
   LineChart,

--- a/frontend/src/PerformancePacketPreview.css
+++ b/frontend/src/PerformancePacketPreview.css
@@ -1,0 +1,687 @@
+.packet-preview-shell {
+  min-height: 100vh;
+  background:
+    radial-gradient(circle at 12% 8%, rgba(255, 255, 255, 0.82), transparent 28rem),
+    #d8d6d0;
+  color: #17202a;
+  padding: 24px 16px 64px;
+}
+
+.packet-preview-toolbar {
+  width: min(980px, 100%);
+  margin: 0 auto 24px;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  gap: 16px;
+}
+
+.packet-preview-toolbar > div {
+  text-align: center;
+  display: grid;
+  gap: 2px;
+}
+
+.packet-preview-toolbar > div span {
+  color: #626b76;
+  font-size: 12px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.packet-preview-toolbar > div strong {
+  font-size: 14px;
+}
+
+.packet-preview-toolbar button {
+  border: 1px solid rgba(23, 32, 42, 0.14);
+  background: rgba(255, 255, 255, 0.86);
+  color: #17202a;
+  border-radius: 999px;
+  padding: 10px 14px;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 700;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  box-shadow: 0 8px 30px rgba(23, 32, 42, 0.08);
+}
+
+.packet-preview-toolbar button:last-child {
+  justify-self: end;
+}
+
+.packet-paper-stack {
+  width: min(900px, 100%);
+  margin: 0 auto;
+  display: grid;
+  gap: 32px;
+}
+
+.packet-sheet {
+  width: min(816px, 100%);
+  aspect-ratio: 8.5 / 11;
+  margin: 0 auto;
+  background: #fffefa;
+  border: 1px solid rgba(20, 24, 28, 0.08);
+  box-shadow:
+    0 2px 5px rgba(23, 32, 42, 0.08),
+    0 28px 70px rgba(23, 32, 42, 0.18);
+  padding: clamp(28px, 6.4vw, 66px);
+  position: relative;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.packet-cover {
+  background:
+    linear-gradient(135deg, rgba(34, 72, 76, 0.035), transparent 45%),
+    #fffefa;
+}
+
+.packet-cover::after {
+  content: "";
+  position: absolute;
+  width: 360px;
+  height: 360px;
+  right: -180px;
+  bottom: 120px;
+  border: 1px solid rgba(31, 79, 82, 0.12);
+  border-radius: 50%;
+  box-shadow:
+    0 0 0 44px rgba(31, 79, 82, 0.025),
+    0 0 0 88px rgba(31, 79, 82, 0.02);
+}
+
+.packet-cover-topline,
+.packet-cover-bottom,
+.packet-page-header,
+.packet-page-footer {
+  position: relative;
+  z-index: 1;
+}
+
+.packet-cover-topline {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+}
+
+.packet-wordmark {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: clamp(12px, 1.7vw, 15px);
+  font-weight: 850;
+  letter-spacing: 0.12em;
+}
+
+.packet-wordmark-mark {
+  width: 30px;
+  height: 30px;
+  border-radius: 9px;
+  display: grid;
+  place-items: center;
+  background: #173f43;
+  color: white;
+  letter-spacing: 0;
+  font-family: Georgia, "Times New Roman", serif;
+}
+
+.packet-confidential {
+  color: #6f7477;
+  font-size: clamp(8px, 1.25vw, 11px);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.packet-cover-main {
+  position: relative;
+  z-index: 1;
+  margin: auto 0;
+  max-width: 620px;
+}
+
+.packet-document-type {
+  margin: 0 0 18px;
+  color: #1f4f52;
+  font-size: clamp(10px, 1.45vw, 13px);
+  font-weight: 800;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.packet-cover h1 {
+  margin: 0;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: clamp(38px, 7vw, 70px);
+  line-height: 0.98;
+  letter-spacing: -0.045em;
+  color: #172126;
+}
+
+.packet-cover h2 {
+  margin: 18px 0 0;
+  font-size: clamp(17px, 2.7vw, 25px);
+  font-weight: 540;
+  color: #454e54;
+}
+
+.packet-location {
+  margin: 7px 0 0;
+  color: #737b80;
+  font-size: clamp(10px, 1.45vw, 13px);
+}
+
+.packet-cover-rule {
+  width: 74px;
+  height: 4px;
+  background: #b68b4c;
+  margin: 30px 0;
+}
+
+.packet-period-block {
+  display: grid;
+  gap: 7px;
+}
+
+.packet-period-block span,
+.packet-cover-bottom > div > span {
+  color: #777e82;
+  font-size: clamp(8px, 1.2vw, 10px);
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.packet-period-block strong {
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: clamp(16px, 2.4vw, 23px);
+  font-weight: 600;
+}
+
+.packet-cover-stats {
+  margin-top: 34px;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0;
+  border-top: 1px solid #d8d5cc;
+  border-bottom: 1px solid #d8d5cc;
+}
+
+.packet-cover-stats div {
+  padding: 18px 18px 18px 0;
+  display: grid;
+  gap: 5px;
+}
+
+.packet-cover-stats div + div {
+  padding-left: 18px;
+  border-left: 1px solid #d8d5cc;
+}
+
+.packet-cover-stats strong {
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: clamp(22px, 4vw, 36px);
+  color: #173f43;
+}
+
+.packet-cover-stats span {
+  font-size: clamp(8px, 1.35vw, 11px);
+  line-height: 1.35;
+  color: #656d72;
+}
+
+.packet-cover-bottom {
+  display: flex;
+  justify-content: space-between;
+  align-items: end;
+  gap: 24px;
+  padding-bottom: 28px;
+}
+
+.packet-cover-bottom > div:first-child {
+  display: grid;
+  gap: 5px;
+}
+
+.packet-cover-bottom strong {
+  font-size: clamp(10px, 1.45vw, 13px);
+}
+
+.packet-cover-proofline {
+  max-width: 330px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: #536166;
+  font-size: clamp(8px, 1.25vw, 10px);
+  text-align: right;
+}
+
+.packet-page-footer {
+  position: absolute;
+  bottom: clamp(18px, 3vw, 30px);
+  left: clamp(28px, 6.4vw, 66px);
+  right: clamp(28px, 6.4vw, 66px);
+  padding-top: 9px;
+  border-top: 1px solid #e3e0d8;
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  color: #8a8e8f;
+  font-size: clamp(7px, 1.05vw, 9px);
+  letter-spacing: 0.04em;
+}
+
+.packet-page-header {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 20px;
+  padding-bottom: 18px;
+  border-bottom: 2px solid #183f43;
+}
+
+.packet-page-header p,
+.packet-section-kicker {
+  margin: 0;
+  color: #667176;
+  font-size: clamp(8px, 1.1vw, 10px);
+  font-weight: 800;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+}
+
+.packet-page-header h2 {
+  margin: 7px 0 0;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: clamp(25px, 4.5vw, 40px);
+  line-height: 1;
+  letter-spacing: -0.035em;
+}
+
+.packet-page-header-mark {
+  color: #173f43;
+  font-size: clamp(8px, 1.2vw, 10px);
+  font-weight: 900;
+  letter-spacing: 0.14em;
+}
+
+.packet-scorecard-intro {
+  margin: 18px 0;
+  max-width: 620px;
+  color: #596267;
+  font-size: clamp(9px, 1.35vw, 12px);
+  line-height: 1.55;
+}
+
+.packet-stat-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  border: 1px solid #dcd9d0;
+  border-radius: 12px;
+  overflow: hidden;
+  background: white;
+}
+
+.packet-stat-grid article {
+  min-width: 0;
+  padding: clamp(10px, 2vw, 17px);
+  display: grid;
+  gap: 5px;
+}
+
+.packet-stat-grid article + article {
+  border-left: 1px solid #e2dfd7;
+}
+
+.packet-stat-grid svg {
+  color: #1f5559;
+}
+
+.packet-stat-grid span {
+  color: #697277;
+  font-size: clamp(7px, 1.05vw, 9px);
+  font-weight: 750;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.packet-stat-grid strong {
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: clamp(22px, 4vw, 34px);
+  line-height: 1;
+}
+
+.packet-scorecard-section {
+  margin-top: clamp(16px, 3vw, 26px);
+}
+
+.packet-section-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+}
+
+.packet-section-heading h3,
+.packet-signature-callout h3 {
+  margin: 5px 0 0;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: clamp(15px, 2.3vw, 20px);
+}
+
+.packet-section-heading svg {
+  color: #1f5559;
+}
+
+.packet-coverage-list {
+  margin-top: 14px;
+  display: grid;
+  gap: 10px;
+}
+
+.packet-coverage-row {
+  display: grid;
+  gap: 6px;
+}
+
+.packet-coverage-copy {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: end;
+}
+
+.packet-coverage-copy > div {
+  display: grid;
+  gap: 2px;
+}
+
+.packet-coverage-copy strong {
+  font-size: clamp(8px, 1.25vw, 11px);
+}
+
+.packet-coverage-copy span {
+  color: #7a8185;
+  font-size: clamp(7px, 1.05vw, 9px);
+}
+
+.packet-coverage-copy b {
+  color: #173f43;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: clamp(12px, 1.9vw, 16px);
+}
+
+.packet-coverage-track,
+.packet-ranked-track {
+  height: 5px;
+  overflow: hidden;
+  background: #ebe8df;
+  border-radius: 999px;
+}
+
+.packet-coverage-track span,
+.packet-ranked-track span {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: #1f5559;
+}
+
+.packet-evidence-depth {
+  margin-top: 12px;
+  padding: 11px 13px;
+  background: #f3f1ea;
+  border-left: 3px solid #b68b4c;
+  display: grid;
+  grid-template-columns: auto auto 1fr;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.packet-evidence-depth span {
+  font-size: clamp(8px, 1.15vw, 10px);
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.packet-evidence-depth strong {
+  color: #173f43;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: clamp(16px, 2.5vw, 21px);
+}
+
+.packet-evidence-depth p {
+  margin: 0;
+  color: #697176;
+  font-size: clamp(7px, 1.05vw, 9px);
+}
+
+.packet-ranked-grid {
+  margin-top: clamp(14px, 2.6vw, 22px);
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.packet-ranked-card {
+  border: 1px solid #dfdcd3;
+  border-radius: 10px;
+  padding: clamp(10px, 2vw, 15px);
+}
+
+.packet-ranked-list {
+  margin-top: 10px;
+  display: grid;
+  gap: 7px;
+}
+
+.packet-ranked-list > div {
+  display: grid;
+  gap: 4px;
+}
+
+.packet-ranked-copy {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  font-size: clamp(7px, 1.1vw, 9px);
+}
+
+.packet-ranked-copy strong {
+  color: #173f43;
+}
+
+.packet-ranked-track {
+  height: 3px;
+}
+
+.packet-empty-copy {
+  margin: 10px 0 0;
+  color: #777e82;
+  font-size: clamp(7px, 1.1vw, 9px);
+}
+
+.packet-signature-callout {
+  margin-top: clamp(14px, 2.6vw, 22px);
+  padding: clamp(10px, 2vw, 16px);
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 12px;
+  background: #173f43;
+  color: white;
+  border-radius: 10px;
+}
+
+.packet-signature-callout .packet-section-kicker {
+  color: #b8cccd;
+}
+
+.packet-signature-callout h3 {
+  color: white;
+}
+
+.packet-signature-callout p:last-child {
+  margin: 6px 0 0;
+  color: #dce5e4;
+  font-size: clamp(7px, 1.1vw, 9px);
+  line-height: 1.45;
+}
+
+.packet-signature-icon {
+  width: clamp(28px, 4vw, 36px);
+  height: clamp(28px, 4vw, 36px);
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.1);
+  color: #e4c28d;
+}
+
+.packet-builder-card {
+  margin: 18px 0 24px;
+  padding: 22px;
+  border: 1px solid rgba(41, 88, 91, 0.2);
+  border-radius: 18px;
+  background:
+    linear-gradient(130deg, rgba(34, 90, 93, 0.08), transparent 55%),
+    #ffffff;
+  box-shadow: 0 16px 42px rgba(23, 32, 42, 0.07);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+}
+
+.packet-builder-copy {
+  max-width: 650px;
+}
+
+.packet-builder-copy > span {
+  display: inline-flex;
+  margin-bottom: 8px;
+  border-radius: 999px;
+  background: #173f43;
+  color: white;
+  padding: 5px 9px;
+  font-size: 10px;
+  font-weight: 850;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.packet-builder-copy h2 {
+  margin: 0;
+  font-size: 22px;
+}
+
+.packet-builder-copy p {
+  margin: 7px 0 0;
+  color: #657077;
+  line-height: 1.55;
+}
+
+.packet-builder-card button {
+  flex: 0 0 auto;
+  border: 0;
+  border-radius: 12px;
+  background: #173f43;
+  color: white;
+  padding: 13px 16px;
+  font: inherit;
+  font-weight: 800;
+  cursor: pointer;
+}
+
+.packet-builder-card button:disabled {
+  cursor: wait;
+  opacity: 0.68;
+}
+
+.packet-builder-error {
+  margin: -12px 0 22px;
+  padding: 12px 14px;
+  border: 1px solid rgba(139, 87, 36, 0.22);
+  border-radius: 12px;
+  background: #fff8eb;
+  color: #714b22;
+  font-size: 13px;
+}
+
+@media (max-width: 700px) {
+  .packet-preview-toolbar {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .packet-preview-toolbar > div {
+    display: none;
+  }
+
+  .packet-cover-topline {
+    align-items: flex-start;
+  }
+
+  .packet-confidential {
+    max-width: 130px;
+    text-align: right;
+  }
+
+  .packet-cover-bottom {
+    align-items: flex-start;
+  }
+
+  .packet-cover-proofline {
+    max-width: 180px;
+  }
+
+  .packet-builder-card {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .packet-builder-card button {
+    width: 100%;
+  }
+}
+
+@media print {
+  @page {
+    size: Letter;
+    margin: 0;
+  }
+
+  body {
+    background: white !important;
+  }
+
+  .packet-preview-shell {
+    padding: 0;
+    background: white;
+  }
+
+  .packet-preview-toolbar {
+    display: none;
+  }
+
+  .packet-paper-stack {
+    width: auto;
+    gap: 0;
+  }
+
+  .packet-sheet {
+    width: 8.5in;
+    height: 11in;
+    aspect-ratio: auto;
+    border: 0;
+    box-shadow: none;
+    page-break-after: always;
+    break-after: page;
+  }
+}

--- a/frontend/src/PerformancePacketPreview.jsx
+++ b/frontend/src/PerformancePacketPreview.jsx
@@ -9,6 +9,7 @@ import {
   Sparkles,
 } from "lucide-react";
 
+import PerformancePacketPages from "./PerformancePacketPages";
 import "./PerformancePacketPreview.css";
 
 function formatDate(value) {
@@ -95,6 +96,7 @@ function PacketFooter({ page }) {
 function PerformancePacketPreview({ packet, onBack }) {
   const scorecard = packet?.scorecard ?? {};
   const subject = packet?.subject ?? {};
+  const context = packet?.context ?? {};
   const topSignature = packet?.signature_accomplishments?.[0];
   const generatedDate = formatDate(packet?.generated_at);
 
@@ -108,12 +110,12 @@ function PerformancePacketPreview({ packet, onBack }) {
 
         <div>
           <span>Performance Packet</span>
-          <strong>Print-first preview</strong>
+          <strong>Physical dossier preview</strong>
         </div>
 
         <button type="button" onClick={() => window.print()}>
           <Printer size={17} />
-          Print preview
+          Print / Save PDF
         </button>
       </header>
 
@@ -124,13 +126,23 @@ function PerformancePacketPreview({ packet, onBack }) {
               <span className="packet-wordmark-mark">B</span>
               <span>BRAGSTACK</span>
             </div>
-            <span className="packet-confidential">Professional development record</span>
+            <span className="packet-confidential">
+              {packet?.confidential
+                ? "Confidential · Professional development record"
+                : "Professional development record"}
+            </span>
           </div>
 
           <div className="packet-cover-main">
             <p className="packet-document-type">Performance Review Packet</p>
             <h1>{subject.name || "BragStack Member"}</h1>
             <h2>{subject.role || "Professional"}</h2>
+            {context.organization && (
+              <p className="packet-cover-context">{context.organization}</p>
+            )}
+            {context.career_area && (
+              <p className="packet-cover-context">{context.career_area}</p>
+            )}
             {subject.location && <p className="packet-location">{subject.location}</p>}
 
             <div className="packet-cover-rule" />
@@ -286,6 +298,8 @@ function PerformancePacketPreview({ packet, onBack }) {
 
           <PacketFooter page={2} />
         </section>
+
+        <PerformancePacketPages packet={packet} />
       </div>
     </main>
   );

--- a/frontend/src/PerformancePacketPreview.jsx
+++ b/frontend/src/PerformancePacketPreview.jsx
@@ -14,6 +14,7 @@ import {
 import { downloadPerformancePacketPdf } from "./api";
 import PerformancePacketPages from "./PerformancePacketPages";
 import "./PerformancePacketPreview.css";
+import "./PerformancePacketExport.css";
 
 function formatDate(value) {
   if (!value) {

--- a/frontend/src/PerformancePacketPreview.jsx
+++ b/frontend/src/PerformancePacketPreview.jsx
@@ -1,7 +1,9 @@
+import { useState } from "react";
 import {
   ArrowLeft,
   Award,
   BarChart3,
+  Download,
   FileText,
   Layers3,
   Printer,
@@ -9,6 +11,7 @@ import {
   Sparkles,
 } from "lucide-react";
 
+import { downloadPerformancePacketPdf } from "./api";
 import PerformancePacketPages from "./PerformancePacketPages";
 import "./PerformancePacketPreview.css";
 
@@ -94,11 +97,44 @@ function PacketFooter({ page }) {
 }
 
 function PerformancePacketPreview({ packet, onBack }) {
+  const [isDownloading, setIsDownloading] = useState(false);
+  const [downloadError, setDownloadError] = useState("");
   const scorecard = packet?.scorecard ?? {};
   const subject = packet?.subject ?? {};
   const context = packet?.context ?? {};
   const topSignature = packet?.signature_accomplishments?.[0];
   const generatedDate = formatDate(packet?.generated_at);
+
+  async function handleDownloadPdf() {
+    setIsDownloading(true);
+    setDownloadError("");
+
+    try {
+      const { blob, filename } = await downloadPerformancePacketPdf(packet);
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = filename;
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      URL.revokeObjectURL(url);
+    } catch (error) {
+      console.error(error);
+      if (error.response?.status === 401) {
+        localStorage.removeItem("bragstack_token");
+        window.location.href = "/login";
+        return;
+      }
+      setDownloadError(
+        error.response?.status === 403
+          ? "PDF export is included with BragStack Pro and higher plans."
+          : "The PDF could not be generated. Try again or use Print as a fallback."
+      );
+    } finally {
+      setIsDownloading(false);
+    }
+  }
 
   return (
     <main className="packet-preview-shell">
@@ -113,11 +149,28 @@ function PerformancePacketPreview({ packet, onBack }) {
           <strong>Physical dossier preview</strong>
         </div>
 
-        <button type="button" onClick={() => window.print()}>
-          <Printer size={17} />
-          Print / Save PDF
-        </button>
+        <span className="packet-preview-toolbar-actions">
+          <button type="button" onClick={() => window.print()}>
+            <Printer size={17} />
+            Print
+          </button>
+          <button
+            type="button"
+            className="packet-download-button"
+            onClick={() => void handleDownloadPdf()}
+            disabled={isDownloading}
+          >
+            <Download size={17} />
+            {isDownloading ? "Building PDF..." : "Download PDF"}
+          </button>
+        </span>
       </header>
+
+      {downloadError && (
+        <p className="packet-preview-download-error" role="alert">
+          {downloadError}
+        </p>
+      )}
 
       <div className="packet-paper-stack">
         <section className="packet-sheet packet-cover" aria-label="Packet cover">

--- a/frontend/src/PerformancePacketPreview.jsx
+++ b/frontend/src/PerformancePacketPreview.jsx
@@ -1,0 +1,294 @@
+import {
+  ArrowLeft,
+  Award,
+  BarChart3,
+  FileText,
+  Layers3,
+  Printer,
+  ShieldCheck,
+  Sparkles,
+} from "lucide-react";
+
+import "./PerformancePacketPreview.css";
+
+function formatDate(value) {
+  if (!value) {
+    return "";
+  }
+
+  return new Intl.DateTimeFormat("en-US", {
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  }).format(new Date(value));
+}
+
+function formatPeriod(period = {}) {
+  if (period.start_date && period.end_date) {
+    return `${formatDate(`${period.start_date}T12:00:00`)} — ${formatDate(
+      `${period.end_date}T12:00:00`
+    )}`;
+  }
+
+  return "All recorded work";
+}
+
+function CoverageRow({ label, value, note }) {
+  const safeValue = Math.max(0, Math.min(100, Number(value) || 0));
+
+  return (
+    <div className="packet-coverage-row">
+      <div className="packet-coverage-copy">
+        <div>
+          <strong>{label}</strong>
+          <span>{note}</span>
+        </div>
+        <b>{safeValue}%</b>
+      </div>
+      <div className="packet-coverage-track" aria-hidden="true">
+        <span style={{ width: `${safeValue}%` }} />
+      </div>
+    </div>
+  );
+}
+
+function RankedList({ title, items }) {
+  const entries = Object.entries(items ?? {}).slice(0, 5);
+  const highest = entries[0]?.[1] || 1;
+
+  return (
+    <div className="packet-ranked-card">
+      <p className="packet-section-kicker">{title}</p>
+
+      {entries.length ? (
+        <div className="packet-ranked-list">
+          {entries.map(([label, count]) => (
+            <div key={label}>
+              <div className="packet-ranked-copy">
+                <span>{label}</span>
+                <strong>{count}</strong>
+              </div>
+              <div className="packet-ranked-track" aria-hidden="true">
+                <span style={{ width: `${Math.max(12, (count / highest) * 100)}%` }} />
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <p className="packet-empty-copy">
+          Add accomplishments and skills to build this view.
+        </p>
+      )}
+    </div>
+  );
+}
+
+function PacketFooter({ page }) {
+  return (
+    <footer className="packet-page-footer">
+      <span>BragStack · Career Evidence System</span>
+      <span>Page {page}</span>
+    </footer>
+  );
+}
+
+function PerformancePacketPreview({ packet, onBack }) {
+  const scorecard = packet?.scorecard ?? {};
+  const subject = packet?.subject ?? {};
+  const topSignature = packet?.signature_accomplishments?.[0];
+  const generatedDate = formatDate(packet?.generated_at);
+
+  return (
+    <main className="packet-preview-shell">
+      <header className="packet-preview-toolbar">
+        <button type="button" onClick={onBack}>
+          <ArrowLeft size={17} />
+          Back to reports
+        </button>
+
+        <div>
+          <span>Performance Packet</span>
+          <strong>Print-first preview</strong>
+        </div>
+
+        <button type="button" onClick={() => window.print()}>
+          <Printer size={17} />
+          Print preview
+        </button>
+      </header>
+
+      <div className="packet-paper-stack">
+        <section className="packet-sheet packet-cover" aria-label="Packet cover">
+          <div className="packet-cover-topline">
+            <div className="packet-wordmark">
+              <span className="packet-wordmark-mark">B</span>
+              <span>BRAGSTACK</span>
+            </div>
+            <span className="packet-confidential">Professional development record</span>
+          </div>
+
+          <div className="packet-cover-main">
+            <p className="packet-document-type">Performance Review Packet</p>
+            <h1>{subject.name || "BragStack Member"}</h1>
+            <h2>{subject.role || "Professional"}</h2>
+            {subject.location && <p className="packet-location">{subject.location}</p>}
+
+            <div className="packet-cover-rule" />
+
+            <div className="packet-period-block">
+              <span>Review period</span>
+              <strong>{formatPeriod(packet?.period)}</strong>
+            </div>
+
+            <div className="packet-cover-stats">
+              <div>
+                <strong>{scorecard.accomplishments ?? 0}</strong>
+                <span>Documented accomplishments</span>
+              </div>
+              <div>
+                <strong>{scorecard.impact_receipts ?? 0}</strong>
+                <span>Impact Receipts</span>
+              </div>
+              <div>
+                <strong>{scorecard.evidence_items ?? 0}</strong>
+                <span>Evidence items</span>
+              </div>
+            </div>
+          </div>
+
+          <div className="packet-cover-bottom">
+            <div>
+              <span>Prepared</span>
+              <strong>{generatedDate || "Today"}</strong>
+            </div>
+            <div className="packet-cover-proofline">
+              <ShieldCheck size={16} />
+              <span>Evidence-backed career record generated from BragStack</span>
+            </div>
+          </div>
+
+          <PacketFooter page={1} />
+        </section>
+
+        <section
+          className="packet-sheet packet-scorecard-page"
+          aria-label="Executive scorecard"
+        >
+          <header className="packet-page-header">
+            <div>
+              <p>01 · Executive Scorecard</p>
+              <h2>Proof at a glance</h2>
+            </div>
+            <div className="packet-page-header-mark">BRAGSTACK</div>
+          </header>
+
+          <p className="packet-scorecard-intro">
+            A transparent summary of documented work for this review period.
+            Coverage measures are calculated from actual accomplishments, Impact
+            Receipts, evidence, and confirmations—not an opaque AI score.
+          </p>
+
+          <section className="packet-stat-grid" aria-label="Packet totals">
+            <article>
+              <FileText size={19} />
+              <span>Accomplishments</span>
+              <strong>{scorecard.accomplishments ?? 0}</strong>
+            </article>
+            <article>
+              <Sparkles size={19} />
+              <span>Impact Receipts</span>
+              <strong>{scorecard.impact_receipts ?? 0}</strong>
+            </article>
+            <article>
+              <ShieldCheck size={19} />
+              <span>Evidence Items</span>
+              <strong>{scorecard.evidence_items ?? 0}</strong>
+            </article>
+            <article>
+              <Layers3 size={19} />
+              <span>Skills Demonstrated</span>
+              <strong>{scorecard.skills_demonstrated ?? 0}</strong>
+            </article>
+          </section>
+
+          <section className="packet-scorecard-section">
+            <div className="packet-section-heading">
+              <div>
+                <p className="packet-section-kicker">Evidence health</p>
+                <h3>Documentation coverage</h3>
+              </div>
+              <BarChart3 size={20} />
+            </div>
+
+            <div className="packet-coverage-list">
+              <CoverageRow
+                label="Impact Receipt coverage"
+                value={scorecard.receipt_coverage_percent}
+                note="Accomplishments converted into structured proof"
+              />
+              <CoverageRow
+                label="Quantified result coverage"
+                value={scorecard.quantified_result_coverage_percent}
+                note="Receipts containing a measurable result"
+              />
+              <CoverageRow
+                label="Evidence coverage"
+                value={scorecard.evidence_coverage_percent}
+                note="Receipts supported by at least one evidence item"
+              />
+              <CoverageRow
+                label="Verification coverage"
+                value={scorecard.verification_coverage_percent}
+                note="Receipts with a confirmed contribution"
+              />
+            </div>
+
+            <div className="packet-evidence-depth">
+              <span>Evidence depth</span>
+              <strong>{scorecard.evidence_depth ?? 0}×</strong>
+              <p>Average supporting evidence items per Impact Receipt.</p>
+            </div>
+          </section>
+
+          <section className="packet-ranked-grid">
+            <RankedList
+              title="Most demonstrated skills"
+              items={packet?.impact_analytics?.top_skills}
+            />
+            <RankedList
+              title="Work themes"
+              items={packet?.impact_analytics?.categories}
+            />
+          </section>
+
+          <section className="packet-signature-callout">
+            <div className="packet-signature-icon">
+              <Award size={21} />
+            </div>
+            <div>
+              <p className="packet-section-kicker">Signature accomplishment</p>
+              {topSignature ? (
+                <>
+                  <h3>{topSignature.title}</h3>
+                  {topSignature.result && <p>{topSignature.result}</p>}
+                </>
+              ) : (
+                <>
+                  <h3>Your strongest proof will appear here.</h3>
+                  <p>
+                    Add an accomplishment with a clear result and Impact Receipt
+                    to strengthen this packet.
+                  </p>
+                </>
+              )}
+            </div>
+          </section>
+
+          <PacketFooter page={2} />
+        </section>
+      </div>
+    </main>
+  );
+}
+
+export default PerformancePacketPreview;

--- a/frontend/src/PublicBragPage.jsx
+++ b/frontend/src/PublicBragPage.jsx
@@ -132,10 +132,6 @@ function PublicBragPage() {
     void loadPage();
   }, [publicSlug, page]);
 
-  useEffect(() => {
-    setPage(1);
-  }, [searchTerm, activeFilter]);
-
   const filteredEntries = useMemo(() => {
     const query = searchTerm.trim().toLowerCase();
 
@@ -148,7 +144,6 @@ function PublicBragPage() {
   }, [entries, searchTerm, activeFilter]);
 
   const categories = Object.entries(categoriesSummary?.categories ?? {});
-  const tags = Object.entries(tagsSummary?.tags ?? {});
   const maxCategoryCount = Math.max(...categories.map(([, count]) => count), 1);
   const maxActivity = Math.max(
     ...entryMeta.activity_last_6_months.map((item) => item.count),
@@ -174,14 +169,19 @@ function PublicBragPage() {
 
   const displayName = profile?.name || "BragStack member";
   const avatarLetter = displayName.charAt(0).toUpperCase() || "B";
-  const totalPages = Math.max(
-    1,
-    Math.ceil(entryMeta.total_entries / PAGE_SIZE),
-  );
-  const start = entryMeta.total_entries
-    ? (page - 1) * PAGE_SIZE + 1
-    : 0;
+  const totalPages = Math.max(1, Math.ceil(entryMeta.total_entries / PAGE_SIZE));
+  const start = entryMeta.total_entries ? (page - 1) * PAGE_SIZE + 1 : 0;
   const end = Math.min(page * PAGE_SIZE, entryMeta.total_entries);
+
+  function handleSearchChange(event) {
+    setSearchTerm(event.target.value);
+    setPage(1);
+  }
+
+  function handleFilterChange(filter) {
+    setActiveFilter(filter);
+    setPage(1);
+  }
 
   return (
     <main className="proof-profile">
@@ -197,10 +197,7 @@ function PublicBragPage() {
         <section className="proof-hero">
           <div>
             <p className="proof-eyebrow">Proof Profile</p>
-            <h1>
-              Career proof,
-              <span>not just claims.</span>
-            </h1>
+            <h1>Career proof,<span>not just claims.</span></h1>
             <p className="proof-headline">
               {profile?.headline || `${displayName}'s evidence-backed career story`}
             </p>
@@ -210,39 +207,22 @@ function PublicBragPage() {
             </p>
 
             {profile?.location && (
-              <p className="proof-location">
-                <MapPin size={15} /> {profile.location}
-              </p>
+              <p className="proof-location"><MapPin size={15} /> {profile.location}</p>
             )}
 
             <div className="proof-actions">
               {profile?.github_url && (
-                <a
-                  className="proof-action primary"
-                  href={profile.github_url}
-                  target="_blank"
-                  rel="noreferrer"
-                >
+                <a className="proof-action primary" href={profile.github_url} target="_blank" rel="noreferrer">
                   GitHub <ExternalLink size={15} />
                 </a>
               )}
               {profile?.portfolio_url && (
-                <a
-                  className="proof-action"
-                  href={profile.portfolio_url}
-                  target="_blank"
-                  rel="noreferrer"
-                >
+                <a className="proof-action" href={profile.portfolio_url} target="_blank" rel="noreferrer">
                   Portfolio <ExternalLink size={15} />
                 </a>
               )}
               {profile?.resume_url && (
-                <a
-                  className="proof-action"
-                  href={profile.resume_url}
-                  target="_blank"
-                  rel="noreferrer"
-                >
+                <a className="proof-action" href={profile.resume_url} target="_blank" rel="noreferrer">
                   Résumé <ExternalLink size={15} />
                 </a>
               )}
@@ -255,32 +235,16 @@ function PublicBragPage() {
               <h2>{displayName}</h2>
             </div>
             <div className="proof-score-grid">
-              <article>
-                <strong>{entryMeta.total_entries}</strong>
-                <span>public wins</span>
-              </article>
-              <article>
-                <strong>{impactReceipts.length}</strong>
-                <span>Impact Receipts</span>
-              </article>
-              <article>
-                <strong>{tagsSummary?.total_unique_tags ?? 0}</strong>
-                <span>skills shown</span>
-              </article>
-              <article>
-                <strong>{weeklyReport?.total_entries ?? 0}</strong>
-                <span>this week</span>
-              </article>
+              <article><strong>{entryMeta.total_entries}</strong><span>public wins</span></article>
+              <article><strong>{impactReceipts.length}</strong><span>Impact Receipts</span></article>
+              <article><strong>{tagsSummary?.total_unique_tags ?? 0}</strong><span>skills shown</span></article>
+              <article><strong>{weeklyReport?.total_entries ?? 0}</strong><span>this week</span></article>
             </div>
           </aside>
         </section>
 
         {isOffline && (
-          <section className="proof-section">
-            <div className="proof-error">
-              Proof Profile data could not be loaded right now.
-            </div>
-          </section>
+          <section className="proof-section"><div className="proof-error">Proof Profile data could not be loaded right now.</div></section>
         )}
 
         {!isOffline && entryMeta.total_entries > 0 && (
@@ -289,31 +253,22 @@ function PublicBragPage() {
               <div>
                 <p className="proof-eyebrow">Career signal</p>
                 <h2>Impact at a glance</h2>
-                <p>
-                  A visual summary of the evidence behind this career story.
-                </p>
+                <p>A visual summary of the evidence behind this career story.</p>
               </div>
-              <span className="proof-live-badge">
-                <Sparkles size={14} /> Live from public proof
-              </span>
+              <span className="proof-live-badge"><Sparkles size={14} /> Live from public proof</span>
             </div>
 
             <div className="proof-kpi-grid">
               <article className="proof-kpi">
-                <span>Receipt coverage</span>
-                <strong>{receiptCoverage}%</strong>
-                <small>
-                  {impactReceipts.length} of {entryMeta.total_entries} wins packaged as receipts
-                </small>
+                <span>Receipt coverage</span><strong>{receiptCoverage}%</strong>
+                <small>{impactReceipts.length} of {entryMeta.total_entries} wins packaged as receipts</small>
               </article>
               <article className="proof-kpi">
-                <span>Evidence-linked</span>
-                <strong>{evidenceCoverage}%</strong>
+                <span>Evidence-linked</span><strong>{evidenceCoverage}%</strong>
                 <small>{evidenceCount} public evidence items</small>
               </article>
               <article className="proof-kpi">
-                <span>Skill breadth</span>
-                <strong>{tagsSummary?.total_unique_tags ?? 0}</strong>
+                <span>Skill breadth</span><strong>{tagsSummary?.total_unique_tags ?? 0}</strong>
                 <small>distinct demonstrated skills</small>
               </article>
             </div>
@@ -327,12 +282,7 @@ function PublicBragPage() {
                       <div className="proof-activity-bar-wrap">
                         <span
                           className="proof-activity-bar"
-                          style={{
-                            height: `${Math.max(
-                              8,
-                              (item.count / maxActivity) * 100,
-                            )}%`,
-                          }}
+                          style={{ height: `${Math.max(8, (item.count / maxActivity) * 100)}%` }}
                           title={`${item.count} accomplishments`}
                         />
                       </div>
@@ -347,19 +297,9 @@ function PublicBragPage() {
                 <div className="proof-bars">
                   {categories.slice(0, 7).map(([category, count]) => (
                     <div className="proof-bar-row" key={category}>
-                      <div className="proof-bar-label">
-                        <span>{category}</span>
-                        <strong>{count}</strong>
-                      </div>
+                      <div className="proof-bar-label"><span>{category}</span><strong>{count}</strong></div>
                       <div className="proof-bar-track">
-                        <span
-                          style={{
-                            width: `${Math.max(
-                              8,
-                              (count / maxCategoryCount) * 100,
-                            )}%`,
-                          }}
-                        />
+                        <span style={{ width: `${Math.max(8, (count / maxCategoryCount) * 100)}%` }} />
                       </div>
                     </div>
                   ))}
@@ -375,13 +315,9 @@ function PublicBragPage() {
               <div>
                 <p className="proof-eyebrow">Featured proof</p>
                 <h2>Impact Receipts</h2>
-                <p>
-                  Structured proof of contribution, result, skills, and evidence.
-                </p>
+                <p>Structured proof of contribution, result, skills, and evidence.</p>
               </div>
-              <span className="proof-live-badge">
-                <ShieldCheck size={14} /> {impactReceipts.length} public
-              </span>
+              <span className="proof-live-badge"><ShieldCheck size={14} /> {impactReceipts.length} public</span>
             </div>
 
             <div className="proof-receipt-grid">
@@ -389,23 +325,11 @@ function PublicBragPage() {
                 <article className="proof-receipt" key={receipt.id}>
                   <p className="proof-eyebrow">Impact Receipt</p>
                   <h3>{receipt.accomplishment}</h3>
-                  <div className="proof-receipt-block">
-                    <span>Contribution</span>
-                    <p>{receipt.contribution}</p>
-                  </div>
-                  <div className="proof-receipt-block">
-                    <span>Result</span>
-                    <p>{receipt.result}</p>
-                  </div>
+                  <div className="proof-receipt-block"><span>Contribution</span><p>{receipt.contribution}</p></div>
+                  <div className="proof-receipt-block"><span>Result</span><p>{receipt.result}</p></div>
                   <div className="proof-chips">
-                    {receipt.trust_signals?.map((signal) => (
-                      <span key={`${receipt.id}-${signal}`}>
-                        {formatSignal(signal)}
-                      </span>
-                    ))}
-                    {receipt.skills?.slice(0, 4).map((skill) => (
-                      <span key={`${receipt.id}-${skill}`}>{skill}</span>
-                    ))}
+                    {receipt.trust_signals?.map((signal) => <span key={`${receipt.id}-${signal}`}>{formatSignal(signal)}</span>)}
+                    {receipt.skills?.slice(0, 4).map((skill) => <span key={`${receipt.id}-${skill}`}>{skill}</span>)}
                   </div>
                 </article>
               ))}
@@ -418,9 +342,7 @@ function PublicBragPage() {
             <div>
               <p className="proof-eyebrow">Evidence library</p>
               <h2>Explore the work</h2>
-              <p>
-                Search the action, impact, projects, skills, and lessons behind the profile.
-              </p>
+              <p>Search the action, impact, projects, skills, and lessons behind the profile.</p>
             </div>
           </div>
 
@@ -429,7 +351,7 @@ function PublicBragPage() {
               <Search size={17} />
               <input
                 value={searchTerm}
-                onChange={(event) => setSearchTerm(event.target.value)}
+                onChange={handleSearchChange}
                 placeholder="Search this page by skill, action, impact, or project..."
               />
             </div>
@@ -439,7 +361,7 @@ function PublicBragPage() {
                   type="button"
                   key={filter}
                   className={activeFilter === filter ? "active" : ""}
-                  onClick={() => setActiveFilter(filter)}
+                  onClick={() => handleFilterChange(filter)}
                 >
                   {filter}
                 </button>
@@ -448,39 +370,20 @@ function PublicBragPage() {
           </div>
 
           {filteredEntries.length === 0 ? (
-            <div className="proof-empty">
-              No matching proof on this page. Try another filter or page.
-            </div>
+            <div className="proof-empty">No matching proof on this page. Try another filter or page.</div>
           ) : (
             <div className="proof-entry-grid">
               {filteredEntries.map((entry) => (
                 <article className="proof-entry-card" key={entry.id}>
-                  <div>
-                    <p className="proof-eyebrow">{entry.category || "General"}</p>
-                    <h3>{entry.title}</h3>
-                  </div>
-                  <div className="proof-entry-meta">
-                    <span>{entry.entry_type || "General"}</span>
-                    <span>{entry.entry_date || "No date"}</span>
-                  </div>
-                  <div className="proof-entry-impact">
-                    <strong>Impact</strong>
-                    <p>{entry.impact || entry.resume_bullet}</p>
-                  </div>
+                  <div><p className="proof-eyebrow">{entry.category || "General"}</p><h3>{entry.title}</h3></div>
+                  <div className="proof-entry-meta"><span>{entry.entry_type || "General"}</span><span>{entry.entry_date || "No date"}</span></div>
+                  <div className="proof-entry-impact"><strong>Impact</strong><p>{entry.impact || entry.resume_bullet}</p></div>
                   <div className="proof-entry-details">
-                    <div>
-                      <strong>Action</strong>
-                      <p>{entry.action || "No action added."}</p>
-                    </div>
-                    <div>
-                      <strong>Situation</strong>
-                      <p>{entry.situation || "No situation added."}</p>
-                    </div>
+                    <div><strong>Action</strong><p>{entry.action || "No action added."}</p></div>
+                    <div><strong>Situation</strong><p>{entry.situation || "No situation added."}</p></div>
                   </div>
                   <div className="proof-chips">
-                    {normalizeTags(entry.tags).map((tag) => (
-                      <span key={`${entry.id}-${tag}`}>{tag}</span>
-                    ))}
+                    {normalizeTags(entry.tags).map((tag) => <span key={`${entry.id}-${tag}`}>{tag}</span>)}
                   </div>
                 </article>
               ))}
@@ -492,34 +395,18 @@ function PublicBragPage() {
               Showing {start}–{end} of {entryMeta.total_entries} public wins · Page {page} of {totalPages}
             </span>
             <div className="proof-pagination-controls">
-              <button
-                type="button"
-                disabled={page === 1}
-                onClick={() => setPage((current) => Math.max(1, current - 1))}
-              >
-                Previous
-              </button>
-              {Array.from({ length: totalPages }, (_, index) => index + 1).map(
-                (pageNumber) => (
-                  <button
-                    type="button"
-                    className={pageNumber === page ? "active" : ""}
-                    key={pageNumber}
-                    onClick={() => setPage(pageNumber)}
-                  >
-                    {pageNumber}
-                  </button>
-                ),
-              )}
-              <button
-                type="button"
-                disabled={page === totalPages}
-                onClick={() =>
-                  setPage((current) => Math.min(totalPages, current + 1))
-                }
-              >
-                Next
-              </button>
+              <button type="button" disabled={page === 1} onClick={() => setPage((current) => Math.max(1, current - 1))}>Previous</button>
+              {Array.from({ length: totalPages }, (_, index) => index + 1).map((pageNumber) => (
+                <button
+                  type="button"
+                  className={pageNumber === page ? "active" : ""}
+                  key={pageNumber}
+                  onClick={() => setPage(pageNumber)}
+                >
+                  {pageNumber}
+                </button>
+              ))}
+              <button type="button" disabled={page === totalPages} onClick={() => setPage((current) => Math.min(totalPages, current + 1))}>Next</button>
             </div>
           </div>
         </section>

--- a/frontend/src/ReportsPage.jsx
+++ b/frontend/src/ReportsPage.jsx
@@ -11,6 +11,7 @@ import {
   Sparkles,
 } from "lucide-react";
 
+import PacketBuilderPanel from "./PacketBuilderPanel";
 import PerformancePacketPreview from "./PerformancePacketPreview";
 import {
   getAllTimeCareerReport,
@@ -25,6 +26,13 @@ const REPORT_TYPES = [
   { key: "all-time", label: "All time" },
   { key: "custom", label: "Custom" },
 ];
+
+const DEFAULT_PACKET_OPTIONS = {
+  careerArea: "",
+  roleTitle: "",
+  organization: "",
+  confidential: true,
+};
 
 function getToday() {
   return new Date().toISOString().slice(0, 10);
@@ -43,9 +51,7 @@ function formatLabel(value = "") {
 }
 
 function buildReportMarkdown(report) {
-  if (!report) {
-    return "";
-  }
+  if (!report) return "";
 
   const totals = report.totals ?? {};
   const period = report.period ?? {};
@@ -66,7 +72,6 @@ function buildReportMarkdown(report) {
     `- Evidence items: ${totals.evidence_items ?? 0}`,
     `- Confirmed contributions: ${totals.confirmed_assertions ?? 0}`,
     `- Quantified results: ${totals.quantified_results ?? 0}`,
-    `- Public proof: ${(totals.public_entries ?? 0) + (totals.public_receipts ?? 0)}`,
     "",
     "## Top Skills",
     "",
@@ -84,17 +89,8 @@ function buildReportMarkdown(report) {
     report.highlights.forEach((highlight) => {
       lines.push(`### ${highlight.title}`);
       lines.push(`- Category: ${highlight.category ?? "Uncategorized"}`);
-      if (highlight.result) {
-        lines.push(`- Result: ${highlight.result}`);
-      }
-      if (highlight.skills?.length) {
-        lines.push(`- Skills: ${highlight.skills.join(", ")}`);
-      }
-      if (highlight.trust_signals?.length) {
-        lines.push(
-          `- Trust signals: ${highlight.trust_signals.map(formatLabel).join(", ")}`
-        );
-      }
+      if (highlight.result) lines.push(`- Result: ${highlight.result}`);
+      if (highlight.skills?.length) lines.push(`- Skills: ${highlight.skills.join(", ")}`);
       lines.push("");
     });
   } else {
@@ -124,10 +120,10 @@ function ReportsPage() {
   const [isPacketLoading, setIsPacketLoading] = useState(false);
   const [packetError, setPacketError] = useState("");
   const [showPacket, setShowPacket] = useState(false);
+  const [packetOptions, setPacketOptions] = useState(DEFAULT_PACKET_OPTIONS);
 
   async function loadReport(type = activeType) {
     const token = localStorage.getItem("bragstack_token");
-
     if (!token) {
       window.location.href = "/login";
       return;
@@ -140,7 +136,6 @@ function ReportsPage() {
 
     try {
       let data;
-
       if (type === "all-time") {
         data = await getAllTimeCareerReport();
       } else if (type === "custom") {
@@ -154,17 +149,12 @@ function ReportsPage() {
       setShowPacket(false);
     } catch (requestError) {
       console.error(requestError);
-
       if (requestError.response?.status === 401) {
         localStorage.removeItem("bragstack_token");
         window.location.href = "/login";
         return;
       }
-
-      setError(
-        requestError.response?.data?.detail ??
-          "The report could not be generated."
-      );
+      setError(requestError.response?.data?.detail ?? "The report could not be generated.");
     } finally {
       setIsLoading(false);
     }
@@ -178,7 +168,6 @@ function ReportsPage() {
     () => Object.entries(report?.top_skills ?? {}).slice(0, 8),
     [report]
   );
-
   const topCategories = useMemo(
     () => Object.entries(report?.categories ?? {}).slice(0, 8),
     [report]
@@ -187,13 +176,10 @@ function ReportsPage() {
   const filteredHighlights = useMemo(() => {
     const query = searchQuery.trim().toLowerCase();
     const highlights = report?.highlights ?? [];
+    if (!query) return highlights;
 
-    if (!query) {
-      return highlights;
-    }
-
-    return highlights.filter((highlight) => {
-      const searchableText = [
+    return highlights.filter((highlight) =>
+      [
         highlight.title,
         highlight.category,
         highlight.result,
@@ -202,20 +188,16 @@ function ReportsPage() {
       ]
         .filter(Boolean)
         .join(" ")
-        .toLowerCase();
-
-      return searchableText.includes(query);
-    });
+        .toLowerCase()
+        .includes(query)
+    );
   }, [report, searchQuery]);
 
   function handleTypeChange(type) {
     setActiveType(type);
     setSearchQuery("");
     setPacketError("");
-
-    if (type !== "custom") {
-      void loadReport(type);
-    }
+    if (type !== "custom") void loadReport(type);
   }
 
   function handleCustomSubmit(event) {
@@ -242,8 +224,7 @@ function ReportsPage() {
 
   function handleCopyBullets() {
     const bullets = report?.resume_bullets ?? [];
-    const text = bullets.map((bullet) => `- ${bullet}`).join("\n");
-    void copyText(text, "Résumé bullets copied.");
+    void copyText(bullets.map((bullet) => `- ${bullet}`).join("\n"), "Résumé bullets copied.");
   }
 
   function handleDownloadReport() {
@@ -251,8 +232,7 @@ function ReportsPage() {
     const blob = new Blob([markdown], { type: "text/markdown;charset=utf-8" });
     const url = URL.createObjectURL(blob);
     const link = document.createElement("a");
-    const periodName =
-      report?.period?.label?.toLowerCase().replace(/\s+/g, "-") || "career";
+    const periodName = report?.period?.label?.toLowerCase().replace(/\s+/g, "-") || "career";
 
     link.href = url;
     link.download = `bragstack-${periodName}-report.md`;
@@ -264,9 +244,7 @@ function ReportsPage() {
   }
 
   async function handleBuildPacket() {
-    if (!report) {
-      return;
-    }
+    if (!report) return;
 
     setIsPacketLoading(true);
     setPacketError("");
@@ -276,14 +254,13 @@ function ReportsPage() {
       const hasDates = Boolean(period.start_date && period.end_date);
       const data = await getPerformancePacket(
         hasDates ? period.start_date : undefined,
-        hasDates ? period.end_date : undefined
+        hasDates ? period.end_date : undefined,
+        packetOptions
       );
-
       setPacket(data.packet);
       setShowPacket(true);
     } catch (requestError) {
       console.error(requestError);
-
       if (requestError.response?.status === 401) {
         localStorage.removeItem("bragstack_token");
         window.location.href = "/login";
@@ -306,12 +283,7 @@ function ReportsPage() {
   }
 
   if (showPacket && packet) {
-    return (
-      <PerformancePacketPreview
-        packet={packet}
-        onBack={() => setShowPacket(false)}
-      />
-    );
+    return <PerformancePacketPreview packet={packet} onBack={() => setShowPacket(false)} />;
   }
 
   const totals = report?.totals ?? {};
@@ -324,12 +296,11 @@ function ReportsPage() {
             <ArrowLeft size={17} />
             Dashboard
           </a>
-
           <p className="reports-eyebrow">BragStack Reports</p>
           <h1>Turn your proof into a career summary.</h1>
           <p className="reports-intro">
-            Review recent work, see your all-time impact, or build a report for
-            a specific review period.
+            Review recent work, see your all-time impact, or build a report for a
+            specific review period.
           </p>
         </div>
 
@@ -361,24 +332,12 @@ function ReportsPage() {
         <form className="custom-report-form" onSubmit={handleCustomSubmit}>
           <label>
             Start date
-            <input
-              type="date"
-              value={startDate}
-              onChange={(event) => setStartDate(event.target.value)}
-              required
-            />
+            <input type="date" value={startDate} onChange={(event) => setStartDate(event.target.value)} required />
           </label>
-
           <label>
             End date
-            <input
-              type="date"
-              value={endDate}
-              onChange={(event) => setEndDate(event.target.value)}
-              required
-            />
+            <input type="date" value={endDate} onChange={(event) => setEndDate(event.target.value)} required />
           </label>
-
           <button type="submit" disabled={isLoading}>
             <CalendarDays size={17} />
             Generate report
@@ -397,16 +356,10 @@ function ReportsPage() {
         <>
           <section className="report-summary-card">
             <div>
-              <p className="reports-eyebrow">
-                {report.period?.label ?? "Career report"}
-              </p>
+              <p className="reports-eyebrow">{report.period?.label ?? "Career report"}</p>
               <h2>{report.summary}</h2>
-              <p>
-                Report dates use the date the work happened, not simply the day
-                it was added to BragStack.
-              </p>
+              <p>Report dates use the date the work happened, not simply the day it was added to BragStack.</p>
             </div>
-
             <span className="report-period-badge">
               {report.period?.start_date && report.period?.end_date
                 ? `${report.period.start_date} → ${report.period.end_date}`
@@ -414,28 +367,13 @@ function ReportsPage() {
             </span>
           </section>
 
-          <section className="packet-builder-card">
-            <div className="packet-builder-copy">
-              <span>Pro · Paper-first</span>
-              <h2>Build a Performance Review Packet</h2>
-              <p>
-                Turn this review period into a professional dossier with a
-                cover, executive scorecard, evidence health, signature
-                accomplishments, and print-ready pages.
-              </p>
-            </div>
-            <button
-              type="button"
-              onClick={() => void handleBuildPacket()}
-              disabled={isPacketLoading}
-            >
-              {isPacketLoading ? "Building packet..." : "Build packet"}
-            </button>
-          </section>
-
-          {packetError && (
-            <p className="packet-builder-error">{String(packetError)}</p>
-          )}
+          <PacketBuilderPanel
+            options={packetOptions}
+            onChange={setPacketOptions}
+            onBuild={() => void handleBuildPacket()}
+            isLoading={isPacketLoading}
+            error={packetError}
+          />
 
           <section className="report-export-bar" aria-label="Report exports">
             <div>
@@ -443,79 +381,32 @@ function ReportsPage() {
               <span>Copy reusable text or download a portable Markdown report.</span>
             </div>
             <div className="report-export-actions">
-              <button type="button" onClick={handleCopyBullets}>
-                <Clipboard size={16} />
-                Copy résumé bullets
-              </button>
-              <button type="button" onClick={handleCopyReport}>
-                <Clipboard size={16} />
-                Copy Markdown
-              </button>
-              <button type="button" onClick={handleDownloadReport}>
-                <Download size={16} />
-                Download .md
-              </button>
+              <button type="button" onClick={handleCopyBullets}><Clipboard size={16} />Copy résumé bullets</button>
+              <button type="button" onClick={handleCopyReport}><Clipboard size={16} />Copy Markdown</button>
+              <button type="button" onClick={handleDownloadReport}><Download size={16} />Download .md</button>
             </div>
           </section>
 
           {copyNotice && <p className="report-copy-notice">{copyNotice}</p>}
 
           <section className="report-metrics">
-            <article>
-              <FileText size={20} />
-              <span>Accomplishments</span>
-              <strong>{totals.entries ?? 0}</strong>
-            </article>
-
-            <article>
-              <Sparkles size={20} />
-              <span>Impact Receipts</span>
-              <strong>{totals.impact_receipts ?? 0}</strong>
-            </article>
-
-            <article>
-              <ShieldCheck size={20} />
-              <span>Evidence items</span>
-              <strong>{totals.evidence_items ?? 0}</strong>
-            </article>
-
-            <article>
-              <ShieldCheck size={20} />
-              <span>Confirmed contributions</span>
-              <strong>{totals.confirmed_assertions ?? 0}</strong>
-            </article>
-
-            <article>
-              <Sparkles size={20} />
-              <span>Quantified results</span>
-              <strong>{totals.quantified_results ?? 0}</strong>
-            </article>
-
-            <article>
-              <FileText size={20} />
-              <span>Public proof</span>
-              <strong>
-                {(totals.public_entries ?? 0) +
-                  (totals.public_receipts ?? 0)}
-              </strong>
-            </article>
+            <article><FileText size={20} /><span>Accomplishments</span><strong>{totals.entries ?? 0}</strong></article>
+            <article><Sparkles size={20} /><span>Impact Receipts</span><strong>{totals.impact_receipts ?? 0}</strong></article>
+            <article><ShieldCheck size={20} /><span>Evidence items</span><strong>{totals.evidence_items ?? 0}</strong></article>
+            <article><ShieldCheck size={20} /><span>Confirmed contributions</span><strong>{totals.confirmed_assertions ?? 0}</strong></article>
+            <article><Sparkles size={20} /><span>Quantified results</span><strong>{totals.quantified_results ?? 0}</strong></article>
+            <article><FileText size={20} /><span>Public proof</span><strong>{(totals.public_entries ?? 0) + (totals.public_receipts ?? 0)}</strong></article>
           </section>
 
           <section className="report-two-column">
             <article className="report-panel">
               <p className="reports-eyebrow">Skill signal</p>
               <h2>Top skills</h2>
-
               {topSkills.length === 0 ? (
                 <p className="report-muted">No skill data for this period.</p>
               ) : (
                 <div className="report-ranked-list">
-                  {topSkills.map(([skill, count]) => (
-                    <div key={skill}>
-                      <span>{skill}</span>
-                      <strong>{count}</strong>
-                    </div>
-                  ))}
+                  {topSkills.map(([skill, count]) => <div key={skill}><span>{skill}</span><strong>{count}</strong></div>)}
                 </div>
               )}
             </article>
@@ -523,17 +414,11 @@ function ReportsPage() {
             <article className="report-panel">
               <p className="reports-eyebrow">Work mix</p>
               <h2>Top categories</h2>
-
               {topCategories.length === 0 ? (
                 <p className="report-muted">No category data for this period.</p>
               ) : (
                 <div className="report-ranked-list">
-                  {topCategories.map(([category, count]) => (
-                    <div key={category}>
-                      <span>{category}</span>
-                      <strong>{count}</strong>
-                    </div>
-                  ))}
+                  {topCategories.map(([category, count]) => <div key={category}><span>{category}</span><strong>{count}</strong></div>)}
                 </div>
               )}
             </article>
@@ -541,10 +426,7 @@ function ReportsPage() {
 
           <section className="report-panel report-highlights">
             <div className="report-panel-heading">
-              <div>
-                <p className="reports-eyebrow">Career proof</p>
-                <h2>Highlights</h2>
-              </div>
+              <div><p className="reports-eyebrow">Career proof</p><h2>Highlights</h2></div>
               <span>{filteredHighlights.length} shown</span>
             </div>
 
@@ -563,62 +445,38 @@ function ReportsPage() {
                 {filteredHighlights.map((highlight) => (
                   <article key={highlight.entry_id}>
                     <div className="report-highlight-top">
-                      <div>
-                        <p>{highlight.category}</p>
-                        <h3>{highlight.title}</h3>
-                      </div>
-
+                      <div><p>{highlight.category}</p><h3>{highlight.title}</h3></div>
                       <div className="report-highlight-badges">
                         {highlight.has_receipt && <span>Impact Receipt</span>}
                         {highlight.is_public && <span>Public</span>}
                       </div>
                     </div>
-
                     {highlight.result && <p>{highlight.result}</p>}
-
                     <div className="report-skill-tags">
-                      {highlight.skills?.map((skill) => (
-                        <span key={`${highlight.entry_id}-${skill}`}>
-                          {skill}
-                        </span>
-                      ))}
+                      {highlight.skills?.map((skill) => <span key={`${highlight.entry_id}-${skill}`}>{skill}</span>)}
                     </div>
-
                     {highlight.trust_signals?.length > 0 && (
                       <div className="report-trust-line">
-                        {highlight.trust_signals.map((signal) => (
-                          <span key={`${highlight.entry_id}-${signal}`}>
-                            {formatLabel(signal)}
-                          </span>
-                        ))}
+                        {highlight.trust_signals.map((signal) => <span key={`${highlight.entry_id}-${signal}`}>{formatLabel(signal)}</span>)}
                       </div>
                     )}
                   </article>
                 ))}
               </div>
             ) : (
-              <p className="report-muted">
-                {searchQuery
-                  ? "No highlights match that search."
-                  : "No accomplishments were recorded for this period."}
-              </p>
+              <p className="report-muted">{searchQuery ? "No highlights match that search." : "No accomplishments were recorded for this period."}</p>
             )}
           </section>
 
           <section className="report-panel">
             <p className="reports-eyebrow">Ready-to-use material</p>
             <h2>Résumé bullets</h2>
-
             {report.resume_bullets?.length ? (
               <ul className="resume-bullet-list">
-                {report.resume_bullets.map((bullet, index) => (
-                  <li key={`${index}-${bullet}`}>{bullet}</li>
-                ))}
+                {report.resume_bullets.map((bullet, index) => <li key={`${index}-${bullet}`}>{bullet}</li>)}
               </ul>
             ) : (
-              <p className="report-muted">
-                No résumé bullets were generated for this period.
-              </p>
+              <p className="report-muted">No résumé bullets were generated for this period.</p>
             )}
           </section>
         </>

--- a/frontend/src/ReportsPage.jsx
+++ b/frontend/src/ReportsPage.jsx
@@ -11,9 +11,11 @@ import {
   Sparkles,
 } from "lucide-react";
 
+import PerformancePacketPreview from "./PerformancePacketPreview";
 import {
   getAllTimeCareerReport,
   getCustomCareerReport,
+  getPerformancePacket,
   getWeeklyCareerReport,
 } from "./api";
 import "./ReportsPage.css";
@@ -118,6 +120,10 @@ function ReportsPage() {
   const [endDate, setEndDate] = useState(getToday());
   const [searchQuery, setSearchQuery] = useState("");
   const [copyNotice, setCopyNotice] = useState("");
+  const [packet, setPacket] = useState(null);
+  const [isPacketLoading, setIsPacketLoading] = useState(false);
+  const [packetError, setPacketError] = useState("");
+  const [showPacket, setShowPacket] = useState(false);
 
   async function loadReport(type = activeType) {
     const token = localStorage.getItem("bragstack_token");
@@ -130,6 +136,7 @@ function ReportsPage() {
     setIsLoading(true);
     setError("");
     setCopyNotice("");
+    setPacketError("");
 
     try {
       let data;
@@ -143,6 +150,8 @@ function ReportsPage() {
       }
 
       setReport(data);
+      setPacket(null);
+      setShowPacket(false);
     } catch (requestError) {
       console.error(requestError);
 
@@ -202,6 +211,7 @@ function ReportsPage() {
   function handleTypeChange(type) {
     setActiveType(type);
     setSearchQuery("");
+    setPacketError("");
 
     if (type !== "custom") {
       void loadReport(type);
@@ -212,6 +222,7 @@ function ReportsPage() {
     event.preventDefault();
     setActiveType("custom");
     setSearchQuery("");
+    setPacketError("");
     void loadReport("custom");
   }
 
@@ -240,7 +251,8 @@ function ReportsPage() {
     const blob = new Blob([markdown], { type: "text/markdown;charset=utf-8" });
     const url = URL.createObjectURL(blob);
     const link = document.createElement("a");
-    const periodName = report?.period?.label?.toLowerCase().replace(/\s+/g, "-") || "career";
+    const periodName =
+      report?.period?.label?.toLowerCase().replace(/\s+/g, "-") || "career";
 
     link.href = url;
     link.download = `bragstack-${periodName}-report.md`;
@@ -249,6 +261,57 @@ function ReportsPage() {
     link.remove();
     URL.revokeObjectURL(url);
     setCopyNotice("Markdown report downloaded.");
+  }
+
+  async function handleBuildPacket() {
+    if (!report) {
+      return;
+    }
+
+    setIsPacketLoading(true);
+    setPacketError("");
+
+    try {
+      const period = report.period ?? {};
+      const hasDates = Boolean(period.start_date && period.end_date);
+      const data = await getPerformancePacket(
+        hasDates ? period.start_date : undefined,
+        hasDates ? period.end_date : undefined
+      );
+
+      setPacket(data.packet);
+      setShowPacket(true);
+    } catch (requestError) {
+      console.error(requestError);
+
+      if (requestError.response?.status === 401) {
+        localStorage.removeItem("bragstack_token");
+        window.location.href = "/login";
+        return;
+      }
+
+      if (requestError.response?.status === 403) {
+        setPacketError(
+          "Performance Review Packets are included with BragStack Pro. Your standard career reports remain available on Free."
+        );
+      } else {
+        setPacketError(
+          requestError.response?.data?.detail ??
+            "The Performance Review Packet could not be built."
+        );
+      }
+    } finally {
+      setIsPacketLoading(false);
+    }
+  }
+
+  if (showPacket && packet) {
+    return (
+      <PerformancePacketPreview
+        packet={packet}
+        onBack={() => setShowPacket(false)}
+      />
+    );
   }
 
   const totals = report?.totals ?? {};
@@ -350,6 +413,29 @@ function ReportsPage() {
                 : "All recorded work"}
             </span>
           </section>
+
+          <section className="packet-builder-card">
+            <div className="packet-builder-copy">
+              <span>Pro · Paper-first</span>
+              <h2>Build a Performance Review Packet</h2>
+              <p>
+                Turn this review period into a professional dossier with a
+                cover, executive scorecard, evidence health, signature
+                accomplishments, and print-ready pages.
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={() => void handleBuildPacket()}
+              disabled={isPacketLoading}
+            >
+              {isPacketLoading ? "Building packet..." : "Build packet"}
+            </button>
+          </section>
+
+          {packetError && (
+            <p className="packet-builder-error">{String(packetError)}</p>
+          )}
 
           <section className="report-export-bar" aria-label="Report exports">
             <div>

--- a/frontend/src/ReportsPage.jsx
+++ b/frontend/src/ReportsPage.jsx
@@ -161,7 +161,11 @@ function ReportsPage() {
   }
 
   useEffect(() => {
-    void loadReport("weekly");
+    const timeoutId = window.setTimeout(() => {
+      void loadReport("weekly");
+    }, 0);
+
+    return () => window.clearTimeout(timeoutId);
   }, []);
 
   const topSkills = useMemo(

--- a/frontend/src/RootContent.jsx
+++ b/frontend/src/RootContent.jsx
@@ -1,0 +1,32 @@
+import AccomplishmentsPage from "./AccomplishmentsPage.jsx";
+import App from "./App.jsx";
+import AppSidebar from "./AppSidebar.jsx";
+import ImpactReceiptsPage from "./ImpactReceiptsPage.jsx";
+
+function RootContent() {
+  const path = window.location.pathname;
+  const isAuthenticatedApp = path.startsWith("/app");
+
+  let Content = App;
+
+  if (path === "/app/accomplishments") {
+    Content = AccomplishmentsPage;
+  } else if (path === "/app/impact-receipts") {
+    Content = ImpactReceiptsPage;
+  }
+
+  if (!isAuthenticatedApp) {
+    return <Content />;
+  }
+
+  return (
+    <div className="app-shell">
+      <AppSidebar />
+      <div className="authenticated-content">
+        <Content />
+      </div>
+    </div>
+  );
+}
+
+export default RootContent;

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -165,16 +165,21 @@ export async function getCustomCareerReport(startDate, endDate) {
   return response.data;
 }
 
-export async function getPerformancePacket(startDate, endDate) {
-  const params =
-    startDate && endDate
+export async function getPerformancePacket(startDate, endDate, options = {}) {
+  const params = {
+    ...(startDate && endDate
       ? {
           start_date: startDate,
           end_date: endDate,
         }
-      : undefined;
+      : {}),
+    ...(options.careerArea ? { career_area: options.careerArea } : {}),
+    ...(options.roleTitle ? { role_title: options.roleTitle } : {}),
+    ...(options.organization ? { organization: options.organization } : {}),
+    confidential: options.confidential !== false,
+  };
 
-  const response = await api.get("/reports/performance-packet", { params });
+  const response = await api.get("/packets/performance-review", { params });
   return response.data;
 }
 

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -165,6 +165,19 @@ export async function getCustomCareerReport(startDate, endDate) {
   return response.data;
 }
 
+export async function getPerformancePacket(startDate, endDate) {
+  const params =
+    startDate && endDate
+      ? {
+          start_date: startDate,
+          end_date: endDate,
+        }
+      : undefined;
+
+  const response = await api.get("/reports/performance-packet", { params });
+  return response.data;
+}
+
 export async function getPublicImpactReceipts(slug) {
   const response = await api.get(getPublicBragPath(slug, "/impact-receipts"));
   return response.data;

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -26,6 +26,26 @@ function getPublicBragPath(slug, suffix = "") {
   return `/public/brag/${encodeURIComponent(normalizedSlug)}${suffix}`;
 }
 
+function getPacketParams(startDate, endDate, options = {}) {
+  return {
+    ...(startDate && endDate
+      ? {
+          start_date: startDate,
+          end_date: endDate,
+        }
+      : {}),
+    ...(options.careerArea ? { career_area: options.careerArea } : {}),
+    ...(options.roleTitle ? { role_title: options.roleTitle } : {}),
+    ...(options.organization ? { organization: options.organization } : {}),
+    confidential: options.confidential !== false,
+  };
+}
+
+function parseDownloadFilename(contentDisposition, fallback) {
+  const match = contentDisposition?.match(/filename="?([^";]+)"?/i);
+  return match?.[1] || fallback;
+}
+
 api.interceptors.request.use((config) => {
   const token = localStorage.getItem("bragstack_token");
 
@@ -166,21 +186,35 @@ export async function getCustomCareerReport(startDate, endDate) {
 }
 
 export async function getPerformancePacket(startDate, endDate, options = {}) {
-  const params = {
-    ...(startDate && endDate
-      ? {
-          start_date: startDate,
-          end_date: endDate,
-        }
-      : {}),
-    ...(options.careerArea ? { career_area: options.careerArea } : {}),
-    ...(options.roleTitle ? { role_title: options.roleTitle } : {}),
-    ...(options.organization ? { organization: options.organization } : {}),
-    confidential: options.confidential !== false,
-  };
-
-  const response = await api.get("/packets/performance-review", { params });
+  const response = await api.get("/packets/performance-review", {
+    params: getPacketParams(startDate, endDate, options),
+  });
   return response.data;
+}
+
+export async function downloadPerformancePacketPdf(packet) {
+  const period = packet?.period ?? {};
+  const context = packet?.context ?? {};
+  const subject = packet?.subject ?? {};
+  const params = getPacketParams(period.start_date, period.end_date, {
+    careerArea: context.career_area,
+    roleTitle: subject.role,
+    organization: context.organization,
+    confidential: packet?.confidential !== false,
+  });
+
+  const response = await api.get("/packets/performance-review.pdf", {
+    params,
+    responseType: "blob",
+  });
+
+  return {
+    blob: response.data,
+    filename: parseDownloadFilename(
+      response.headers["content-disposition"],
+      "bragstack-performance-review.pdf"
+    ),
+  };
 }
 
 export async function getPublicImpactReceipts(slug) {

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -3,33 +3,10 @@ import { createRoot } from "react-dom/client";
 
 import "./index.css";
 import "./ProductPolish.css";
-import App from "./App.jsx";
-import AccomplishmentsPage from "./AccomplishmentsPage.jsx";
-import ImpactReceiptsPage from "./ImpactReceiptsPage.jsx";
-import AppSidebar from "./AppSidebar.jsx";
-
-const path = window.location.pathname;
-const isAuthenticatedApp = path.startsWith("/app");
-
-let Content = App;
-
-if (path === "/app/accomplishments") {
-  Content = AccomplishmentsPage;
-} else if (path === "/app/impact-receipts") {
-  Content = ImpactReceiptsPage;
-}
+import RootContent from "./RootContent.jsx";
 
 createRoot(document.getElementById("root")).render(
   <StrictMode>
-    {isAuthenticatedApp ? (
-      <div className="app-shell">
-        <AppSidebar />
-        <div className="authenticated-content">
-          <Content />
-        </div>
-      </div>
-    ) : (
-      <Content />
-    )}
+    <RootContent />
   </StrictMode>,
 );


### PR DESCRIPTION
## What changed

- adds a dedicated, Pro-gated `/packets/performance-review` API for complete Performance Review Packet data
- keeps the packet schema and language career-neutral across healthcare, education, sales, operations, skilled trades, creative work, customer service, management, government, nonprofit, students, technology, and other careers
- supports review-period selection plus optional career area, role title, organization/team, and confidential marking
- calculates transparent evidence metrics from real Brag Entries and Impact Receipts: receipt coverage, quantified-result coverage, evidence coverage, verification coverage, evidence depth, skill breadth, and confirmed assertions
- adds activity trends, work themes, trust signals, skill evidence timelines, signature accomplishments, measurable results, contribution records, deterministic Impact Receipt references, evidence index data, review narrative, and review talking points
- renders a paper-first US Letter dossier with a physical packet preview
- includes Cover, Executive Scorecard, Impact Analytics, Signature Accomplishments, Measurable Results, Skills & Growth, Contribution & Recognition, Impact Receipt appendix, Evidence Index, and Review Summary pages
- dynamically creates additional receipt/evidence pages as the packet grows
- adds receipt-style proof records with contribution, result, skills, evidence counts, confirmations, shared credit, and verification state
- adds print-specific Letter sizing and keeps browser Print as a fallback
- adds a true one-click `Download PDF` flow backed by a server-generated ReportLab PDF
- enforces the dedicated `export_pdf` entitlement at the PDF export boundary
- emits deterministic US Letter pages with repeated BragStack/review-period/page footers, optional confidential marking, safe clickable evidence links, and filenames containing the user + review period
- tests both normal PDF generation and long evidence-heavy packet generation
- adds dedicated backend coverage using non-technical community-programs and operations examples
- adds Frontend CI so pull requests now run both ESLint and the Vite production build
- fixes pre-existing React lint issues surfaced by the new frontend gate

## Why

BragStack Pro needs a tangible artifact someone would actually pay for—not another dashboard card. The Performance Review Packet turns documented work into a professional, evidence-backed dossier that can be reviewed on screen, downloaded as a real PDF, printed, attached to a review, or brought into a career conversation in any profession.

## Product principles

- universal career language rather than tech-specific assumptions
- real evidence and reproducible stats rather than opaque AI scoring
- print-first presentation rather than a dashboard screenshot
- every claim should lead back to documented work, an Impact Receipt, evidence, or confirmation
- missing proof should create useful empty states rather than invented content
- PDF export should be a real artifact, not a rasterized screenshot

## Validation

- Backend CI ✅
- Frontend ESLint ✅
- Frontend production build ✅
- direct PDF generation tests ✅
- long evidence-index PDF generation test ✅
- Free users receive the paid-feature response for packet generation/export
- Pro packet tests cover custom periods and non-tech career scenarios

Closes #13
Closes #14
Closes #15
Closes #16
Closes #17
Closes #18.