### PR TITLE
Add evidence-backed Promotion Packet V1

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5,6 +5,7 @@ from app.auth_routes import router as auth_router
 from app.impact_receipt_routes import router as impact_receipts_router
 from app.performance_packet_export_routes import router as performance_packet_export_router
 from app.performance_packet_routes import router as performance_packet_router
+from app.promotion_packet_routes import router as promotion_packet_router
 from app.public_slug_routes import router as public_slug_router
 from app.reports_routes import router as reports_router
 from app.routes import public_router, router as entries_router
@@ -36,6 +37,7 @@ app.include_router(impact_receipts_router)
 app.include_router(reports_router)
 app.include_router(performance_packet_router)
 app.include_router(performance_packet_export_router)
+app.include_router(promotion_packet_router)
 
 
 @app.get("/")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5,6 +5,7 @@ from app.auth_routes import router as auth_router
 from app.impact_receipt_routes import router as impact_receipts_router
 from app.performance_packet_export_routes import router as performance_packet_export_router
 from app.performance_packet_routes import router as performance_packet_router
+from app.promotion_packet_export_routes import router as promotion_packet_export_router
 from app.promotion_packet_routes import router as promotion_packet_router
 from app.public_slug_routes import router as public_slug_router
 from app.reports_routes import router as reports_router
@@ -38,6 +39,7 @@ app.include_router(reports_router)
 app.include_router(performance_packet_router)
 app.include_router(performance_packet_export_router)
 app.include_router(promotion_packet_router)
+app.include_router(promotion_packet_export_router)
 
 
 @app.get("/")

--- a/backend/app/promotion_packet_export_routes.py
+++ b/backend/app/promotion_packet_export_routes.py
@@ -6,9 +6,9 @@ from fastapi import APIRouter, Depends, Query
 from fastapi.responses import StreamingResponse
 
 from app.auth import get_current_user
-from app.performance_packet_pdf import build_performance_packet_pdf, make_packet_filename
 from app.performance_packet_routes import _parse_period
 from app.plans import require_feature
+from app.promotion_packet_pdf import build_promotion_packet_pdf, make_promotion_packet_filename
 from app.promotion_packet_routes import _build_promotion_packet
 
 
@@ -43,8 +43,8 @@ def download_promotion_packet_pdf(
         target_level=target_level,
     )["packet"]
 
