### PR TITLE
Add Google and GitHub OAuth

### DIFF
--- a/backend/app/auth_routes.py
+++ b/backend/app/auth_routes.py
@@ -19,33 +19,17 @@ router = APIRouter(prefix="/auth", tags=["auth"])
 
 
 class RegisterRequest(BaseModel):
-    """Request body for creating a new user account.
-
-    Attributes:
-        name: The user's display name.
-        email: The user's email address.
-        password: The user's plain-text password.
-    """
-
     name: str = Field(..., min_length=1, max_length=80)
     email: EmailStr
     password: str = Field(..., min_length=8)
 
 
 class LoginRequest(BaseModel):
-    """Request body for logging in an existing user.
-
-    Attributes:
-        email: The user's email address.
-        password: The user's plain-text password.
-    """
-
     email: EmailStr
     password: str
 
-class ProfileUpdateRequest(BaseModel):
-    """Editable public profile information."""
 
+class ProfileUpdateRequest(BaseModel):
     name: str = Field(..., min_length=1, max_length=80)
     headline: str = Field(default="", max_length=120)
     bio: str = Field(default="", max_length=500)
@@ -54,41 +38,25 @@ class ProfileUpdateRequest(BaseModel):
     portfolio_url: str = Field(default="", max_length=300)
     resume_url: str = Field(default="", max_length=300)
 
+
 def slugify(value: str) -> str:
-    """Convert a display name into a URL-safe slug."""
     slug = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
     return slug or "user"
 
 
 def generate_unique_public_slug(name: str) -> str:
-    """Generate a stable, unique public profile slug."""
-
     base_slug = slugify(name)
-
     while True:
         random_suffix = secrets.token_hex(3)
         slug = f"{base_slug}-{random_suffix}"
-
         if not users_collection.find_one({"public_slug": slug}):
             return slug
 
+
 @router.post("/register")
 def register_user(payload: RegisterRequest):
-    """Create a new user account and return an access token.
-
-    Args:
-        payload: The registration request containing name, email, and password.
-
-    Returns:
-        A dictionary containing the access token, token type, and serialized user.
-
-    Raises:
-        HTTPException: If an account already exists for the provided email.
-    """
     normalized_email = payload.email.lower().strip()
-
     existing_user = users_collection.find_one({"email": normalized_email})
-
     if existing_user:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
@@ -96,19 +64,15 @@ def register_user(payload: RegisterRequest):
         )
 
     user_doc = {
-    "name": payload.name.strip(),
-    "email": normalized_email,
-    "public_slug": generate_unique_public_slug(payload.name),
-    "hashed_password": hash_password(payload.password),
-    "created_at": datetime.now(timezone.utc).isoformat(),
-}
-
+        "name": payload.name.strip(),
+        "email": normalized_email,
+        "public_slug": generate_unique_public_slug(payload.name),
+        "hashed_password": hash_password(payload.password),
+        "created_at": datetime.now(timezone.utc).isoformat(),
+    }
     result = users_collection.insert_one(user_doc)
-
     access_token = create_access_token({"sub": str(result.inserted_id)})
-
     created_user = users_collection.find_one({"_id": result.inserted_id})
-
     return {
         "access_token": access_token,
         "token_type": "bearer",
@@ -118,64 +82,43 @@ def register_user(payload: RegisterRequest):
 
 @router.post("/login")
 def login_user(form_data: OAuth2PasswordRequestForm = Depends()):
-    """Authenticate a user and return an access token.
-
-    Args:
-        form_data: OAuth2-compatible login form data from Swagger or the frontend.
-            The username field should contain the user's email address.
-
-    Returns:
-        A dictionary containing the access token, token type, and serialized user.
-
-    Raises:
-        HTTPException: If the email or password is invalid.
-    """
     normalized_email = form_data.username.lower().strip()
-
     user = users_collection.find_one({"email": normalized_email})
+    hashed_password = user.get("hashed_password") if user else None
 
-    if not user or not verify_password(form_data.password, user["hashed_password"]):
+    if not user or not hashed_password or not verify_password(form_data.password, hashed_password):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid email or password",
         )
 
     access_token = create_access_token({"sub": str(user["_id"])})
-
     return {
         "access_token": access_token,
         "token_type": "bearer",
         "user": serialize_user(user),
     }
 
