### PR TITLE
Harden production auth configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,16 @@
+# BragStack environment configuration
+# Copy to .env for local development. Never commit real secrets.
+
+# Backend
+MONGO_URL=mongodb://mongo:27017
+JWT_SECRET=replace-with-a-long-random-secret
+ACCESS_TOKEN_EXPIRE_MINUTES=1440
+FRONTEND_URL=http://localhost:5173
+
+# Google OAuth
+GOOGLE_CLIENT_ID=replace-with-google-client-id
+GOOGLE_CLIENT_SECRET=replace-with-google-client-secret
+
+# GitHub OAuth
+GITHUB_CLIENT_ID=replace-with-github-client-id
+GITHUB_CLIENT_SECRET=replace-with-github-client-secret

--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -10,7 +10,10 @@ from passlib.context import CryptContext
 from app.database import users_collection
 from app.plans import get_entitlements_for_user, get_plan_for_user
 
-SECRET_KEY = os.getenv("JWT_SECRET", "change-this-dev-secret")
+SECRET_KEY = os.getenv("JWT_SECRET")
+if not SECRET_KEY:
+    raise RuntimeError("JWT_SECRET environment variable is required")
+
 ALGORITHM = "HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES = int(
     os.getenv("ACCESS_TOKEN_EXPIRE_MINUTES", "1440")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,3 +1,5 @@
+import os
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
@@ -28,9 +30,12 @@ app = FastAPI(
     version="1.0.0",
 )
 
+frontend_url = os.getenv("FRONTEND_URL", "http://localhost:5173").rstrip("/")
+
 app.add_middleware(
     CORSMiddleware,
     allow_origins=[
+        frontend_url,
         "http://localhost:5173",
         "http://127.0.0.1:5173",
     ],


### PR DESCRIPTION
Adds production auth configuration hooks:

- require JWT_SECRET from the environment
- make frontend CORS origin configurable with FRONTEND_URL
- add .env.example placeholders for JWT, Google OAuth, and GitHub OAuth credentials

No real secrets are committed.