-    pdf_bytes = build_performance_packet_pdf(packet)
-    filename = make_packet_filename(packet)
+    pdf_bytes = build_promotion_packet_pdf(packet)
+    filename = make_promotion_packet_filename(packet)
 
     return StreamingResponse(
         io.BytesIO(pdf_bytes),

--- a/backend/app/promotion_packet_export_routes.py
+++ b/backend/app/promotion_packet_export_routes.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import io
+
+from fastapi import APIRouter, Depends, Query
+from fastapi.responses import StreamingResponse
+
+from app.auth import get_current_user
+from app.performance_packet_pdf import build_performance_packet_pdf, make_packet_filename
+from app.performance_packet_routes import _parse_period
+from app.plans import require_feature
+from app.promotion_packet_routes import _build_promotion_packet
+
+
+router = APIRouter(prefix="/packets", tags=["packets"])
+
+
+@router.get("/promotion.pdf")
+def download_promotion_packet_pdf(
+    start_date: str | None = Query(None),
+    end_date: str | None = Query(None),
+    career_area: str | None = Query(None, max_length=120),
+    role_title: str | None = Query(None, max_length=160),
+    organization: str | None = Query(None, max_length=180),
+    confidential: bool = Query(True),
+    target_role: str | None = Query(None, max_length=160),
+    target_level: str | None = Query(None, max_length=120),
+    current_user: dict = Depends(get_current_user),
+):
+    """Generate a downloadable PDF promotion packet for eligible plans."""
+
+    require_feature(current_user, "export_pdf")
+    parsed_start, parsed_end = _parse_period(start_date, end_date)
+    packet = _build_promotion_packet(
+        current_user=current_user,
+        start_date=parsed_start,
+        end_date=parsed_end,
+        career_area=career_area,
+        role_title=role_title,
+        organization=organization,
+        confidential=confidential,
+        target_role=target_role,
+        target_level=target_level,
+    )["packet"]
+
+    pdf_bytes = build_performance_packet_pdf(packet)
+    filename = make_packet_filename(packet)
+
+    return StreamingResponse(
+        io.BytesIO(pdf_bytes),
+        media_type="application/pdf",
+        headers={
+            "Content-Disposition": f'attachment; filename="{filename}"',
+            "Cache-Control": "private, no-store",
+            "X-Content-Type-Options": "nosniff",
+        },
+    )

--- a/backend/app/promotion_packet_pdf.py
+++ b/backend/app/promotion_packet_pdf.py
@@ -1,0 +1,424 @@
+from __future__ import annotations
+
+import io
+import re
+from html import escape
+from typing import Any
+
+from reportlab.graphics.shapes import Drawing, Rect, String
+from reportlab.lib import colors
+from reportlab.lib.pagesizes import LETTER
+from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
+from reportlab.lib.units import inch
+from reportlab.platypus import (
+    HRFlowable,
+    PageBreak,
+    Paragraph,
+    SimpleDocTemplate,
+    Spacer,
+    Table,
+    TableStyle,
+)
+
+TEAL = colors.HexColor("#173F43")
+TEAL_2 = colors.HexColor("#1F5559")
+GOLD = colors.HexColor("#B68B4C")
+INK = colors.HexColor("#172126")
+MUTED = colors.HexColor("#667176")
+LIGHT = colors.HexColor("#F3F1EA")
+LINE = colors.HexColor("#DEDAD0")
+PAGE_WIDTH, PAGE_HEIGHT = LETTER
+MARGIN_X = 0.62 * inch
+CONTENT_WIDTH = PAGE_WIDTH - (MARGIN_X * 2)
+
+
+def _clean(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _safe(value: Any) -> str:
+    return escape(_clean(value))
+
+
+def _period_display(period: dict[str, Any]) -> str:
+    if period.get("start_date") and period.get("end_date"):
+        return f"{period['start_date']} — {period['end_date']}"
+    return period.get("label") or "All recorded work"
+
+
+def _safe_filename_part(value: str, fallback: str) -> str:
+    cleaned = re.sub(r"[^A-Za-z0-9]+", "-", value or "").strip("-")
+    return cleaned or fallback
+
+
+def make_promotion_packet_filename(packet: dict[str, Any]) -> str:
+    subject = packet.get("subject", {})
+    period = packet.get("period", {})
+    subject_part = _safe_filename_part(_clean(subject.get("name")), "bragstack-member")
+    if period.get("start_date") and period.get("end_date"):
+        period_part = f"{period['start_date']}-to-{period['end_date']}"
+    else:
+        period_part = "all-time"
+    return f"{subject_part}-promotion-packet-{period_part}.pdf"
+
+
+def _styles() -> dict[str, ParagraphStyle]:
+    base = getSampleStyleSheet()
+    return {
+        "kicker": ParagraphStyle(
+            "PromotionKicker",
+            parent=base["Normal"],
+            fontName="Helvetica-Bold",
+            fontSize=7.4,
+            leading=9.5,
+            textColor=TEAL_2,
+            spaceAfter=4,
+        ),
+        "cover_name": ParagraphStyle(
+            "PromotionCoverName",
+            parent=base["Title"],
+            fontName="Times-Bold",
+            fontSize=31,
+            leading=33,
+            textColor=INK,
+            spaceAfter=8,
+        ),
+        "cover_role": ParagraphStyle(
+            "PromotionCoverRole",
+            parent=base["Normal"],
+            fontName="Helvetica",
+            fontSize=13,
+            leading=17,
+            textColor=colors.HexColor("#454E54"),
+            spaceAfter=5,
+        ),
+        "title": ParagraphStyle(
+            "PromotionTitle",
+            parent=base["Heading1"],
+            fontName="Times-Bold",
+            fontSize=23,
+            leading=26,
+            textColor=INK,
+            spaceAfter=9,
+        ),
+        "subhead": ParagraphStyle(
+            "PromotionSubhead",
+            parent=base["Heading2"],
+            fontName="Times-Bold",
+            fontSize=13,
+            leading=16,
+            textColor=INK,
+            spaceBefore=3,
+            spaceAfter=5,
+        ),
+        "body": ParagraphStyle(
+            "PromotionBody",
+            parent=base["BodyText"],
+            fontName="Helvetica",
+            fontSize=8.5,
+            leading=12,
+            textColor=colors.HexColor("#505A60"),
+            spaceAfter=6,
+        ),
+        "small": ParagraphStyle(
+            "PromotionSmall",
+            parent=base["BodyText"],
+            fontName="Helvetica",
+            fontSize=7.3,
+            leading=9.8,
+            textColor=MUTED,
+            spaceAfter=4,
+        ),
+        "metric": ParagraphStyle(
+            "PromotionMetric",
+            parent=base["Normal"],
+            fontName="Times-Bold",
+            fontSize=18,
+            leading=20,
+            textColor=TEAL,
+            alignment=1,
+        ),
+        "metric_label": ParagraphStyle(
+            "PromotionMetricLabel",
+            parent=base["Normal"],
+            fontName="Helvetica-Bold",
+            fontSize=6.2,
+            leading=8,
+            textColor=MUTED,
+            alignment=1,
+        ),
+    }
+
+
+def _section_header(story: list, styles: dict[str, ParagraphStyle], index: str, title: str) -> None:
+    story.append(Paragraph(_safe(index), styles["kicker"]))
+    story.append(Paragraph(_safe(title), styles["title"]))
+    story.append(HRFlowable(width="100%", thickness=1.7, color=TEAL, spaceAfter=12))
+
+
+def _footer(canvas, doc, packet: dict[str, Any]) -> None:
+    canvas.saveState()
+    canvas.setStrokeColor(LINE)
+    canvas.setLineWidth(0.5)
+    canvas.line(MARGIN_X, 0.42 * inch, PAGE_WIDTH - MARGIN_X, 0.42 * inch)
+    canvas.setFillColor(MUTED)
+    canvas.setFont("Helvetica", 6.5)
+    canvas.drawString(MARGIN_X, 0.27 * inch, "BragStack · Career Evidence System")
+    canvas.drawCentredString(PAGE_WIDTH / 2, 0.27 * inch, _period_display(packet.get("period", {}))[:70])
+    canvas.drawRightString(PAGE_WIDTH - MARGIN_X, 0.27 * inch, f"Page {doc.page}")
+    if packet.get("confidential"):
+        canvas.setFillColor(TEAL)
+        canvas.setFont("Helvetica-Bold", 6.4)
+        canvas.drawRightString(PAGE_WIDTH - MARGIN_X, PAGE_HEIGHT - 0.34 * inch, "CONFIDENTIAL")
+    canvas.restoreState()
+
+
+def _metrics_table(scorecard: dict[str, Any], styles: dict[str, ParagraphStyle]) -> Table:
+    values = [
+        (scorecard.get("accomplishments", 0), "Accomplishments"),
+        (scorecard.get("impact_receipts", 0), "Impact Receipts"),
+        (scorecard.get("evidence_items", 0), "Evidence Items"),
+        (scorecard.get("confirmed_assertions", 0), "Confirmed Signals"),
+    ]
+    cells = []
+    for value, label in values:
+        cells.append([
+            Paragraph(_safe(value), styles["metric"]),
+            Paragraph(_safe(label), styles["metric_label"]),
+        ])
+    table = Table([cells], colWidths=[CONTENT_WIDTH / 4] * 4)
+    table.setStyle(
+        TableStyle(
+            [
+                ("BOX", (0, 0), (-1, -1), 0.7, LINE),
+                ("INNERGRID", (0, 0), (-1, -1), 0.5, LINE),
+                ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
+                ("TOPPADDING", (0, 0), (-1, -1), 10),
+                ("BOTTOMPADDING", (0, 0), (-1, -1), 10),
+            ]
+        )
+    )
+    return table
+
+
+def _bars(items: dict[str, int], styles: dict[str, ParagraphStyle], limit: int = 8) -> Drawing:
+    entries = list(items.items())[:limit]
+    row_h = 19
+    height = max(28, len(entries) * row_h + 6)
+    drawing = Drawing(CONTENT_WIDTH, height)
+    if not entries:
+        drawing.add(String(0, height - 14, "No data for this period.", fontName="Helvetica", fontSize=8, fillColor=MUTED))
+        return drawing
+    maximum = max(value for _, value in entries) or 1
+    label_w = 140
+    bar_w = CONTENT_WIDTH - label_w - 35
+    for index, (label, value) in enumerate(entries):
+        y = height - ((index + 1) * row_h) + 4
+        drawing.add(String(0, y + 4, str(label)[:28], fontName="Helvetica", fontSize=7.2, fillColor=INK))
+        drawing.add(Rect(label_w, y + 2, bar_w, 7, fillColor=colors.HexColor("#E8E5DC"), strokeColor=None))
+        drawing.add(Rect(label_w, y + 2, max(6, bar_w * (float(value) / maximum)), 7, fillColor=TEAL_2, strokeColor=None))
+        drawing.add(String(label_w + bar_w + 8, y + 3, str(value), fontName="Helvetica-Bold", fontSize=7, fillColor=TEAL))
+    return drawing
+
+
+def _link_or_text(reference: str, styles: dict[str, ParagraphStyle]) -> Paragraph:
+    reference = _clean(reference)
+    if reference.startswith("https://") or reference.startswith("http://"):
+        value = escape(reference)
+        return Paragraph(f'<link href="{value}" color="#1F5559"><u>{value}</u></link>', styles["small"])
+    return Paragraph(_safe(reference or "—"), styles["small"])
+
+
+def build_promotion_packet_pdf(packet: dict[str, Any]) -> bytes:
+    styles = _styles()
+    buffer = io.BytesIO()
+    doc = SimpleDocTemplate(
+        buffer,
+        pagesize=LETTER,
+        leftMargin=MARGIN_X,
+        rightMargin=MARGIN_X,
+        topMargin=0.58 * inch,
+        bottomMargin=0.58 * inch,
+        title="BragStack Promotion Packet",
+        author="BragStack",
+        subject="Evidence-backed promotion packet",
+    )
+
+    story: list = []
+    subject = packet.get("subject", {})
+    context = packet.get("context", {})
+    target = packet.get("target", {})
+    scorecard = packet.get("scorecard", {})
+    promotion_case = packet.get("promotion_case", {})
+
+    # Cover
+    story.append(Spacer(1, 0.42 * inch))
+    story.append(Paragraph("BRAGSTACK · PROMOTION PACKET", styles["kicker"]))
+    story.append(Spacer(1, 0.28 * inch))
+    story.append(Paragraph(_safe(subject.get("name") or "BragStack Member"), styles["cover_name"]))
+    story.append(Paragraph(_safe(subject.get("role") or "Professional"), styles["cover_role"]))
+    if context.get("organization"):
+        story.append(Paragraph(_safe(context.get("organization")), styles["body"]))
+    if context.get("career_area"):
+        story.append(Paragraph(_safe(context.get("career_area")), styles["small"]))
+    story.append(Spacer(1, 0.16 * inch))
+    story.append(HRFlowable(width=0.85 * inch, thickness=3, color=GOLD, spaceAfter=18))
+    story.append(Paragraph("PROGRESSION TARGET", styles["kicker"]))
+    target_text = " · ".join(value for value in [_clean(target.get("role")), _clean(target.get("level"))] if value) or "Promotion / increased scope"
+    story.append(Paragraph(_safe(target_text), styles["subhead"]))
+    story.append(Paragraph("REVIEW PERIOD", styles["kicker"]))
+    story.append(Paragraph(_safe(_period_display(packet.get("period", {}))), styles["body"]))
+    story.append(Spacer(1, 0.18 * inch))
+    story.append(_metrics_table(scorecard, styles))
+    story.append(Spacer(1, 0.28 * inch))
+    story.append(Paragraph("An evidence-backed progression dossier. BragStack presents documented work and proof; it does not assign promotion readiness or make an employment decision.", styles["small"]))
+
+    # Case overview
+    story.append(PageBreak())
+    _section_header(story, styles, "01 · PROMOTION CASE", "The evidence-backed case")
+    story.append(Paragraph(_safe(packet.get("promotion_summary")), styles["body"]))
+    story.append(_metrics_table(scorecard, styles))
+    story.append(Spacer(1, 14))
+    coverage_rows = [
+        ["Structured proof", f"{scorecard.get('receipt_coverage_percent', 0)}%", "Accomplishments represented by Impact Receipts"],
+        ["Measurable impact", f"{scorecard.get('quantified_result_coverage_percent', 0)}%", "Receipts with quantified outcomes"],
+        ["Evidence coverage", f"{scorecard.get('evidence_coverage_percent', 0)}%", "Receipts supported by evidence"],
+        ["Verification", f"{scorecard.get('verification_coverage_percent', 0)}%", "Receipts with confirmed contribution"],
+    ]
+    table = Table(
+        [[Paragraph("<b>Area</b>", styles["small"]), Paragraph("<b>Coverage</b>", styles["small"]), Paragraph("<b>What it means</b>", styles["small"])]]
+        + [[Paragraph(_safe(a), styles["small"]), Paragraph(f"<b>{_safe(b)}</b>", styles["small"]), Paragraph(_safe(c), styles["small"])] for a, b, c in coverage_rows],
+        colWidths=[1.65 * inch, 0.8 * inch, CONTENT_WIDTH - 2.45 * inch],
+        repeatRows=1,
+    )
+    table.setStyle(TableStyle([("BACKGROUND", (0, 0), (-1, 0), LIGHT), ("GRID", (0, 0), (-1, -1), 0.4, LINE), ("VALIGN", (0, 0), (-1, -1), "TOP"), ("TOPPADDING", (0, 0), (-1, -1), 6), ("BOTTOMPADDING", (0, 0), (-1, -1), 6)]))
+    story.append(table)
+
+    # Demonstrated impact
+    story.append(PageBreak())
+    _section_header(story, styles, "02 · DEMONSTRATED IMPACT", "The work supporting progression")
+    impact = promotion_case.get("demonstrated_impact") or []
+    if impact:
+        for index, item in enumerate(impact[:8], 1):
+            story.append(Paragraph(f"{index:02d} · {_safe(item.get('title'))}", styles["subhead"]))
+            meta = " · ".join(filter(None, [_clean(item.get("category")), _clean(item.get("entry_date"))]))
+            if meta:
+                story.append(Paragraph(_safe(meta), styles["small"]))
+            if item.get("result"):
+                story.append(Paragraph(_safe(item.get("result")), styles["body"]))
+            signals = []
+            if item.get("verified"):
+                signals.append("Verified")
+            if item.get("evidence_count"):
+                signals.append(f"{item['evidence_count']} evidence")
+            if item.get("skills"):
+                signals.extend(item.get("skills", [])[:4])
+            if signals:
+                story.append(Paragraph(_safe(" · ".join(signals)), styles["small"]))
+            story.append(HRFlowable(width="100%", thickness=0.4, color=LINE, spaceAfter=7))
+    else:
+        story.append(Paragraph("No documented impact is available for this period yet.", styles["body"]))
+
+    # Scope and ownership
+    story.append(PageBreak())
+    _section_header(story, styles, "03 · SCOPE & OWNERSHIP", "How responsibility shows up in the record")
+    ownership = promotion_case.get("scope_and_ownership") or []
+    if ownership:
+        for item in ownership[:10]:
+            status = "Verified" if item.get("verified") else "Self-documented"
+            story.append(Paragraph(f"{_safe(item.get('reference'))} · {_safe(status)}", styles["kicker"]))
+            story.append(Paragraph(_safe(item.get("accomplishment")), styles["subhead"]))
+            if item.get("contribution"):
+                story.append(Paragraph(f"<b>Contribution:</b> {_safe(item.get('contribution'))}", styles["body"]))
+            if item.get("result"):
+                story.append(Paragraph(f"<b>Result:</b> {_safe(item.get('result'))}", styles["body"]))
+            story.append(HRFlowable(width="100%", thickness=0.4, color=LINE, spaceAfter=7))
+    else:
+        story.append(Paragraph("Add Impact Receipts to make scope and ownership easier to review.", styles["body"]))
+
+    # Growth and capabilities
+    story.append(PageBreak())
+    _section_header(story, styles, "04 · GROWTH & CAPABILITIES", "Demonstrated skills over time")
+    analytics = packet.get("impact_analytics", {})
+    story.append(Paragraph("Most demonstrated capabilities", styles["subhead"]))
+    story.append(_bars(analytics.get("top_skills") or {}, styles))
+    story.append(Spacer(1, 12))
+    skill_details = promotion_case.get("growth_and_capabilities") or []
+    if skill_details:
+        rows = [[Paragraph("<b>Capability</b>", styles["small"]), Paragraph("<b>Uses</b>", styles["small"]), Paragraph("<b>First seen</b>", styles["small"]), Paragraph("<b>Most recent</b>", styles["small"])]]
+        for item in skill_details[:18]:
+            rows.append([
+                Paragraph(_safe(item.get("skill")), styles["small"]),
+                Paragraph(_safe(item.get("count")), styles["small"]),
+                Paragraph(_safe(item.get("first_seen") or "—"), styles["small"]),
+                Paragraph(_safe(item.get("last_seen") or "—"), styles["small"]),
+            ])
+        table = Table(rows, colWidths=[2.45 * inch, 0.55 * inch, 1.3 * inch, CONTENT_WIDTH - 4.3 * inch], repeatRows=1)
+        table.setStyle(TableStyle([("BACKGROUND", (0, 0), (-1, 0), LIGHT), ("GRID", (0, 0), (-1, -1), 0.4, LINE), ("VALIGN", (0, 0), (-1, -1), "TOP"), ("TOPPADDING", (0, 0), (-1, -1), 5), ("BOTTOMPADDING", (0, 0), (-1, -1), 5)]))
+        story.append(table)
+
+    # Recognition and case strengthening
+    story.append(PageBreak())
+    _section_header(story, styles, "05 · RECOGNITION & NEXT PROOF", "What is confirmed—and what could strengthen the case")
+    recognition = promotion_case.get("verified_recognition") or []
+    story.append(Paragraph("Verified recognition", styles["subhead"]))
+    if recognition:
+        for item in recognition[:8]:
+            story.append(Paragraph(f"<b>{_safe(item.get('accomplishment'))}</b> · {_safe(item.get('reference'))}", styles["body"]))
+            confirmed = [c for c in item.get("confirmations", []) if c.get("status") == "confirmed"]
+            if confirmed:
+                labels = []
+                for confirmation in confirmed:
+                    label = confirmation.get("name") or "Confirmed contributor"
+                    if confirmation.get("role"):
+                        label += f" · {confirmation['role']}"
+                    labels.append(label)
+                story.append(Paragraph(_safe("; ".join(labels)), styles["small"]))
+    else:
+        story.append(Paragraph("No independent confirmations are attached to this review period yet. Verification is optional and should only be requested when appropriate.", styles["body"]))
+
+    story.append(Spacer(1, 10))
+    story.append(Paragraph("Strengthen the case", styles["subhead"]))
+    for item in promotion_case.get("strengthening_actions") or []:
+        story.append(Paragraph(f"<b>{_safe(item.get('area'))}</b> — {_safe(item.get('action'))}", styles["body"]))
+        story.append(Paragraph(_safe(item.get("why")), styles["small"]))
+
+    # Evidence appendix
+    story.append(PageBreak())
+    _section_header(story, styles, "06 · EVIDENCE INDEX", "Traceable proof behind the promotion case")
+    evidence = packet.get("evidence_index") or []
+    if evidence:
+        rows = [[Paragraph("<b>Receipt</b>", styles["small"]), Paragraph("<b>Evidence</b>", styles["small"]), Paragraph("<b>Type</b>", styles["small"]), Paragraph("<b>Reference</b>", styles["small"])]]
+        for item in evidence:
+            rows.append([
+                Paragraph(_safe(item.get("receipt_reference")), styles["small"]),
+                Paragraph(_safe(item.get("title") or "Evidence item"), styles["small"]),
+                Paragraph(_safe(_clean(item.get("type")).replace("-", " ").title()), styles["small"]),
+                _link_or_text(item.get("reference") or "", styles),
+            ])
+        table = Table(rows, colWidths=[1.05 * inch, 2.2 * inch, 1.05 * inch, CONTENT_WIDTH - 4.3 * inch], repeatRows=1)
+        table.setStyle(TableStyle([("BACKGROUND", (0, 0), (-1, 0), LIGHT), ("GRID", (0, 0), (-1, -1), 0.4, LINE), ("VALIGN", (0, 0), (-1, -1), "TOP"), ("TOPPADDING", (0, 0), (-1, -1), 5), ("BOTTOMPADDING", (0, 0), (-1, -1), 5)]))
+        story.append(table)
+    else:
+        story.append(Paragraph("No evidence items are attached to this packet yet.", styles["body"]))
+
+    # Closing summary
+    story.append(PageBreak())
+    _section_header(story, styles, "07 · CONVERSATION SUMMARY", "Use the proof—keep the decision human")
+    story.append(Paragraph(_safe(packet.get("promotion_summary")), styles["body"]))
+    talking_points = packet.get("talking_points") or []
+    if talking_points:
+        story.append(Spacer(1, 8))
+        story.append(Paragraph("Promotion conversation talking points", styles["subhead"]))
+        for item in talking_points:
+            story.append(Paragraph(f"• <b>{_safe(item.get('title'))}</b> — {_safe(item.get('result') or item.get('category') or '')}", styles["body"]))
+    story.append(Spacer(1, 12))
+    story.append(HRFlowable(width="100%", thickness=2, color=TEAL, spaceAfter=9))
+    story.append(Paragraph("This packet is an evidence organizer. It does not determine job level, readiness, compensation, promotion eligibility, or an employment outcome.", styles["small"]))
+
+    doc.build(
+        story,
+        onFirstPage=lambda canvas, doc_obj: _footer(canvas, doc_obj, packet),
+        onLaterPages=lambda canvas, doc_obj: _footer(canvas, doc_obj, packet),
+    )
+    return buffer.getvalue()

--- a/backend/app/promotion_packet_routes.py
+++ b/backend/app/promotion_packet_routes.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Query
+
+from app.auth import get_current_user
+from app.performance_packet_routes import _build_packet, _parse_period
+from app.plans import require_feature
+
+
+router = APIRouter(prefix="/packets", tags=["packets"])
+
+
+def _promotion_summary(packet: dict, target_role: str, target_level: str) -> str:
+    subject = packet.get("subject", {})
+    scorecard = packet.get("scorecard", {})
+    name = subject.get("name") or "This professional"
+    target = " / ".join(value for value in [target_role, target_level] if value)
+
+    parts = [
+        f"{name} has documented {scorecard.get('accomplishments', 0)} accomplishment"
+        f"{'s' if scorecard.get('accomplishments', 0) != 1 else ''} for this review period."
+    ]
+
+    if target:
+        parts.append(
+            f"This packet organizes the evidence for a progression conversation toward {target}."
+        )
+    else:
+        parts.append(
+            "This packet organizes the evidence for a promotion or increased-scope conversation."
+        )
+
+    if scorecard.get("impact_receipts"):
+        parts.append(
+            f"The record includes {scorecard['impact_receipts']} structured Impact Receipt"
+            f"{'s' if scorecard['impact_receipts'] != 1 else ''}, "
+            f"{scorecard.get('evidence_items', 0)} supporting evidence item"
+            f"{'s' if scorecard.get('evidence_items', 0) != 1 else ''}, and "
+            f"{scorecard.get('confirmed_assertions', 0)} confirmed assertion"
+            f"{'s' if scorecard.get('confirmed_assertions', 0) != 1 else ''}."
+        )
+
+    parts.append(
+        "BragStack does not assign promotion readiness or make an employment decision; "
+        "the packet presents the documented case and the underlying proof."
+    )
+    return " ".join(parts)
+
+
+def _strengthening_actions(scorecard: dict) -> list[dict]:
+    actions: list[dict] = []
+
+    if scorecard.get("receipt_coverage_percent", 0) < 75:
+        actions.append(
+            {
+                "area": "Structured proof",
+                "action": "Convert more high-value accomplishments into Impact Receipts.",
+                "why": "Promotion cases are easier to review when contribution, result, skills, and evidence are structured consistently.",
+            }
+        )
+
+    if scorecard.get("quantified_result_coverage_percent", 0) < 60:
+        actions.append(
+            {
+                "area": "Measurable impact",
+                "action": "Add numbers, counts, percentages, time saved, quality changes, or other measurable outcomes where they are genuinely known.",
+                "why": "Concrete outcomes make scope and impact easier to evaluate without inventing a score.",
+            }
+        )
+
+    if scorecard.get("evidence_coverage_percent", 0) < 70:
+        actions.append(
+            {
+                "area": "Supporting evidence",
+                "action": "Attach artifacts, feedback, documents, certificates, links, or other proof to the strongest receipts.",
+                "why": "Evidence gives reviewers a traceable basis for the promotion case.",
+            }
+        )
+
+    if scorecard.get("verification_coverage_percent", 0) < 50:
+        actions.append(
+            {
+                "area": "Recognition",
+                "action": "Request confirmation or recognition on a few of the most important accomplishments when appropriate.",
+                "why": "A small number of independent confirmations can strengthen credibility without turning BragStack into surveillance.",
+            }
+        )
+
+    if not actions:
+        actions.append(
+            {
+                "area": "Case quality",
+                "action": "The evidence foundation is strong. Focus the conversation on increased scope, sustained impact, and the responsibilities expected in the target role or level.",
+                "why": "Strong documentation is most useful when it is connected to the actual progression expectations of the organization or profession.",
+            }
+        )
+
+    return actions
+
+
+def _build_promotion_packet(
+    *,
+    current_user: dict,
+    start_date,
+    end_date,
+    career_area: str | None,
+    role_title: str | None,
+    organization: str | None,
+    confidential: bool,
+    target_role: str | None,
+    target_level: str | None,
+) -> dict:
+    require_feature(current_user, "promotion_packet")
+
+    packet = _build_packet(
+        current_user=current_user,
+        start_date=start_date,
+        end_date=end_date,
+        career_area=career_area,
+        role_title=role_title,
+        organization=organization,
+        confidential=confidential,
+    )["packet"]
+
+    target_role_value = (target_role or "").strip()
+    target_level_value = (target_level or "").strip()
+    scorecard = packet.get("scorecard", {})
+
+    verified_records = [
+        record for record in packet.get("contribution_records", []) if record.get("verified")
+    ]
+
+    packet.update(
+        {
+            "kind": "promotion",
+            "title": "Promotion Packet",
+            "target": {
+                "role": target_role_value,
+                "level": target_level_value,
+            },
+            "promotion_summary": _promotion_summary(
+                packet,
+                target_role_value,
+                target_level_value,
+            ),
+            "promotion_case": {
+                "demonstrated_impact": packet.get("signature_accomplishments", []),
+                "measurable_impact": packet.get("measurable_results", []),
+                "scope_and_ownership": packet.get("contribution_records", []),
+                "growth_and_capabilities": packet.get("skill_details", []),
+                "verified_recognition": verified_records,
+                "strengthening_actions": _strengthening_actions(scorecard),
+            },
+            "review_summary": _promotion_summary(
+                packet,
+                target_role_value,
+                target_level_value,
+            ),
+        }
+    )
+
+    return {"packet": packet}
+
+
+@router.get("/promotion")
+def get_promotion_packet(
+    start_date: str | None = Query(None),
+    end_date: str | None = Query(None),
+    career_area: str | None = Query(None, max_length=120),
+    role_title: str | None = Query(None, max_length=160),
+    organization: str | None = Query(None, max_length=180),
+    confidential: bool = Query(True),
+    target_role: str | None = Query(None, max_length=160),
+    target_level: str | None = Query(None, max_length=120),
+    current_user: dict = Depends(get_current_user),
+):
+    """Build a career-neutral, evidence-backed promotion packet."""
+
+    parsed_start, parsed_end = _parse_period(start_date, end_date)
+    return _build_promotion_packet(
+        current_user=current_user,
+        start_date=parsed_start,
+        end_date=parsed_end,
+        career_area=career_area,
+        role_title=role_title,
+        organization=organization,
+        confidential=confidential,
+        target_role=target_role,
+        target_level=target_level,
+    )

--- a/backend/tests/test_promotion_packet.py
+++ b/backend/tests/test_promotion_packet.py
@@ -1,0 +1,189 @@
+from datetime import datetime, timezone
+
+import mongomock
+import pytest
+from bson import ObjectId
+from fastapi.testclient import TestClient
+
+import app.performance_packet_routes as packet_routes
+from app.main import app
+
+
+client = TestClient(app)
+
+
+@pytest.fixture
+def promotion_context(monkeypatch):
+    mock_client = mongomock.MongoClient()
+    mock_db = mock_client["bragstack_promotion_packet_test"]
+    entries = mock_db["entries"]
+    receipts = mock_db["impact_receipts"]
+
+    monkeypatch.setattr(packet_routes, "entries_collection", entries)
+    monkeypatch.setattr(packet_routes, "impact_receipts_collection", receipts)
+
+    yield entries, receipts
+    app.dependency_overrides.clear()
+
+
+def _seed_operations_case(entries, receipts, user):
+    first = entries.insert_one(
+        {
+            "user_id": str(user["_id"]),
+            "title": "Improved shift handoff quality",
+            "category": "Operations",
+            "entry_type": "Current Job",
+            "entry_date": "2026-03-18",
+            "tags": ["Coaching", "Quality", "Operations"],
+            "impact": "Reduced repeat handoff issues by 21% across 3 shifts.",
+            "created_at": datetime.now(timezone.utc),
+        }
+    )
+    second = entries.insert_one(
+        {
+            "user_id": str(user["_id"]),
+            "title": "Expanded lead training coverage",
+            "category": "People Development",
+            "entry_type": "Current Job",
+            "entry_date": "2026-05-10",
+            "tags": ["Training", "Coaching", "Leadership"],
+            "impact": "Prepared 12 team leads to run the updated handoff process.",
+            "created_at": datetime.now(timezone.utc),
+        }
+    )
+
+    receipts.insert_one(
+        {
+            "user_id": str(user["_id"]),
+            "source_entry_id": str(first.inserted_id),
+            "accomplishment": "Improved shift handoff quality",
+            "contribution": "Designed the checklist, piloted it with leads, and coached each shift on the new standard.",
+            "result": "Reduced repeat handoff issues by 21% across 3 shifts.",
+            "evidence": [
+                {
+                    "title": "Quality review summary",
+                    "evidence_type": "documentation",
+                    "reference": "OPS-Q2-2026",
+                    "description": "Before-and-after handoff quality review.",
+                    "is_public": False,
+                }
+            ],
+            "skills": ["Coaching", "Quality", "Operations"],
+            "credit": [],
+            "confirmations": [
+                {
+                    "name": "Regional Operations Manager",
+                    "role": "Regional Manager",
+                    "confirmation_type": "stakeholder",
+                    "status": "confirmed",
+                }
+            ],
+            "trust_signals": ["evidence-linked", "stakeholder-verified"],
+            "is_public": False,
+            "created_at": datetime.now(timezone.utc),
+            "updated_at": datetime.now(timezone.utc),
+        }
+    )
+
+    receipts.insert_one(
+        {
+            "user_id": str(user["_id"]),
+            "source_entry_id": str(second.inserted_id),
+            "accomplishment": "Expanded lead training coverage",
+            "contribution": "Built a short training session and coached team leads through live shift handoffs.",
+            "result": "Prepared 12 team leads to run the updated handoff process.",
+            "evidence": [],
+            "skills": ["Training", "Coaching", "Leadership"],
+            "credit": [],
+            "confirmations": [],
+            "trust_signals": ["self-documented"],
+            "is_public": False,
+            "created_at": datetime.now(timezone.utc),
+            "updated_at": datetime.now(timezone.utc),
+        }
+    )
+
+
+def test_free_user_cannot_build_promotion_packet(promotion_context):
+    user = {
+        "_id": ObjectId(),
+        "name": "Free Member",
+        "email": "free@example.com",
+        "plan": "free",
+    }
+    app.dependency_overrides[packet_routes.get_current_user] = lambda: user
+
+    response = client.get("/packets/promotion")
+
+    assert response.status_code == 403
+    assert response.json()["detail"]["feature"] == "promotion_packet"
+
+
+def test_pro_promotion_packet_is_evidence_backed_and_career_neutral(promotion_context):
+    entries, receipts = promotion_context
+    user = {
+        "_id": ObjectId(),
+        "name": "Morgan Reyes",
+        "email": "morgan@example.com",
+        "headline": "Operations Supervisor",
+        "plan": "pro",
+    }
+    app.dependency_overrides[packet_routes.get_current_user] = lambda: user
+    _seed_operations_case(entries, receipts, user)
+
+    response = client.get(
+        "/packets/promotion",
+        params={
+            "start_date": "2026-01-01",
+            "end_date": "2026-06-30",
+            "career_area": "Operations",
+            "role_title": "Operations Supervisor",
+            "organization": "Regional Fulfillment Center",
+            "target_role": "Senior Operations Manager",
+            "target_level": "Next-level leadership",
+        },
+    )
+
+    assert response.status_code == 200
+    packet = response.json()["packet"]
+    assert packet["kind"] == "promotion"
+    assert packet["title"] == "Promotion Packet"
+    assert packet["target"]["role"] == "Senior Operations Manager"
+    assert packet["target"]["level"] == "Next-level leadership"
+    assert packet["scorecard"]["accomplishments"] == 2
+    assert len(packet["promotion_case"]["demonstrated_impact"]) == 2
+    assert len(packet["promotion_case"]["scope_and_ownership"]) == 2
+    assert len(packet["promotion_case"]["verified_recognition"]) == 1
+    assert packet["promotion_case"]["strengthening_actions"]
+    assert "does not assign promotion readiness" in packet["promotion_summary"]
+    assert "Senior Operations Manager" in packet["promotion_summary"]
+
+
+def test_pro_user_downloads_dedicated_promotion_pdf(promotion_context):
+    entries, receipts = promotion_context
+    user = {
+        "_id": ObjectId(),
+        "name": "Morgan Reyes",
+        "email": "morgan@example.com",
+        "headline": "Operations Supervisor",
+        "plan": "pro",
+    }
+    app.dependency_overrides[packet_routes.get_current_user] = lambda: user
+    _seed_operations_case(entries, receipts, user)
+
+    response = client.get(
+        "/packets/promotion.pdf",
+        params={
+            "start_date": "2026-01-01",
+            "end_date": "2026-06-30",
+            "career_area": "Operations",
+            "target_role": "Senior Operations Manager",
+            "target_level": "Next-level leadership",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("application/pdf")
+    assert response.content.startswith(b"%PDF")
+    assert len(response.content) > 5000
+    assert "Morgan-Reyes-promotion-packet-2026-01-01-to-2026-06-30.pdf" in response.headers["content-disposition"]

--- a/frontend/src/PacketBuilderPanel.jsx
+++ b/frontend/src/PacketBuilderPanel.jsx
@@ -19,6 +19,17 @@ const CAREER_AREAS = [
   "Other",
 ];
 
+const PACKET_TYPES = [
+  {
+    value: "performance-review",
+    label: "Performance Review Packet",
+  },
+  {
+    value: "promotion",
+    label: "Promotion Packet",
+  },
+];
+
 function PacketBuilderPanel({
   options,
   onChange,
@@ -26,6 +37,8 @@ function PacketBuilderPanel({
   isLoading,
   error,
 }) {
+  const isPromotion = options.packetType === "promotion";
+
   function update(name, value) {
     onChange((current) => ({
       ...current,
@@ -41,16 +54,32 @@ function PacketBuilderPanel({
         </div>
         <div>
           <span>BragStack Pro · Premium Artifact</span>
-          <h2 id="packet-builder-title">Build a Performance Review Packet</h2>
+          <h2 id="packet-builder-title">
+            Build a {isPromotion ? "Promotion Packet" : "Performance Review Packet"}
+          </h2>
           <p>
-            Create a physical-style career dossier with analytics, measurable
-            results, skills, contribution records, Impact Receipts, and an
-            evidence index. The language stays useful across any profession.
+            {isPromotion
+              ? "Organize documented impact, increased responsibility, growth, recognition, and supporting evidence into a professional promotion case—without inventing a readiness score."
+              : "Create a physical-style career dossier with analytics, measurable results, skills, contribution records, Impact Receipts, and an evidence index. The language stays useful across any profession."}
           </p>
         </div>
       </div>
 
       <div className="packet-builder-fields">
+        <label>
+          <span>Packet type</span>
+          <select
+            value={options.packetType}
+            onChange={(event) => update("packetType", event.target.value)}
+          >
+            {PACKET_TYPES.map((type) => (
+              <option key={type.value} value={type.value}>
+                {type.label}
+              </option>
+            ))}
+          </select>
+        </label>
+
         <label>
           <span>Career / work area</span>
           <select
@@ -66,7 +95,7 @@ function PacketBuilderPanel({
         </label>
 
         <label>
-          <span>Role title</span>
+          <span>Current role title</span>
           <input
             type="text"
             value={options.roleTitle}
@@ -86,6 +115,32 @@ function PacketBuilderPanel({
             maxLength={180}
           />
         </label>
+
+        {isPromotion && (
+          <>
+            <label>
+              <span>Target role</span>
+              <input
+                type="text"
+                value={options.targetRole}
+                onChange={(event) => update("targetRole", event.target.value)}
+                placeholder="Example: Senior Manager, Lead Teacher, RN II"
+                maxLength={160}
+              />
+            </label>
+
+            <label>
+              <span>Target level / progression</span>
+              <input
+                type="text"
+                value={options.targetLevel}
+                onChange={(event) => update("targetLevel", event.target.value)}
+                placeholder="Optional level, grade, title, or progression step"
+                maxLength={120}
+              />
+            </label>
+          </>
+        )}
       </div>
 
       <div className="packet-builder-pro-footer">
@@ -107,7 +162,11 @@ function PacketBuilderPanel({
             Uses the currently selected report period
           </div>
           <button type="button" onClick={onBuild} disabled={isLoading}>
-            {isLoading ? "Building packet…" : "Build my packet"}
+            {isLoading
+              ? "Building packet…"
+              : isPromotion
+                ? "Build promotion packet"
+                : "Build performance packet"}
           </button>
         </div>
       </div>

--- a/frontend/src/PacketBuilderPanel.jsx
+++ b/frontend/src/PacketBuilderPanel.jsx
@@ -37,7 +37,8 @@ function PacketBuilderPanel({
   isLoading,
   error,
 }) {
-  const isPromotion = options.packetType === "promotion";
+  const packetType = options.packetType || "performance-review";
+  const isPromotion = packetType === "promotion";
 
   function update(name, value) {
     onChange((current) => ({
@@ -69,7 +70,7 @@ function PacketBuilderPanel({
         <label>
           <span>Packet type</span>
           <select
-            value={options.packetType}
+            value={packetType}
             onChange={(event) => update("packetType", event.target.value)}
           >
             {PACKET_TYPES.map((type) => (
@@ -83,7 +84,7 @@ function PacketBuilderPanel({
         <label>
           <span>Career / work area</span>
           <select
-            value={options.careerArea}
+            value={options.careerArea ?? ""}
             onChange={(event) => update("careerArea", event.target.value)}
           >
             {CAREER_AREAS.map((area) => (
@@ -98,7 +99,7 @@ function PacketBuilderPanel({
           <span>Current role title</span>
           <input
             type="text"
-            value={options.roleTitle}
+            value={options.roleTitle ?? ""}
             onChange={(event) => update("roleTitle", event.target.value)}
             placeholder="Use profile headline"
             maxLength={160}
@@ -109,7 +110,7 @@ function PacketBuilderPanel({
           <span>Organization / team</span>
           <input
             type="text"
-            value={options.organization}
+            value={options.organization ?? ""}
             onChange={(event) => update("organization", event.target.value)}
             placeholder="Optional"
             maxLength={180}
@@ -122,7 +123,7 @@ function PacketBuilderPanel({
               <span>Target role</span>
               <input
                 type="text"
-                value={options.targetRole}
+                value={options.targetRole ?? ""}
                 onChange={(event) => update("targetRole", event.target.value)}
                 placeholder="Example: Senior Manager, Lead Teacher, RN II"
                 maxLength={160}
@@ -133,7 +134,7 @@ function PacketBuilderPanel({
               <span>Target level / progression</span>
               <input
                 type="text"
-                value={options.targetLevel}
+                value={options.targetLevel ?? ""}
                 onChange={(event) => update("targetLevel", event.target.value)}
                 placeholder="Optional level, grade, title, or progression step"
                 maxLength={120}
@@ -147,7 +148,7 @@ function PacketBuilderPanel({
         <label className="packet-confidential-toggle">
           <input
             type="checkbox"
-            checked={options.confidential}
+            checked={options.confidential !== false}
             onChange={(event) => update("confidential", event.target.checked)}
           />
           <span>

--- a/frontend/src/PerformancePacketPreview.jsx
+++ b/frontend/src/PerformancePacketPreview.jsx
@@ -11,8 +11,12 @@ import {
   Sparkles,
 } from "lucide-react";
 
-import { downloadPerformancePacketPdf } from "./api";
+import {
+  downloadPerformancePacketPdf,
+  downloadPromotionPacketPdf,
+} from "./api";
 import PerformancePacketPages from "./PerformancePacketPages";
+import PromotionPacketPages from "./PromotionPacketPages";
 import "./PerformancePacketPreview.css";
 import "./PerformancePacketExport.css";
 
@@ -103,15 +107,22 @@ function PerformancePacketPreview({ packet, onBack }) {
   const scorecard = packet?.scorecard ?? {};
   const subject = packet?.subject ?? {};
   const context = packet?.context ?? {};
+  const target = packet?.target ?? {};
   const topSignature = packet?.signature_accomplishments?.[0];
   const generatedDate = formatDate(packet?.generated_at);
+  const isPromotion = packet?.kind === "promotion";
+  const packetTitle = packet?.title || "Performance Review Packet";
+  const targetText = [target.role, target.level].filter(Boolean).join(" · ");
 
   async function handleDownloadPdf() {
     setIsDownloading(true);
     setDownloadError("");
 
     try {
-      const { blob, filename } = await downloadPerformancePacketPdf(packet);
+      const downloader = isPromotion
+        ? downloadPromotionPacketPdf
+        : downloadPerformancePacketPdf;
+      const { blob, filename } = await downloader(packet);
       const url = URL.createObjectURL(blob);
       const link = document.createElement("a");
       link.href = url;
@@ -146,7 +157,7 @@ function PerformancePacketPreview({ packet, onBack }) {
         </button>
 
         <div>
-          <span>Performance Packet</span>
+          <span>{packetTitle}</span>
           <strong>Physical dossier preview</strong>
         </div>
 
@@ -188,7 +199,7 @@ function PerformancePacketPreview({ packet, onBack }) {
           </div>
 
           <div className="packet-cover-main">
-            <p className="packet-document-type">Performance Review Packet</p>
+            <p className="packet-document-type">{packetTitle}</p>
             <h1>{subject.name || "BragStack Member"}</h1>
             <h2>{subject.role || "Professional"}</h2>
             {context.organization && (
@@ -200,6 +211,13 @@ function PerformancePacketPreview({ packet, onBack }) {
             {subject.location && <p className="packet-location">{subject.location}</p>}
 
             <div className="packet-cover-rule" />
+
+            {isPromotion && targetText && (
+              <div className="packet-period-block">
+                <span>Progression target</span>
+                <strong>{targetText}</strong>
+              </div>
+            )}
 
             <div className="packet-period-block">
               <span>Review period</span>
@@ -238,20 +256,20 @@ function PerformancePacketPreview({ packet, onBack }) {
 
         <section
           className="packet-sheet packet-scorecard-page"
-          aria-label="Executive scorecard"
+          aria-label={isPromotion ? "Promotion evidence scorecard" : "Executive scorecard"}
         >
           <header className="packet-page-header">
             <div>
-              <p>01 · Executive Scorecard</p>
-              <h2>Proof at a glance</h2>
+              <p>01 · {isPromotion ? "Promotion Evidence Scorecard" : "Executive Scorecard"}</p>
+              <h2>{isPromotion ? "The proof behind the case" : "Proof at a glance"}</h2>
             </div>
             <div className="packet-page-header-mark">BRAGSTACK</div>
           </header>
 
           <p className="packet-scorecard-intro">
-            A transparent summary of documented work for this review period.
-            Coverage measures are calculated from actual accomplishments, Impact
-            Receipts, evidence, and confirmations—not an opaque AI score.
+            {isPromotion
+              ? "A transparent view of the documentation supporting this progression conversation. These measures describe the evidence record; they do not calculate promotion readiness."
+              : "A transparent summary of documented work for this review period. Coverage measures are calculated from actual accomplishments, Impact Receipts, evidence, and confirmations—not an opaque AI score."}
           </p>
 
           <section className="packet-stat-grid" aria-label="Packet totals">
@@ -332,7 +350,9 @@ function PerformancePacketPreview({ packet, onBack }) {
               <Award size={21} />
             </div>
             <div>
-              <p className="packet-section-kicker">Signature accomplishment</p>
+              <p className="packet-section-kicker">
+                {isPromotion ? "Promotion evidence highlight" : "Signature accomplishment"}
+              </p>
               {topSignature ? (
                 <>
                   <h3>{topSignature.title}</h3>
@@ -353,7 +373,11 @@ function PerformancePacketPreview({ packet, onBack }) {
           <PacketFooter page={2} />
         </section>
 
-        <PerformancePacketPages packet={packet} />
+        {isPromotion ? (
+          <PromotionPacketPages packet={packet} />
+        ) : (
+          <PerformancePacketPages packet={packet} />
+        )}
       </div>
     </main>
   );

--- a/frontend/src/PromotionPacketPages.jsx
+++ b/frontend/src/PromotionPacketPages.jsx
@@ -1,0 +1,468 @@
+import {
+  Award,
+  BadgeCheck,
+  BookOpenCheck,
+  CheckCircle2,
+  FileCheck2,
+  Medal,
+  ReceiptText,
+  ShieldCheck,
+  Sparkles,
+  Target,
+  TrendingUp,
+  UsersRound,
+} from "lucide-react";
+
+import "./PerformancePacketPages.css";
+
+function formatShortDate(value) {
+  if (!value) return "—";
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  }).format(new Date(`${value}T12:00:00`));
+}
+
+function formatLabel(value = "") {
+  return String(value)
+    .replace(/-/g, " ")
+    .replace(/\b\w/g, (character) => character.toUpperCase());
+}
+
+function chunk(items, size) {
+  const result = [];
+  for (let index = 0; index < items.length; index += size) {
+    result.push(items.slice(index, index + size));
+  }
+  return result.length ? result : [[]];
+}
+
+function PacketFooter({ page }) {
+  return (
+    <footer className="packet-page-footer">
+      <span>BragStack · Career Evidence System</span>
+      <span>Page {page}</span>
+    </footer>
+  );
+}
+
+function PacketHeader({ index, title, eyebrow }) {
+  return (
+    <header className="packet-page-header">
+      <div>
+        <p>{String(index).padStart(2, "0")} · {eyebrow}</p>
+        <h2>{title}</h2>
+      </div>
+      <div className="packet-page-header-mark">BRAGSTACK</div>
+    </header>
+  );
+}
+
+function EmptyState({ children }) {
+  return (
+    <div className="packet-document-empty">
+      <BookOpenCheck size={22} />
+      <p>{children}</p>
+    </div>
+  );
+}
+
+function PromotionCasePage({ packet, page }) {
+  const target = packet?.target ?? {};
+  const scorecard = packet?.scorecard ?? {};
+  const targetText = [target.role, target.level].filter(Boolean).join(" · ");
+
+  return (
+    <section className="packet-sheet packet-document-page packet-summary-page">
+      <PacketHeader index={2} eyebrow="Promotion Case" title="The evidence-backed progression case" />
+
+      <div className="packet-result-hero">
+        <TrendingUp size={24} />
+        <div>
+          <strong>{targetText || "Next step"}</strong>
+          <span>user-defined progression target</span>
+        </div>
+      </div>
+
+      <section className="packet-summary-narrative">
+        <Medal size={26} />
+        <div>
+          <p className="packet-section-kicker">Case summary</p>
+          <p>{packet?.promotion_summary}</p>
+        </div>
+      </section>
+
+      <div className="packet-kpi-ribbon">
+        <div><strong>{scorecard.receipt_coverage_percent ?? 0}%</strong><span>Structured proof</span></div>
+        <div><strong>{scorecard.quantified_result_coverage_percent ?? 0}%</strong><span>Measurable impact</span></div>
+        <div><strong>{scorecard.verification_coverage_percent ?? 0}%</strong><span>Verified recognition</span></div>
+      </div>
+
+      <div className="packet-document-note">
+        <strong>No black-box readiness score</strong>
+        <p>
+          BragStack organizes the case and the receipts. It does not decide whether
+          someone is ready for promotion, assign job level, or make an employment decision.
+        </p>
+      </div>
+
+      <PacketFooter page={page} />
+    </section>
+  );
+}
+
+function DemonstratedImpactPage({ packet, page }) {
+  const items = packet?.promotion_case?.demonstrated_impact ?? [];
+
+  return (
+    <section className="packet-sheet packet-document-page">
+      <PacketHeader index={3} eyebrow="Demonstrated Impact" title="The work supporting progression" />
+      <p className="packet-page-lead">
+        High-value examples are prioritized using documented results, structured proof,
+        evidence, and confirmation signals—not profession-specific assumptions.
+      </p>
+
+      {items.length ? (
+        <div className="packet-accomplishment-list">
+          {items.slice(0, 6).map((item, index) => (
+            <article key={item.entry_id} className="packet-accomplishment-record">
+              <div className="packet-accomplishment-number">{String(index + 1).padStart(2, "0")}</div>
+              <div>
+                <div className="packet-record-meta">
+                  <span>{item.category || "Accomplishment"}</span>
+                  {item.entry_date && <span>{formatShortDate(item.entry_date)}</span>}
+                  {item.verified && <span className="packet-verified-chip"><BadgeCheck size={12} /> Verified</span>}
+                </div>
+                <h3>{item.title}</h3>
+                {item.result && <p>{item.result}</p>}
+                <div className="packet-record-tags">
+                  {item.skills?.slice(0, 5).map((skill) => <span key={skill}>{skill}</span>)}
+                </div>
+              </div>
+              <div className="packet-record-proof">
+                <strong>{item.evidence_count ?? 0}</strong>
+                <span>evidence</span>
+              </div>
+            </article>
+          ))}
+        </div>
+      ) : (
+        <EmptyState>Add accomplishments with outcomes to build the demonstrated-impact case.</EmptyState>
+      )}
+
+      <PacketFooter page={page} />
+    </section>
+  );
+}
+
+function ScopeOwnershipPage({ packet, page }) {
+  const records = packet?.promotion_case?.scope_and_ownership ?? [];
+
+  return (
+    <section className="packet-sheet packet-document-page">
+      <PacketHeader index={4} eyebrow="Scope & Ownership" title="How responsibility shows up in the record" />
+      <p className="packet-page-lead">
+        This section focuses on what the person actually carried, changed, coordinated,
+        improved, delivered, taught, served, created, or led—across any kind of career.
+      </p>
+
+      {records.length ? (
+        <div className="packet-contribution-list">
+          {records.slice(0, 7).map((item) => (
+            <article key={item.reference}>
+              <div className="packet-contribution-topline">
+                <span>{item.reference}</span>
+                {item.verified && <span className="packet-verified-chip"><BadgeCheck size={12} /> Confirmed</span>}
+              </div>
+              <h3>{item.accomplishment}</h3>
+              {item.contribution && <p><strong>Contribution:</strong> {item.contribution}</p>}
+              {item.result && <p><strong>Result:</strong> {item.result}</p>}
+              <div className="packet-contribution-meta">
+                <span>{item.evidence_count ?? 0} evidence item{item.evidence_count === 1 ? "" : "s"}</span>
+                {item.confirmations?.slice(0, 2).map((confirmation) => (
+                  <span key={`${item.reference}-${confirmation.name}`}>
+                    {confirmation.name}{confirmation.role ? ` · ${confirmation.role}` : ""}
+                  </span>
+                ))}
+              </div>
+            </article>
+          ))}
+        </div>
+      ) : (
+        <EmptyState>Create Impact Receipts to make scope and ownership easier to review.</EmptyState>
+      )}
+
+      <PacketFooter page={page} />
+    </section>
+  );
+}
+
+function GrowthRecognitionPage({ packet, page }) {
+  const skills = packet?.promotion_case?.growth_and_capabilities ?? [];
+  const recognition = packet?.promotion_case?.verified_recognition ?? [];
+  const maxCount = Math.max(...skills.map((item) => Number(item.count) || 0), 1);
+
+  return (
+    <section className="packet-sheet packet-document-page">
+      <PacketHeader index={5} eyebrow="Growth & Recognition" title="Capabilities demonstrated and independently confirmed" />
+
+      <div className="packet-document-two-column">
+        <section className="packet-document-section compact">
+          <div className="packet-document-section-title">
+            <div><p>Growth</p><h3>Demonstrated capabilities</h3></div>
+            <Sparkles size={19} />
+          </div>
+
+          {skills.length ? (
+            <div className="packet-skill-evidence-list">
+              {skills.slice(0, 7).map((item, index) => (
+                <article key={item.skill}>
+                  <div className="packet-skill-rank">{index + 1}</div>
+                  <div className="packet-skill-main">
+                    <div><strong>{item.skill}</strong><span>{item.count} documented use{item.count === 1 ? "" : "s"}</span></div>
+                    <div className="packet-skill-track"><span style={{ width: `${Math.max(8, (item.count / maxCount) * 100)}%` }} /></div>
+                  </div>
+                </article>
+              ))}
+            </div>
+          ) : (
+            <EmptyState>Add skills to work records to build this section.</EmptyState>
+          )}
+        </section>
+
+        <section className="packet-document-section compact">
+          <div className="packet-document-section-title">
+            <div><p>Recognition</p><h3>Confirmed contributions</h3></div>
+            <BadgeCheck size={19} />
+          </div>
+
+          {recognition.length ? (
+            <div className="packet-contribution-list">
+              {recognition.slice(0, 5).map((item) => (
+                <article key={item.reference}>
+                  <div className="packet-contribution-topline">
+                    <span>{item.reference}</span>
+                    <span className="packet-verified-chip"><BadgeCheck size={12} /> Confirmed</span>
+                  </div>
+                  <h3>{item.accomplishment}</h3>
+                  <div className="packet-contribution-meta">
+                    {item.confirmations?.filter((confirmation) => confirmation.status === "confirmed").slice(0, 2).map((confirmation) => (
+                      <span key={`${item.reference}-${confirmation.name}`}>
+                        {confirmation.name}{confirmation.role ? ` · ${confirmation.role}` : ""}
+                      </span>
+                    ))}
+                  </div>
+                </article>
+              ))}
+            </div>
+          ) : (
+            <EmptyState>Independent confirmation is optional; confirmed accomplishments will appear here.</EmptyState>
+          )}
+        </section>
+      </div>
+
+      <PacketFooter page={page} />
+    </section>
+  );
+}
+
+function StrengthenCasePage({ packet, page }) {
+  const actions = packet?.promotion_case?.strengthening_actions ?? [];
+  const results = packet?.promotion_case?.measurable_impact ?? [];
+
+  return (
+    <section className="packet-sheet packet-document-page">
+      <PacketHeader index={6} eyebrow="Strengthen the Case" title="Useful next proof—not a verdict" />
+
+      <div className="packet-result-hero">
+        <Target size={24} />
+        <div>
+          <strong>{results.length}</strong>
+          <span>documented measurable result{results.length === 1 ? "" : "s"} in this case</span>
+        </div>
+      </div>
+
+      {actions.length ? (
+        <div className="packet-accomplishment-list">
+          {actions.map((item, index) => (
+            <article className="packet-accomplishment-record" key={`${item.area}-${index}`}>
+              <div className="packet-accomplishment-number">{String(index + 1).padStart(2, "0")}</div>
+              <div>
+                <p className="packet-section-kicker">{item.area}</p>
+                <h3>{item.action}</h3>
+                <p>{item.why}</p>
+              </div>
+              <div className="packet-record-proof">
+                <FileCheck2 size={18} />
+                <span>Next proof</span>
+              </div>
+            </article>
+          ))}
+        </div>
+      ) : (
+        <EmptyState>The current documentation already covers the main evidence-health areas.</EmptyState>
+      )}
+
+      <div className="packet-document-note">
+        <strong>Keep expectations explicit</strong>
+        <p>
+          A strong evidence record should still be compared with the actual promotion,
+          licensure, grade, scope, or progression expectations used by the organization or profession.
+        </p>
+      </div>
+
+      <PacketFooter page={page} />
+    </section>
+  );
+}
+
+function ImpactReceiptCard({ receipt }) {
+  return (
+    <article className="packet-receipt-card">
+      <div className="packet-receipt-top">
+        <div><ReceiptText size={17} /><span>Impact Receipt</span></div>
+        <strong>{receipt.reference}</strong>
+      </div>
+      <div className="packet-receipt-title">
+        <p>{receipt.entry_date ? formatShortDate(receipt.entry_date) : "Documented proof"}</p>
+        <h3>{receipt.accomplishment}</h3>
+      </div>
+      <dl>
+        <div><dt>Contribution</dt><dd>{receipt.contribution || "Documented in source accomplishment."}</dd></div>
+        <div><dt>Result</dt><dd>{receipt.result || "Result not yet added."}</dd></div>
+      </dl>
+      <div className="packet-receipt-skills">
+        {receipt.skills?.slice(0, 7).map((skill) => <span key={skill}>{skill}</span>)}
+      </div>
+      <div className="packet-receipt-proof-grid">
+        <div><strong>{receipt.evidence?.length ?? 0}</strong><span>Evidence</span></div>
+        <div><strong>{receipt.confirmations?.filter((item) => item.status === "confirmed").length ?? 0}</strong><span>Confirmations</span></div>
+        <div><strong>{receipt.credit?.length ?? 0}</strong><span>Shared credit</span></div>
+      </div>
+      <div className="packet-receipt-status">
+        {receipt.verified ? <><BadgeCheck size={14} /> Confirmed contribution</> : <><ShieldCheck size={14} /> Evidence-backed record</>}
+      </div>
+    </article>
+  );
+}
+
+function ReceiptPages({ packet, startPage }) {
+  const pages = chunk(packet?.receipt_records ?? [], 2);
+  return pages.map((items, index) => (
+    <section key={`promotion-receipt-${index}`} className="packet-sheet packet-document-page">
+      <PacketHeader index={7} eyebrow="Impact Receipts" title={index === 0 ? "Receipts behind the case" : "Impact Receipts · continued"} />
+      <p className="packet-page-lead">
+        The promotion narrative stays traceable to the same contribution, result,
+        skill, evidence, credit, and confirmation records used elsewhere in BragStack.
+      </p>
+      {items.length ? (
+        <div className="packet-receipt-stack">
+          {items.map((receipt) => <ImpactReceiptCard key={receipt.reference} receipt={receipt} />)}
+        </div>
+      ) : (
+        <EmptyState>Create Impact Receipts to add structured proof to the promotion case.</EmptyState>
+      )}
+      <PacketFooter page={startPage + index} />
+    </section>
+  ));
+}
+
+function EvidencePages({ packet, startPage }) {
+  const pages = chunk(packet?.evidence_index ?? [], 10);
+  return pages.map((items, index) => (
+    <section key={`promotion-evidence-${index}`} className="packet-sheet packet-document-page">
+      <PacketHeader index={8} eyebrow="Evidence Index" title={index === 0 ? "Source material behind the case" : "Evidence Index · continued"} />
+      {items.length ? (
+        <div className="packet-evidence-table" role="table" aria-label="Promotion evidence index">
+          <div className="packet-evidence-row header" role="row">
+            <span>Receipt</span><span>Evidence</span><span>Type</span><span>Reference</span>
+          </div>
+          {items.map((item, itemIndex) => (
+            <div className="packet-evidence-row" role="row" key={`${item.receipt_reference}-${item.title}-${itemIndex}`}>
+              <span>{item.receipt_reference}</span>
+              <span><strong>{item.title}</strong><small>{item.description}</small></span>
+              <span>{formatLabel(item.type)}</span>
+              <span>{item.reference || "Stored in BragStack"}</span>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <EmptyState>Add evidence to Impact Receipts to populate the source index.</EmptyState>
+      )}
+      <PacketFooter page={startPage + index} />
+    </section>
+  ));
+}
+
+function ConversationSummaryPage({ packet, page }) {
+  const points = packet?.talking_points ?? [];
+  return (
+    <section className="packet-sheet packet-document-page packet-summary-page">
+      <PacketHeader index={9} eyebrow="Conversation Summary" title="Use the proof—keep the decision human" />
+
+      <section className="packet-summary-narrative">
+        <Award size={26} />
+        <div>
+          <p className="packet-section-kicker">Promotion case summary</p>
+          <p>{packet?.promotion_summary}</p>
+        </div>
+      </section>
+
+      <section className="packet-talking-points">
+        <div className="packet-document-section-title">
+          <div><p>Conversation guide</p><h3>Promotion talking points</h3></div>
+          <UsersRound size={19} />
+        </div>
+        {points.length ? (
+          <ol>
+            {points.map((item) => (
+              <li key={`${item.title}-${item.result}`}>
+                <strong>{item.title}</strong>
+                {item.result && <span>{item.result}</span>}
+              </li>
+            ))}
+          </ol>
+        ) : (
+          <EmptyState>Add accomplishments to generate evidence-backed talking points.</EmptyState>
+        )}
+      </section>
+
+      <div className="packet-summary-close">
+        <CheckCircle2 size={20} />
+        <div>
+          <strong>Bring the receipts. Make the case.</strong>
+          <p>
+            Every claim should be traceable to documented work. The final promotion
+            decision remains with the people and process responsible for it.
+          </p>
+        </div>
+      </div>
+
+      <PacketFooter page={page} />
+    </section>
+  );
+}
+
+function PromotionPacketPages({ packet }) {
+  const receiptPageCount = Math.max(1, Math.ceil((packet?.receipt_records?.length ?? 0) / 2));
+  const evidencePageCount = Math.max(1, Math.ceil((packet?.evidence_index?.length ?? 0) / 10));
+  const receiptStartPage = 8;
+  const evidenceStartPage = receiptStartPage + receiptPageCount;
+  const summaryPage = evidenceStartPage + evidencePageCount;
+
+  return (
+    <>
+      <PromotionCasePage packet={packet} page={3} />
+      <DemonstratedImpactPage packet={packet} page={4} />
+      <ScopeOwnershipPage packet={packet} page={5} />
+      <GrowthRecognitionPage packet={packet} page={6} />
+      <StrengthenCasePage packet={packet} page={7} />
+      <ReceiptPages packet={packet} startPage={receiptStartPage} />
+      <EvidencePages packet={packet} startPage={evidenceStartPage} />
+      <ConversationSummaryPage packet={packet} page={summaryPage} />
+    </>
+  );
+}
+
+export default PromotionPacketPages;

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -37,6 +37,8 @@ function getPacketParams(startDate, endDate, options = {}) {
     ...(options.careerArea ? { career_area: options.careerArea } : {}),
     ...(options.roleTitle ? { role_title: options.roleTitle } : {}),
     ...(options.organization ? { organization: options.organization } : {}),
+    ...(options.targetRole ? { target_role: options.targetRole } : {}),
+    ...(options.targetLevel ? { target_level: options.targetLevel } : {}),
     confidential: options.confidential !== false,
   };
 }
@@ -44,6 +46,34 @@ function getPacketParams(startDate, endDate, options = {}) {
 function parseDownloadFilename(contentDisposition, fallback) {
   const match = contentDisposition?.match(/filename="?([^";]+)"?/i);
   return match?.[1] || fallback;
+}
+
+async function downloadPacketPdf(path, packet, fallbackFilename) {
+  const period = packet?.period ?? {};
+  const context = packet?.context ?? {};
+  const subject = packet?.subject ?? {};
+  const target = packet?.target ?? {};
+  const params = getPacketParams(period.start_date, period.end_date, {
+    careerArea: context.career_area,
+    roleTitle: subject.role,
+    organization: context.organization,
+    targetRole: target.role,
+    targetLevel: target.level,
+    confidential: packet?.confidential !== false,
+  });
+
+  const response = await api.get(path, {
+    params,
+    responseType: "blob",
+  });
+
+  return {
+    blob: response.data,
+    filename: parseDownloadFilename(
+      response.headers["content-disposition"],
+      fallbackFilename
+    ),
+  };
 }
 
 api.interceptors.request.use((config) => {
@@ -192,29 +222,27 @@ export async function getPerformancePacket(startDate, endDate, options = {}) {
   return response.data;
 }
 
+export async function getPromotionPacket(startDate, endDate, options = {}) {
+  const response = await api.get("/packets/promotion", {
+    params: getPacketParams(startDate, endDate, options),
+  });
+  return response.data;
+}
+
 export async function downloadPerformancePacketPdf(packet) {
-  const period = packet?.period ?? {};
-  const context = packet?.context ?? {};
-  const subject = packet?.subject ?? {};
-  const params = getPacketParams(period.start_date, period.end_date, {
-    careerArea: context.career_area,
-    roleTitle: subject.role,
-    organization: context.organization,
-    confidential: packet?.confidential !== false,
-  });
+  return downloadPacketPdf(
+    "/packets/performance-review.pdf",
+    packet,
+    "bragstack-performance-review.pdf"
+  );
+}
 
-  const response = await api.get("/packets/performance-review.pdf", {
-    params,
-    responseType: "blob",
-  });
-
-  return {
-    blob: response.data,
-    filename: parseDownloadFilename(
-      response.headers["content-disposition"],
-      "bragstack-performance-review.pdf"
-    ),
-  };
+export async function downloadPromotionPacketPdf(packet) {
+  return downloadPacketPdf(
+    "/packets/promotion.pdf",
+    packet,
+    "bragstack-promotion-packet.pdf"
+  );
 }
 
 export async function getPublicImpactReceipts(slug) {

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -216,7 +216,11 @@ export async function getCustomCareerReport(startDate, endDate) {
 }
 
 export async function getPerformancePacket(startDate, endDate, options = {}) {
-  const response = await api.get("/packets/performance-review", {
+  const path =
+    options.packetType === "promotion"
+      ? "/packets/promotion"
+      : "/packets/performance-review";
+  const response = await api.get(path, {
     params: getPacketParams(startDate, endDate, options),
   });
   return response.data;


### PR DESCRIPTION
## What changed

- adds a Pro-gated `/packets/promotion` endpoint that reuses the same evidence engine as the Performance Review Packet
- adds optional target role and target level/progression fields without baking a profession into the schema
- builds a deterministic promotion case from documented accomplishments, Impact Receipts, measurable outcomes, skills, evidence, shared credit, and confirmations
- adds career-neutral sections for demonstrated impact, scope & ownership, growth & capabilities, verified recognition, and concrete ways to strengthen the evidence case
- explicitly avoids automated promotion-readiness scores or employment decisions
- adds a dedicated server-generated Promotion Packet PDF at `/packets/promotion.pdf`
- adds a Promotion Packet physical preview with promotion-specific cover, scorecard framing, case pages, receipt appendix, evidence index, and conversation summary
- lets the existing Pro packet builder switch between Performance Review Packet and Promotion Packet
- adds direct Promotion PDF download using the authenticated blob-download flow
- adds backend coverage using a non-technical Operations Supervisor → Senior Operations Manager scenario

## Product principle

Promotion is a human/organizational decision. BragStack makes the evidence case dramatically easier to assemble and inspect without pretending it can decide readiness, level, compensation, or an employment outcome.

## Validation

- Backend CI ✅
- Promotion API entitlement test ✅
- Non-tech promotion-case test ✅
- Dedicated Promotion PDF generation test ✅
- Frontend ESLint ✅
- Frontend production build ✅

## Stack

This PR intentionally targets `feature/performance-review-packet-v1` and should land after #19.

Closes #26.