+
 @router.get("/me")
 def get_me(current_user: dict = Depends(get_current_user)):
-    """Return the currently authenticated user."""
-
     current_slug = current_user.get("public_slug", "")
     basic_name_slug = slugify(current_user.get("name", "user"))
-
     if not current_slug or current_slug == basic_name_slug:
-        public_slug = generate_unique_public_slug(
-            current_user.get("name", "user")
-        )
-
+        public_slug = generate_unique_public_slug(current_user.get("name", "user"))
         users_collection.update_one(
             {"_id": current_user["_id"]},
             {"$set": {"public_slug": public_slug}},
         )
-
         current_user["public_slug"] = public_slug
-
     return serialize_user(current_user)
+
 
 @router.patch("/me/profile")
 def update_profile(
     payload: ProfileUpdateRequest,
     current_user: dict = Depends(get_current_user),
 ):
-    """Update the authenticated user's public profile."""
-
     updates = {
         "name": payload.name.strip(),
         "headline": payload.headline.strip(),
@@ -185,12 +128,8 @@ def update_profile(
         "portfolio_url": payload.portfolio_url.strip(),
         "resume_url": payload.resume_url.strip(),
     }
-
-    url_fields = ("github_url", "portfolio_url", "resume_url")
-
-    for field_name in url_fields:
+    for field_name in ("github_url", "portfolio_url", "resume_url"):
         value = updates[field_name]
-
         if value and not value.startswith(("http://", "https://")):
             raise HTTPException(
                 status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
@@ -201,9 +140,5 @@ def update_profile(
         {"_id": current_user["_id"]},
         {"$set": updates},
     )
-
-    updated_user = users_collection.find_one(
-        {"_id": current_user["_id"]}
-    )
-
+    updated_user = users_collection.find_one({"_id": current_user["_id"]})
     return serialize_user(updated_user)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,6 +4,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.auth_routes import router as auth_router
+from app.oauth_routes import router as oauth_router
 from app.beta_metrics_routes import router as beta_metrics_router
 from app.certification_packet_export_routes import router as certification_packet_export_router
 from app.certification_packet_routes import router as certification_packet_router
@@ -46,6 +47,7 @@ app.add_middleware(
 )
 
 app.include_router(auth_router)
+app.include_router(oauth_router)
 app.include_router(entries_router)
 app.include_router(public_router)
 app.include_router(public_slug_router)

--- a/backend/app/oauth_routes.py
+++ b/backend/app/oauth_routes.py
@@ -1,0 +1,238 @@
+import os
+import re
+import secrets
+from datetime import datetime, timezone
+from urllib.parse import urlencode
+
+import httpx
+from fastapi import APIRouter, HTTPException, Request, status
+from fastapi.responses import RedirectResponse
+
+from app.auth import create_access_token
+from app.database import users_collection
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+
+FRONTEND_URL = os.getenv("FRONTEND_URL", "http://localhost:5173").rstrip("/")
+GOOGLE_CLIENT_ID = os.getenv("GOOGLE_CLIENT_ID", "")
+GOOGLE_CLIENT_SECRET = os.getenv("GOOGLE_CLIENT_SECRET", "")
+GITHUB_CLIENT_ID = os.getenv("GITHUB_CLIENT_ID", "")
+GITHUB_CLIENT_SECRET = os.getenv("GITHUB_CLIENT_SECRET", "")
+
+GOOGLE_AUTHORIZE_URL = "https://accounts.google.com/o/oauth2/v2/auth"
+GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token"
+GOOGLE_USERINFO_URL = "https://openidconnect.googleapis.com/v1/userinfo"
+GITHUB_AUTHORIZE_URL = "https://github.com/login/oauth/authorize"
+GITHUB_TOKEN_URL = "https://github.com/login/oauth/access_token"
+GITHUB_USER_URL = "https://api.github.com/user"
+GITHUB_EMAILS_URL = "https://api.github.com/user/emails"
+
+
+def _slugify(value: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+    return slug or "user"
+
+
+def _generate_unique_public_slug(name: str) -> str:
+    base_slug = _slugify(name)
+    while True:
+        slug = f"{base_slug}-{secrets.token_hex(3)}"
+        if not users_collection.find_one({"public_slug": slug}):
+            return slug
+
+
+def _require_credentials(provider: str) -> None:
+    configured = {
+        "google": GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET,
+        "github": GITHUB_CLIENT_ID and GITHUB_CLIENT_SECRET,
+    }
+    if not configured.get(provider):
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=f"{provider.title()} OAuth is not configured",
+        )
+
+
+def _redirect_uri(request: Request, provider: str) -> str:
+    return str(request.url_for(f"{provider}_callback"))
+
+
+def _find_or_create_oauth_user(
+    provider: str,
+    provider_user_id: str,
+    email: str,
+    name: str,
+) -> dict:
+    normalized_email = email.lower().strip()
+    provider_field = f"oauth.{provider}_id"
+
+    user = users_collection.find_one({provider_field: provider_user_id})
+    if user:
+        return user
+
+    user = users_collection.find_one({"email": normalized_email})
+    if user:
+        users_collection.update_one(
+            {"_id": user["_id"]},
+            {"$set": {provider_field: provider_user_id}},
+        )
+        return users_collection.find_one({"_id": user["_id"]})
+
+    user_doc = {
+        "name": (name or normalized_email.split("@", 1)[0]).strip(),
+        "email": normalized_email,
+        "public_slug": _generate_unique_public_slug(name or "user"),
+        "oauth": {f"{provider}_id": provider_user_id},
+        "created_at": datetime.now(timezone.utc).isoformat(),
+    }
+    result = users_collection.insert_one(user_doc)
+    return users_collection.find_one({"_id": result.inserted_id})
+
+
+def _frontend_success_redirect(user: dict) -> RedirectResponse:
+    token = create_access_token({"sub": str(user["_id"])})
+    return RedirectResponse(
+        url=f"{FRONTEND_URL}/auth/callback#token={token}",
+        status_code=status.HTTP_302_FOUND,
+    )
+
+
+def _set_state_cookie(response: RedirectResponse, provider: str, state_value: str) -> None:
+    response.set_cookie(
+        key=f"oauth_state_{provider}",
+        value=state_value,
+        max_age=600,
+        httponly=True,
+        secure=True,
+        samesite="lax",
+    )
+
+
+def _validate_state(request: Request, provider: str, state_value: str | None) -> None:
+    expected = request.cookies.get(f"oauth_state_{provider}")
+    if not expected or not state_value or not secrets.compare_digest(expected, state_value):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid OAuth state",
+        )
+
+
+@router.get("/google/login", name="google_login")
+def google_login(request: Request):
+    _require_credentials("google")
+    state_value = secrets.token_urlsafe(32)
+    params = {
+        "client_id": GOOGLE_CLIENT_ID,
+        "redirect_uri": _redirect_uri(request, "google"),
+        "response_type": "code",
+        "scope": "openid email profile",
+        "state": state_value,
+        "prompt": "select_account",
+    }
+    response = RedirectResponse(f"{GOOGLE_AUTHORIZE_URL}?{urlencode(params)}")
+    _set_state_cookie(response, "google", state_value)
+    return response
+
+
+@router.get("/google/callback", name="google_callback")
+async def google_callback(request: Request, code: str, state: str | None = None):
+    _require_credentials("google")
+    _validate_state(request, "google", state)
+
+    async with httpx.AsyncClient(timeout=15.0) as client:
+        token_response = await client.post(
+            GOOGLE_TOKEN_URL,
+            data={
+                "client_id": GOOGLE_CLIENT_ID,
+                "client_secret": GOOGLE_CLIENT_SECRET,
+                "code": code,
+                "grant_type": "authorization_code",
+                "redirect_uri": _redirect_uri(request, "google"),
+            },
+        )
+        token_response.raise_for_status()
+        access_token = token_response.json().get("access_token")
+        if not access_token:
+            raise HTTPException(status_code=400, detail="Google did not return an access token")
+
+        userinfo_response = await client.get(
+            GOOGLE_USERINFO_URL,
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+        userinfo_response.raise_for_status()
+        profile = userinfo_response.json()
+
+    if not profile.get("email") or profile.get("email_verified") is not True:
+        raise HTTPException(status_code=400, detail="Google account must have a verified email")
+
+    user = _find_or_create_oauth_user(
+        "google",
+        str(profile.get("sub")),
+        profile["email"],
+        profile.get("name") or "",
+    )
+    response = _frontend_success_redirect(user)
+    response.delete_cookie("oauth_state_google")
+    return response
+
+
+@router.get("/github/login", name="github_login")
+def github_login(request: Request):
+    _require_credentials("github")
+    state_value = secrets.token_urlsafe(32)
+    params = {
+        "client_id": GITHUB_CLIENT_ID,
+        "redirect_uri": _redirect_uri(request, "github"),
+        "scope": "user:email",
+        "state": state_value,
+    }
+    response = RedirectResponse(f"{GITHUB_AUTHORIZE_URL}?{urlencode(params)}")
+    _set_state_cookie(response, "github", state_value)
+    return response
+
+
+@router.get("/github/callback", name="github_callback")
+async def github_callback(request: Request, code: str, state: str | None = None):
+    _require_credentials("github")
+    _validate_state(request, "github", state)
+
+    headers = {"Accept": "application/json", "User-Agent": "BragStack"}
+    async with httpx.AsyncClient(timeout=15.0, headers=headers) as client:
+        token_response = await client.post(
+            GITHUB_TOKEN_URL,
+            data={
+                "client_id": GITHUB_CLIENT_ID,
+                "client_secret": GITHUB_CLIENT_SECRET,
+                "code": code,
+                "redirect_uri": _redirect_uri(request, "github"),
+            },
+        )
+        token_response.raise_for_status()
+        access_token = token_response.json().get("access_token")
+        if not access_token:
+            raise HTTPException(status_code=400, detail="GitHub did not return an access token")
+
+        auth_headers = {"Authorization": f"Bearer {access_token}"}
+        user_response = await client.get(GITHUB_USER_URL, headers=auth_headers)
+        user_response.raise_for_status()
+        profile = user_response.json()
+
+        emails_response = await client.get(GITHUB_EMAILS_URL, headers=auth_headers)
+        emails_response.raise_for_status()
+        emails = emails_response.json()
+
+    verified_emails = [item for item in emails if item.get("verified") and item.get("email")]
+    primary = next((item for item in verified_emails if item.get("primary")), None)
+    selected_email = (primary or (verified_emails[0] if verified_emails else None))
+    if not selected_email:
+        raise HTTPException(status_code=400, detail="GitHub account must have a verified email")
+
+    user = _find_or_create_oauth_user(
+        "github",
+        str(profile.get("id")),
+        selected_email["email"],
+        profile.get("name") or profile.get("login") or "",
+    )
+    response = _frontend_success_redirect(user)
+    response.delete_cookie("oauth_state_github")
+    return response

--- a/frontend/public/auth/callback/index.html
+++ b/frontend/public/auth/callback/index.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Signing in to BragStack…</title>
+  </head>
+  <body>
+    <p>Signing you in to BragStack…</p>
+    <script>
+      (() => {
+        const params = new URLSearchParams(window.location.hash.slice(1));
+        const token = params.get("token");
+        if (!token) {
+          window.location.replace("/login?oauth_error=missing_token");
+          return;
+        }
+        localStorage.setItem("bragstack_token", token);
+        history.replaceState(null, "", "/auth/callback");
+        window.location.replace("/app");
+      })();
+    </script>
+  </body>
+</html>

--- a/frontend/src/AuthPage.css
+++ b/frontend/src/AuthPage.css
@@ -121,36 +121,67 @@
 }
 
 .auth-oauth-button {
-  min-height: 48px;
+  min-height: 50px;
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 10px;
+  gap: 11px;
   border-radius: 16px;
-  border: 1px solid rgba(148, 163, 184, 0.24);
-  background: rgba(2, 6, 23, 0.52);
-  color: #f8fafc;
+  border: 1px solid transparent;
   font-weight: 900;
   text-decoration: none;
-  transition: border-color 150ms ease, transform 150ms ease, background 150ms ease;
+  transition: transform 150ms ease, box-shadow 150ms ease, border-color 150ms ease, background 150ms ease;
 }
 
 .auth-oauth-button:hover {
   transform: translateY(-1px);
-  border-color: rgba(147, 197, 253, 0.7);
-  background: rgba(15, 23, 42, 0.88);
+}
+
+.auth-oauth-google {
+  background: #ffffff;
+  color: #202124;
+  border-color: #dadce0;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.16);
+}
+
+.auth-oauth-google:hover {
+  background: #f8f9fa;
+  border-color: #c7c9cc;
+  box-shadow: 0 10px 28px rgba(66, 133, 244, 0.18);
 }
 
 .auth-google-mark {
-  width: 20px;
-  height: 20px;
+  width: 21px;
+  height: 21px;
   display: grid;
   place-items: center;
-  border-radius: 50%;
-  background: #fff;
-  color: #1f2937;
-  font-size: 0.82rem;
+  font-size: 1rem;
   font-weight: 1000;
+  line-height: 1;
+  background: conic-gradient(
+    from -45deg,
+    #4285f4 0deg 92deg,
+    #34a853 92deg 176deg,
+    #fbbc05 176deg 252deg,
+    #ea4335 252deg 322deg,
+    #4285f4 322deg 360deg
+  );
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.auth-oauth-github {
+  background: #0d1117;
+  color: #f0f6fc;
+  border-color: #30363d;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.28);
+}
+
+.auth-oauth-github:hover {
+  background: #161b22;
+  border-color: #8b949e;
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.34);
 }
 
 .auth-divider {

--- a/frontend/src/AuthPage.css
+++ b/frontend/src/AuthPage.css
@@ -35,11 +35,7 @@
   position: absolute;
   inset: 0;
   pointer-events: none;
-  background: linear-gradient(
-    135deg,
-    rgba(255, 255, 255, 0.08),
-    transparent 38%
-  );
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.08), transparent 38%);
 }
 
 .auth-copy {
@@ -118,6 +114,65 @@
   line-height: 1.65;
 }
 
+.auth-oauth-grid {
+  display: grid;
+  gap: 10px;
+  margin-bottom: 18px;
+}
+
+.auth-oauth-button {
+  min-height: 48px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  background: rgba(2, 6, 23, 0.52);
+  color: #f8fafc;
+  font-weight: 900;
+  text-decoration: none;
+  transition: border-color 150ms ease, transform 150ms ease, background 150ms ease;
+}
+
+.auth-oauth-button:hover {
+  transform: translateY(-1px);
+  border-color: rgba(147, 197, 253, 0.7);
+  background: rgba(15, 23, 42, 0.88);
+}
+
+.auth-google-mark {
+  width: 20px;
+  height: 20px;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  background: #fff;
+  color: #1f2937;
+  font-size: 0.82rem;
+  font-weight: 1000;
+}
+
+.auth-divider {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin: 4px 0 18px;
+  color: #64748b;
+  font-size: 0.78rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.auth-divider::before,
+.auth-divider::after {
+  content: "";
+  flex: 1;
+  height: 1px;
+  background: rgba(148, 163, 184, 0.18);
+}
+
 .auth-error {
   margin-bottom: 16px;
   padding: 13px 14px;
@@ -146,10 +201,7 @@
   color: #93c5fd;
   border-radius: 16px;
   padding: 0 13px;
-  transition:
-    border-color 150ms ease,
-    box-shadow 150ms ease,
-    background 150ms ease;
+  transition: border-color 150ms ease, box-shadow 150ms ease, background 150ms ease;
 }
 
 .auth-field div:focus-within {

--- a/frontend/src/AuthPage.jsx
+++ b/frontend/src/AuthPage.jsx
@@ -84,13 +84,19 @@ function AuthPage({ mode = "login", onLogin, onRegister }) {
           </p>
 
           <div className="auth-oauth-grid">
-            <a className="auth-oauth-button" href={`${apiBaseUrl}/auth/google/login`}>
-              <span className="auth-google-mark">G</span>
-              Continue with Google
+            <a
+              className="auth-oauth-button auth-oauth-google"
+              href={`${apiBaseUrl}/auth/google/login`}
+            >
+              <span className="auth-google-mark" aria-hidden="true">G</span>
+              <span>Continue with Google</span>
             </a>
-            <a className="auth-oauth-button" href={`${apiBaseUrl}/auth/github/login`}>
-              <Github size={18} />
-              Continue with GitHub
+            <a
+              className="auth-oauth-button auth-oauth-github"
+              href={`${apiBaseUrl}/auth/github/login`}
+            >
+              <Github size={20} aria-hidden="true" />
+              <span>Continue with GitHub</span>
             </a>
           </div>
 

--- a/frontend/src/AuthPage.jsx
+++ b/frontend/src/AuthPage.jsx
@@ -1,26 +1,27 @@
 import { useState } from "react";
-import { Lock, Mail, Sparkles, UserPlus } from "lucide-react";
+import { Github, Lock, Mail, Sparkles, UserPlus } from "lucide-react";
 import "./AuthPage.css";
+
+function getApiBaseUrl() {
+  if (window.location.hostname.endsWith(".app.github.dev")) return "/api";
+  return import.meta.env.VITE_API_BASE_URL || import.meta.env.VITE_API_URL || "http://localhost:8000";
+}
 
 function AuthPage({ mode = "login", onLogin, onRegister }) {
   const isRegister = mode === "register";
+  const apiBaseUrl = getApiBaseUrl().replace(/\/$/, "");
 
   const [formData, setFormData] = useState({
     name: "",
     email: "",
     password: "",
   });
-
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [errorMessage, setErrorMessage] = useState("");
 
   function handleChange(event) {
     const { name, value } = event.target;
-
-    setFormData((current) => ({
-      ...current,
-      [name]: value,
-    }));
+    setFormData((current) => ({ ...current, [name]: value }));
   }
 
   async function handleSubmit(event) {
@@ -32,10 +33,7 @@ function AuthPage({ mode = "login", onLogin, onRegister }) {
       if (isRegister) {
         await onRegister(formData);
       } else {
-        await onLogin({
-          email: formData.email,
-          password: formData.password,
-        });
+        await onLogin({ email: formData.email, password: formData.password });
       }
     } catch (error) {
       console.error(error);
@@ -54,18 +52,15 @@ function AuthPage({ mode = "login", onLogin, onRegister }) {
       <section className="auth-shell">
         <div className="auth-copy">
           <p className="mini-label">BragStack</p>
-
           <h1>
             Save your wins before
             <span> they disappear.</span>
           </h1>
-
           <p>
             Track technical work, turn progress into resume bullets, and build a
             private career proof system you can reuse for reviews, interviews,
             raises, and job searches.
           </p>
-
           <div className="auth-proof-list">
             <span>Private by default</span>
             <span>Resume-ready proof</span>
@@ -81,14 +76,25 @@ function AuthPage({ mode = "login", onLogin, onRegister }) {
           <p className="mini-label">
             {isRegister ? "Create account" : "Welcome back"}
           </p>
-
           <h2>{isRegister ? "Start your BragStack" : "Log in to BragStack"}</h2>
-
           <p className="auth-muted">
             {isRegister
               ? "Create your private workspace for career proof."
               : "Open your dashboard and keep building your proof."}
           </p>
+
+          <div className="auth-oauth-grid">
+            <a className="auth-oauth-button" href={`${apiBaseUrl}/auth/google/login`}>
+              <span className="auth-google-mark">G</span>
+              Continue with Google
+            </a>
+            <a className="auth-oauth-button" href={`${apiBaseUrl}/auth/github/login`}>
+              <Github size={18} />
+              Continue with GitHub
+            </a>
+          </div>
+
+          <div className="auth-divider"><span>or use email</span></div>
 
           {errorMessage && <div className="auth-error">{errorMessage}</div>}
 
@@ -140,11 +146,7 @@ function AuthPage({ mode = "login", onLogin, onRegister }) {
           </label>
 
           <button className="btn primary auth-submit" disabled={isSubmitting}>
-            {isSubmitting
-              ? "Working..."
-              : isRegister
-              ? "Create account"
-              : "Log in"}
+            {isSubmitting ? "Working..." : isRegister ? "Create account" : "Log in"}
           </button>
 
           <p className="auth-switch">


### PR DESCRIPTION
Adds production OAuth authentication for Google and GitHub.

- Google OAuth login/callback routes
- GitHub OAuth login/callback routes
- CSRF state cookies for provider redirects
- verified-email account linking so the same email reuses the same BragStack user
- OAuth-only account support in password login
- Google/GitHub buttons on login/register
- frontend callback handler that stores the BragStack JWT and redirects to /app

Required Render backend variables after merge:
GOOGLE_CLIENT_ID
GOOGLE_CLIENT_SECRET
GITHUB_CLIENT_ID
GITHUB_CLIENT_SECRET
FRONTEND_URL=https://usebragstack.com

Production callback URLs:
https://api.usebragstack.com/auth/google/callback
https://api.usebragstack.com/auth/github/callback