### PR TITLE
Add Stripe billing and enforce plan entitlements

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,8 @@ GOOGLE_CLIENT_SECRET=replace-with-google-client-secret
 # GitHub OAuth
 GITHUB_CLIENT_ID=replace-with-github-client-id
 GITHUB_CLIENT_SECRET=replace-with-github-client-secret
+
+# Stripe billing (backend only)
+STRIPE_SECRET_KEY=replace-with-stripe-secret-key
+STRIPE_PRO_PRICE_ID=replace-with-stripe-recurring-price-id
+STRIPE_WEBHOOK_SECRET=replace-with-stripe-webhook-signing-secret

--- a/backend/app/billing_routes.py
+++ b/backend/app/billing_routes.py
@@ -3,7 +3,6 @@ import hmac
 import json
 import os
 import time
-from urllib.parse import parse_qs
 
 import httpx
 from bson import ObjectId
@@ -122,10 +121,30 @@ def _user_id_from_subscription(subscription: dict) -> str | None:
     return str(user["_id"]) if user else None
 
 
+def _find_user_for_invoice(invoice: dict) -> dict | None:
+    subscription_id = invoice.get("subscription")
+    customer_id = invoice.get("customer")
+    user = None
+    if subscription_id:
+        user = users_collection.find_one({"stripe_subscription_id": subscription_id})
+    if user is None and customer_id:
+        user = users_collection.find_one({"stripe_customer_id": customer_id})
+    return user
+
+
 @router.post("/checkout-session")
 async def create_checkout_session(current_user: dict = Depends(get_current_user)):
     """Create a Stripe Checkout subscription session for BragStack Pro."""
     _require_stripe_checkout_config()
+
+    if get_plan_for_user(current_user) == "pro" and current_user.get("billing_status") in {
+        "active",
+        "trialing",
+    }:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="This account already has an active BragStack Pro subscription.",
+        )
 
     user_id = str(current_user["_id"])
     form = {
@@ -221,20 +240,25 @@ async def stripe_webhook(request: Request):
             )
 
     elif event_type == "invoice.payment_failed":
-        subscription_id = obj.get("subscription")
-        customer_id = obj.get("customer")
-        user = None
-        if subscription_id:
-            user = users_collection.find_one({"stripe_subscription_id": subscription_id})
-        if user is None and customer_id:
-            user = users_collection.find_one({"stripe_customer_id": customer_id})
+        user = _find_user_for_invoice(obj)
         if user:
             _set_subscription_state(
                 str(user["_id"]),
                 plan="free",
                 billing_status="payment_failed",
-                customer_id=customer_id,
-                subscription_id=subscription_id,
+                customer_id=obj.get("customer"),
+                subscription_id=obj.get("subscription"),
+            )
+
+    elif event_type == "invoice.paid":
+        user = _find_user_for_invoice(obj)
+        if user:
+            _set_subscription_state(
+                str(user["_id"]),
+                plan="pro",
+                billing_status="active",
+                customer_id=obj.get("customer"),
+                subscription_id=obj.get("subscription"),
             )
 
     return {"received": True}

--- a/backend/app/billing_routes.py
+++ b/backend/app/billing_routes.py
@@ -1,0 +1,240 @@
+import hashlib
+import hmac
+import json
+import os
+import time
+from urllib.parse import parse_qs
+
+import httpx
+from bson import ObjectId
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+
+from app.auth import get_current_user
+from app.database import users_collection
+from app.plans import get_plan_for_user
+
+router = APIRouter(prefix="/billing", tags=["billing"])
+
+STRIPE_API_BASE = "https://api.stripe.com/v1"
+STRIPE_SECRET_KEY = os.getenv("STRIPE_SECRET_KEY", "")
+STRIPE_WEBHOOK_SECRET = os.getenv("STRIPE_WEBHOOK_SECRET", "")
+STRIPE_PRO_PRICE_ID = os.getenv("STRIPE_PRO_PRICE_ID", "")
+FRONTEND_URL = os.getenv("FRONTEND_URL", "http://localhost:5173").rstrip("/")
+
+
+def _require_stripe_checkout_config() -> None:
+    if not STRIPE_SECRET_KEY or not STRIPE_PRO_PRICE_ID:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Stripe billing is not configured yet.",
+        )
+
+
+def _stripe_headers() -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {STRIPE_SECRET_KEY}",
+        "Content-Type": "application/x-www-form-urlencoded",
+    }
+
+
+def _verify_stripe_signature(payload: bytes, signature_header: str) -> None:
+    if not STRIPE_WEBHOOK_SECRET:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Stripe webhook verification is not configured.",
+        )
+
+    parts: dict[str, list[str]] = {}
+    for item in signature_header.split(","):
+        if "=" not in item:
+            continue
+        key, value = item.split("=", 1)
+        parts.setdefault(key, []).append(value)
+
+    timestamp_values = parts.get("t", [])
+    signatures = parts.get("v1", [])
+    if not timestamp_values or not signatures:
+        raise HTTPException(status_code=400, detail="Invalid Stripe signature header")
+
+    timestamp = timestamp_values[0]
+    try:
+        timestamp_int = int(timestamp)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail="Invalid Stripe signature timestamp") from exc
+
+    if abs(int(time.time()) - timestamp_int) > 300:
+        raise HTTPException(status_code=400, detail="Expired Stripe webhook signature")
+
+    signed_payload = timestamp.encode("utf-8") + b"." + payload
+    expected = hmac.new(
+        STRIPE_WEBHOOK_SECRET.encode("utf-8"),
+        signed_payload,
+        hashlib.sha256,
+    ).hexdigest()
+
+    if not any(hmac.compare_digest(expected, candidate) for candidate in signatures):
+        raise HTTPException(status_code=400, detail="Invalid Stripe webhook signature")
+
+
+def _set_subscription_state(
+    user_id: str,
+    *,
+    plan: str,
+    billing_status: str,
+    customer_id: str | None = None,
+    subscription_id: str | None = None,
+) -> None:
+    if not ObjectId.is_valid(user_id):
+        return
+
+    updates = {
+        "plan": plan,
+        "billing_status": billing_status,
+    }
+    if customer_id:
+        updates["stripe_customer_id"] = customer_id
+    if subscription_id:
+        updates["stripe_subscription_id"] = subscription_id
+
+    users_collection.update_one(
+        {"_id": ObjectId(user_id)},
+        {"$set": updates},
+    )
+
+
+def _user_id_from_subscription(subscription: dict) -> str | None:
+    metadata = subscription.get("metadata") or {}
+    user_id = metadata.get("user_id")
+    if user_id:
+        return str(user_id)
+
+    subscription_id = subscription.get("id")
+    customer_id = subscription.get("customer")
+    query = {"$or": []}
+    if subscription_id:
+        query["$or"].append({"stripe_subscription_id": subscription_id})
+    if customer_id:
+        query["$or"].append({"stripe_customer_id": customer_id})
+    if not query["$or"]:
+        return None
+
+    user = users_collection.find_one(query)
+    return str(user["_id"]) if user else None
+
+
+@router.post("/checkout-session")
+async def create_checkout_session(current_user: dict = Depends(get_current_user)):
+    """Create a Stripe Checkout subscription session for BragStack Pro."""
+    _require_stripe_checkout_config()
+
+    user_id = str(current_user["_id"])
+    form = {
+        "mode": "subscription",
+        "line_items[0][price]": STRIPE_PRO_PRICE_ID,
+        "line_items[0][quantity]": "1",
+        "success_url": f"{FRONTEND_URL}/?billing=success",
+        "cancel_url": f"{FRONTEND_URL}/?billing=cancelled#pricing",
+        "client_reference_id": user_id,
+        "customer_email": current_user.get("email", ""),
+        "metadata[user_id]": user_id,
+        "subscription_data[metadata][user_id]": user_id,
+        "allow_promotion_codes": "true",
+    }
+
+    async with httpx.AsyncClient(timeout=20.0) as client:
+        response = await client.post(
+            f"{STRIPE_API_BASE}/checkout/sessions",
+            headers=_stripe_headers(),
+            data=form,
+        )
+
+    if response.status_code >= 400:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Stripe could not create a checkout session.",
+        )
+
+    session = response.json()
+    checkout_url = session.get("url")
+    if not checkout_url:
+        raise HTTPException(status_code=502, detail="Stripe did not return a checkout URL")
+
+    return {"url": checkout_url}
+
+
+@router.get("/status")
+def billing_status(current_user: dict = Depends(get_current_user)):
+    return {
+        "plan": get_plan_for_user(current_user),
+        "billing_status": current_user.get("billing_status", "free"),
+    }
+
+
+@router.post("/webhook")
+async def stripe_webhook(request: Request):
+    """Apply Stripe subscription lifecycle events to BragStack entitlements."""
+    payload = await request.body()
+    signature = request.headers.get("stripe-signature", "")
+    _verify_stripe_signature(payload, signature)
+
+    try:
+        event = json.loads(payload.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise HTTPException(status_code=400, detail="Invalid Stripe webhook body") from exc
+
+    event_type = event.get("type")
+    obj = ((event.get("data") or {}).get("object") or {})
+
+    if event_type == "checkout.session.completed":
+        user_id = obj.get("client_reference_id") or (obj.get("metadata") or {}).get("user_id")
+        if user_id:
+            _set_subscription_state(
+                str(user_id),
+                plan="pro",
+                billing_status="active",
+                customer_id=obj.get("customer"),
+                subscription_id=obj.get("subscription"),
+            )
+
+    elif event_type in {"customer.subscription.created", "customer.subscription.updated"}:
+        user_id = _user_id_from_subscription(obj)
+        if user_id:
+            stripe_status = str(obj.get("status") or "unknown")
+            paid = stripe_status in {"active", "trialing"}
+            _set_subscription_state(
+                user_id,
+                plan="pro" if paid else "free",
+                billing_status=stripe_status,
+                customer_id=obj.get("customer"),
+                subscription_id=obj.get("id"),
+            )
+
+    elif event_type == "customer.subscription.deleted":
+        user_id = _user_id_from_subscription(obj)
+        if user_id:
+            _set_subscription_state(
+                user_id,
+                plan="free",
+                billing_status="cancelled",
+                customer_id=obj.get("customer"),
+                subscription_id=obj.get("id"),
+            )
+
+    elif event_type == "invoice.payment_failed":
+        subscription_id = obj.get("subscription")
+        customer_id = obj.get("customer")
+        user = None
+        if subscription_id:
+            user = users_collection.find_one({"stripe_subscription_id": subscription_id})
+        if user is None and customer_id:
+            user = users_collection.find_one({"stripe_customer_id": customer_id})
+        if user:
+            _set_subscription_state(
+                str(user["_id"]),
+                plan="free",
+                billing_status="payment_failed",
+                customer_id=customer_id,
+                subscription_id=subscription_id,
+            )
+
+    return {"received": True}

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -64,8 +64,13 @@ def enforce_entry_usage(request: Request, current_user: dict = Depends(get_curre
 
 
 def enforce_receipt_usage(request: Request, current_user: dict = Depends(get_current_user)):
-    if request.method != "POST":
+    path = request.url.path.rstrip("/")
+    is_create = request.method == "POST" and (
+        path == "/impact-receipts" or path.startswith("/impact-receipts/from-entry/")
+    )
+    if not is_create:
         return
+
     user_id = str(current_user["_id"])
     enforce_usage_limit(
         user=current_user,

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,10 +1,12 @@
 import os
 
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
+from app.auth import get_current_user
 from app.auth_routes import router as auth_router
 from app.oauth_routes import router as oauth_router
+from app.billing_routes import router as billing_router
 from app.beta_metrics_routes import router as beta_metrics_router
 from app.certification_packet_export_routes import router as certification_packet_export_router
 from app.certification_packet_routes import router as certification_packet_router
@@ -18,6 +20,7 @@ from app.packet_platform_routes import router as packet_platform_router
 from app.packet_share_routes import router as packet_share_router
 from app.performance_packet_export_routes import router as performance_packet_export_router
 from app.performance_packet_routes import router as performance_packet_router
+from app.plans import require_feature
 from app.promotion_packet_export_routes import router as promotion_packet_export_router
 from app.promotion_packet_routes import router as promotion_packet_router
 from app.public_slug_routes import router as public_slug_router
@@ -46,27 +49,53 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+
+def require_advanced_reports(current_user: dict = Depends(get_current_user)):
+    require_feature(current_user, "advanced_reports")
+
+
+def require_performance_builder(current_user: dict = Depends(get_current_user)):
+    require_feature(current_user, "performance_review_builder")
+
+
+def require_promotion_packet(current_user: dict = Depends(get_current_user)):
+    require_feature(current_user, "promotion_packet")
+
+
+def require_interview_packet(current_user: dict = Depends(get_current_user)):
+    require_feature(current_user, "interview_packet")
+
+
+def require_certification_packet(current_user: dict = Depends(get_current_user)):
+    require_feature(current_user, "certification_packet")
+
+
+def require_pdf_export(current_user: dict = Depends(get_current_user)):
+    require_feature(current_user, "export_pdf")
+
+
 app.include_router(auth_router)
 app.include_router(oauth_router)
+app.include_router(billing_router)
 app.include_router(entries_router)
 app.include_router(public_router)
 app.include_router(public_slug_router)
 app.include_router(impact_receipts_router)
-app.include_router(core_output_router)
+app.include_router(core_output_router, dependencies=[Depends(require_performance_builder)])
 app.include_router(beta_metrics_router)
-app.include_router(reports_router)
-app.include_router(performance_packet_router)
-app.include_router(performance_packet_export_router)
-app.include_router(packet_platform_router)
-app.include_router(packet_platform_export_router)
-app.include_router(packet_audit_router)
-app.include_router(packet_share_router)
-app.include_router(promotion_packet_router)
-app.include_router(promotion_packet_export_router)
-app.include_router(interview_packet_router)
-app.include_router(interview_packet_export_router)
-app.include_router(certification_packet_router)
-app.include_router(certification_packet_export_router)
+app.include_router(reports_router, dependencies=[Depends(require_advanced_reports)])
+app.include_router(performance_packet_router, dependencies=[Depends(require_performance_builder)])
+app.include_router(performance_packet_export_router, dependencies=[Depends(require_pdf_export)])
+app.include_router(packet_platform_router, dependencies=[Depends(require_performance_builder)])
+app.include_router(packet_platform_export_router, dependencies=[Depends(require_pdf_export)])
+app.include_router(packet_audit_router, dependencies=[Depends(require_performance_builder)])
+app.include_router(packet_share_router, dependencies=[Depends(require_performance_builder)])
+app.include_router(promotion_packet_router, dependencies=[Depends(require_promotion_packet)])
+app.include_router(promotion_packet_export_router, dependencies=[Depends(require_pdf_export)])
+app.include_router(interview_packet_router, dependencies=[Depends(require_interview_packet)])
+app.include_router(interview_packet_export_router, dependencies=[Depends(require_pdf_export)])
+app.include_router(certification_packet_router, dependencies=[Depends(require_certification_packet)])
+app.include_router(certification_packet_export_router, dependencies=[Depends(require_pdf_export)])
 
 
 @app.get("/")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,6 +1,6 @@
 import os
 
-from fastapi import Depends, FastAPI
+from fastapi import Depends, FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.auth import get_current_user
@@ -11,6 +11,7 @@ from app.beta_metrics_routes import router as beta_metrics_router
 from app.certification_packet_export_routes import router as certification_packet_export_router
 from app.certification_packet_routes import router as certification_packet_router
 from app.core_output_routes import router as core_output_router
+from app.database import entries_collection, impact_receipts_collection
 from app.impact_receipt_routes import router as impact_receipts_router
 from app.interview_packet_export_routes import router as interview_packet_export_router
 from app.interview_packet_routes import router as interview_packet_router
@@ -20,7 +21,7 @@ from app.packet_platform_routes import router as packet_platform_router
 from app.packet_share_routes import router as packet_share_router
 from app.performance_packet_export_routes import router as performance_packet_export_router
 from app.performance_packet_routes import router as performance_packet_router
-from app.plans import require_feature
+from app.plans import enforce_usage_limit, require_feature
 from app.promotion_packet_export_routes import router as promotion_packet_export_router
 from app.promotion_packet_routes import router as promotion_packet_router
 from app.public_slug_routes import router as public_slug_router
@@ -50,6 +51,30 @@ app.add_middleware(
 )
 
 
+def enforce_entry_usage(request: Request, current_user: dict = Depends(get_current_user)):
+    if request.method != "POST" or request.url.path.rstrip("/") != "/entries":
+        return
+    user_id = str(current_user["_id"])
+    enforce_usage_limit(
+        user=current_user,
+        entitlement_name="max_entries",
+        current_count=entries_collection.count_documents({"user_id": user_id}),
+        resource_name="proof entries",
+    )
+
+
+def enforce_receipt_usage(request: Request, current_user: dict = Depends(get_current_user)):
+    if request.method != "POST":
+        return
+    user_id = str(current_user["_id"])
+    enforce_usage_limit(
+        user=current_user,
+        entitlement_name="max_impact_receipts",
+        current_count=impact_receipts_collection.count_documents({"user_id": user_id}),
+        resource_name="Impact Receipts",
+    )
+
+
 def require_advanced_reports(current_user: dict = Depends(get_current_user)):
     require_feature(current_user, "advanced_reports")
 
@@ -77,10 +102,10 @@ def require_pdf_export(current_user: dict = Depends(get_current_user)):
 app.include_router(auth_router)
 app.include_router(oauth_router)
 app.include_router(billing_router)
-app.include_router(entries_router)
+app.include_router(entries_router, dependencies=[Depends(enforce_entry_usage)])
 app.include_router(public_router)
 app.include_router(public_slug_router)
-app.include_router(impact_receipts_router)
+app.include_router(impact_receipts_router, dependencies=[Depends(enforce_receipt_usage)])
 app.include_router(core_output_router, dependencies=[Depends(require_performance_builder)])
 app.include_router(beta_metrics_router)
 app.include_router(reports_router, dependencies=[Depends(require_advanced_reports)])

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -21,7 +21,7 @@ from app.packet_platform_routes import router as packet_platform_router
 from app.packet_share_routes import router as packet_share_router
 from app.performance_packet_export_routes import router as performance_packet_export_router
 from app.performance_packet_routes import router as performance_packet_router
-from app.plans import enforce_usage_limit, require_feature
+from app.plans import enforce_usage_limit
 from app.promotion_packet_export_routes import router as promotion_packet_export_router
 from app.promotion_packet_routes import router as promotion_packet_router
 from app.public_slug_routes import router as public_slug_router
@@ -52,8 +52,10 @@ app.add_middleware(
 
 
 def enforce_entry_usage(request: Request, current_user: dict = Depends(get_current_user)):
+    """Enforce the current plan's proof-entry creation limit."""
     if request.method != "POST" or request.url.path.rstrip("/") != "/entries":
         return
+
     user_id = str(current_user["_id"])
     enforce_usage_limit(
         user=current_user,
@@ -64,6 +66,7 @@ def enforce_entry_usage(request: Request, current_user: dict = Depends(get_curre
 
 
 def enforce_receipt_usage(request: Request, current_user: dict = Depends(get_current_user)):
+    """Enforce the current plan's Impact Receipt creation limit."""
     path = request.url.path.rstrip("/")
     is_create = request.method == "POST" and (
         path == "/impact-receipts" or path.startswith("/impact-receipts/from-entry/")
@@ -80,30 +83,6 @@ def enforce_receipt_usage(request: Request, current_user: dict = Depends(get_cur
     )
 
 
-def require_advanced_reports(current_user: dict = Depends(get_current_user)):
-    require_feature(current_user, "advanced_reports")
-
-
-def require_performance_builder(current_user: dict = Depends(get_current_user)):
-    require_feature(current_user, "performance_review_builder")
-
-
-def require_promotion_packet(current_user: dict = Depends(get_current_user)):
-    require_feature(current_user, "promotion_packet")
-
-
-def require_interview_packet(current_user: dict = Depends(get_current_user)):
-    require_feature(current_user, "interview_packet")
-
-
-def require_certification_packet(current_user: dict = Depends(get_current_user)):
-    require_feature(current_user, "certification_packet")
-
-
-def require_pdf_export(current_user: dict = Depends(get_current_user)):
-    require_feature(current_user, "export_pdf")
-
-
 app.include_router(auth_router)
 app.include_router(oauth_router)
 app.include_router(billing_router)
@@ -111,21 +90,21 @@ app.include_router(entries_router, dependencies=[Depends(enforce_entry_usage)])
 app.include_router(public_router)
 app.include_router(public_slug_router)
 app.include_router(impact_receipts_router, dependencies=[Depends(enforce_receipt_usage)])
-app.include_router(core_output_router, dependencies=[Depends(require_performance_builder)])
+app.include_router(core_output_router)
 app.include_router(beta_metrics_router)
-app.include_router(reports_router, dependencies=[Depends(require_advanced_reports)])
-app.include_router(performance_packet_router, dependencies=[Depends(require_performance_builder)])
-app.include_router(performance_packet_export_router, dependencies=[Depends(require_pdf_export)])
-app.include_router(packet_platform_router, dependencies=[Depends(require_performance_builder)])
-app.include_router(packet_platform_export_router, dependencies=[Depends(require_pdf_export)])
-app.include_router(packet_audit_router, dependencies=[Depends(require_performance_builder)])
-app.include_router(packet_share_router, dependencies=[Depends(require_performance_builder)])
-app.include_router(promotion_packet_router, dependencies=[Depends(require_promotion_packet)])
-app.include_router(promotion_packet_export_router, dependencies=[Depends(require_pdf_export)])
-app.include_router(interview_packet_router, dependencies=[Depends(require_interview_packet)])
-app.include_router(interview_packet_export_router, dependencies=[Depends(require_pdf_export)])
-app.include_router(certification_packet_router, dependencies=[Depends(require_certification_packet)])
-app.include_router(certification_packet_export_router, dependencies=[Depends(require_pdf_export)])
+app.include_router(reports_router)
+app.include_router(performance_packet_router)
+app.include_router(performance_packet_export_router)
+app.include_router(packet_platform_router)
+app.include_router(packet_platform_export_router)
+app.include_router(packet_audit_router)
+app.include_router(packet_share_router)
+app.include_router(promotion_packet_router)
+app.include_router(promotion_packet_export_router)
+app.include_router(interview_packet_router)
+app.include_router(interview_packet_export_router)
+app.include_router(certification_packet_router)
+app.include_router(certification_packet_export_router)
 
 
 @app.get("/")

--- a/frontend/public/_redirects
+++ b/frontend/public/_redirects
@@ -1,2 +1,0 @@
-/auth/callback/* /auth/callback/index.html 200
-/* /index.html 200

--- a/frontend/public/_redirects
+++ b/frontend/public/_redirects
@@ -1,0 +1,2 @@
+/auth/callback/* /auth/callback/index.html 200
+/* /index.html 200

--- a/frontend/public/upgrade/index.html
+++ b/frontend/public/upgrade/index.html
@@ -1,0 +1,63 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Upgrade to BragStack Pro</title>
+    <style>
+      body{margin:0;min-height:100vh;display:grid;place-items:center;background:#020617;color:#f8fafc;font-family:Inter,system-ui,sans-serif}.card{width:min(92vw,520px);padding:32px;border:1px solid rgba(148,163,184,.2);border-radius:28px;background:rgba(15,23,42,.88);box-shadow:0 30px 90px rgba(0,0,0,.45)}h1{margin:0 0 12px;font-size:2.2rem}p{color:#cbd5e1;line-height:1.6}.price{font-size:1.4rem;font-weight:800;color:#c4b5fd}.actions{display:flex;gap:12px;flex-wrap:wrap;margin-top:24px}a,button{border:0;border-radius:14px;padding:12px 18px;font-weight:800;text-decoration:none;cursor:pointer}.primary{background:linear-gradient(135deg,#93c5fd,#c084fc);color:#020617}.secondary{background:#1e293b;color:#f8fafc}.error{margin-top:16px;color:#fecaca}
+    </style>
+  </head>
+  <body>
+    <main class="card">
+      <div class="price">BragStack Pro · $9/month</div>
+      <h1>Unlock your full career proof system.</h1>
+      <p>Pro includes unlimited proof entries and Impact Receipts, advanced career reports, performance review and promotion packets, PDF exports, integrations, and advanced public profile features.</p>
+      <div id="status">Checking your account…</div>
+      <div id="actions" class="actions"></div>
+      <div id="error" class="error"></div>
+    </main>
+    <script>
+      (() => {
+        const token = localStorage.getItem('bragstack_token');
+        const status = document.getElementById('status');
+        const actions = document.getElementById('actions');
+        const error = document.getElementById('error');
+        const apiBase = location.hostname === 'localhost' ? 'http://localhost:8000' : 'https://api.usebragstack.com';
+
+        if (!token) {
+          status.textContent = 'Sign in or create a free account first. Then you can continue to secure Stripe Checkout.';
+          actions.innerHTML = '<a class="primary" href="/register">Create account</a><a class="secondary" href="/login">Sign in</a>';
+          return;
+        }
+
+        async function startCheckout() {
+          status.textContent = 'Opening secure Stripe Checkout…';
+          error.textContent = '';
+          actions.innerHTML = '';
+          try {
+            const response = await fetch(`${apiBase}/billing/checkout-session`, {
+              method: 'POST',
+              headers: { Authorization: `Bearer ${token}` }
+            });
+            if (response.status === 401) {
+              localStorage.removeItem('bragstack_token');
+              location.replace('/login');
+              return;
+            }
+            const data = await response.json();
+            if (!response.ok || !data.url) throw new Error(data.detail || 'Checkout is not available yet.');
+            location.replace(data.url);
+          } catch (err) {
+            status.textContent = 'We could not open checkout.';
+            error.textContent = typeof err.message === 'string' ? err.message : 'Please try again.';
+            actions.innerHTML = '<button class="primary" id="retry">Try again</button><a class="secondary" href="/">Back to pricing</a>';
+            document.getElementById('retry')?.addEventListener('click', startCheckout);
+          }
+        }
+
+        void startCheckout();
+      })();
+    </script>
+  </body>
+</html>

--- a/frontend/src/AppSidebar.jsx
+++ b/frontend/src/AppSidebar.jsx
@@ -5,17 +5,17 @@ import {
   ListChecks,
   LogOut,
   ReceiptText,
+  Sparkles,
   UserRound,
 } from "lucide-react";
 
 import { getCurrentUser } from "./api";
 import "./AppShell.css";
 
-const NAV_ITEMS = [
+const BASE_NAV_ITEMS = [
   { href: "/app", label: "Overview", icon: Home },
   { href: "/app/accomplishments", label: "Accomplishments", icon: ListChecks },
   { href: "/app/impact-receipts", label: "Impact Receipts", icon: ReceiptText },
-  { href: "/app/reports", label: "Reports", icon: FileText },
 ];
 
 function AppSidebar() {
@@ -28,9 +28,7 @@ function AppSidebar() {
     async function loadUser() {
       try {
         const data = await getCurrentUser();
-        if (isMounted) {
-          setUser(data);
-        }
+        if (isMounted) setUser(data);
       } catch (error) {
         if (error.response?.status === 401) {
           localStorage.removeItem("bragstack_token");
@@ -40,15 +38,17 @@ function AppSidebar() {
     }
 
     void loadUser();
-
-    return () => {
-      isMounted = false;
-    };
+    return () => { isMounted = false; };
   }, []);
 
   function logout() {
     localStorage.removeItem("bragstack_token");
     window.location.assign("/login");
+  }
+
+  const navItems = [...BASE_NAV_ITEMS];
+  if (user?.entitlements?.advanced_reports) {
+    navItems.push({ href: "/app/reports", label: "Reports", icon: FileText });
   }
 
   return (
@@ -57,18 +57,15 @@ function AppSidebar() {
         <span className="sidebar-logo">B</span>
         <span>
           <strong>BragStack</strong>
-          <small>Career proof</small>
+          <small>{user?.plan === "pro" ? "Pro career proof" : "Career proof"}</small>
         </span>
       </a>
 
-      <a className="sidebar-add" href="/app#entries">
-        + Add accomplishment
-      </a>
+      <a className="sidebar-add" href="/app#entries">+ Add accomplishment</a>
 
       <nav className="sidebar-nav" aria-label="BragStack navigation">
-        {NAV_ITEMS.map(({ href, label, icon: Icon }) => {
+        {navItems.map(({ href, label, icon: Icon }) => {
           const isActive = path === href;
-
           return (
             <a className={isActive ? "active" : ""} href={href} key={href}>
               <Icon size={18} />
@@ -83,6 +80,13 @@ function AppSidebar() {
             <span>Proof Profile</span>
           </a>
         )}
+
+        {user && user.plan !== "pro" && (
+          <a href="/upgrade">
+            <Sparkles size={18} />
+            <span>Upgrade to Pro</span>
+          </a>
+        )}
       </nav>
 
       <div className="sidebar-footer">
@@ -92,7 +96,7 @@ function AppSidebar() {
           </span>
           <span>
             <strong>{user?.name || "BragStack member"}</strong>
-            <small>{user?.headline || "Build your proof"}</small>
+            <small>{user?.plan === "pro" ? "Pro plan" : "Free plan"}</small>
           </span>
         </div>
 

--- a/frontend/src/AuthPage.jsx
+++ b/frontend/src/AuthPage.jsx
@@ -1,10 +1,24 @@
 import { useState } from "react";
-import { Github, Lock, Mail, Sparkles, UserPlus } from "lucide-react";
+import { Lock, Mail, Sparkles, UserPlus } from "lucide-react";
 import "./AuthPage.css";
 
 function getApiBaseUrl() {
   if (window.location.hostname.endsWith(".app.github.dev")) return "/api";
   return import.meta.env.VITE_API_BASE_URL || import.meta.env.VITE_API_URL || "http://localhost:8000";
+}
+
+function GitHubMark() {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 24 24"
+      width="20"
+      height="20"
+      fill="currentColor"
+    >
+      <path d="M12 .7a11.5 11.5 0 0 0-3.64 22.41c.58.11.79-.25.79-.56v-2.02c-3.22.7-3.9-1.37-3.9-1.37-.53-1.34-1.29-1.7-1.29-1.7-1.05-.72.08-.7.08-.7 1.17.08 1.78 1.2 1.78 1.2 1.04 1.78 2.72 1.27 3.38.97.1-.75.4-1.27.74-1.56-2.57-.29-5.27-1.29-5.27-5.74 0-1.27.45-2.3 1.2-3.11-.12-.3-.52-1.48.11-3.08 0 0 .98-.31 3.16 1.19a10.9 10.9 0 0 1 5.75 0c2.19-1.5 3.16-1.19 3.16-1.19.63 1.6.23 2.78.11 3.08.75.81 1.2 1.84 1.2 3.11 0 4.46-2.71 5.45-5.29 5.74.42.36.79 1.07.79 2.16v3.02c0 .31.21.68.8.56A11.5 11.5 0 0 0 12 .7Z" />
+    </svg>
+  );
 }
 
 function AuthPage({ mode = "login", onLogin, onRegister }) {
@@ -95,7 +109,7 @@ function AuthPage({ mode = "login", onLogin, onRegister }) {
               className="auth-oauth-button auth-oauth-github"
               href={`${apiBaseUrl}/auth/github/login`}
             >
-              <Github size={20} aria-hidden="true" />
+              <GitHubMark />
               <span>Continue with GitHub</span>
             </a>
           </div>

--- a/frontend/src/LandingPage.jsx
+++ b/frontend/src/LandingPage.jsx
@@ -56,7 +56,7 @@ const plans = [
     badge: "Best for your career",
     features: ["Unlimited proof + Impact Receipts", "Advanced career analytics", "Performance Review Builder", "Promotion Packet", "PDF and career exports", "Integrations and advanced public profile"],
     cta: "Unlock BragStack Pro",
-    href: "/register",
+    href: "/upgrade",
   },
   {
     name: "Team",
@@ -75,6 +75,62 @@ const plans = [
     features: ["Everything in Team", "SSO / SCIM", "Audit logs", "Retention controls", "Advanced admin policies", "Custom integrations and support"],
     cta: "Contact us",
     href: "mailto:hello@bragstack.app?subject=BragStack%20Enterprise",
+  },
+];
+
+const productDetails = [
+  {
+    id: "product-impact-receipts",
+    title: "Impact Receipts",
+    description: "Turn an accomplishment into structured proof: what happened, what you contributed, the result, skills used, evidence references, measurable outcomes, shared credit, and optional trust signals. Receipts remain private unless you explicitly make them public.",
+  },
+  {
+    id: "product-career-analytics",
+    title: "Career Analytics",
+    description: "See patterns across the work you capture: recurring skills, categories of impact, evidence coverage, activity over time, and the kinds of ownership your proof demonstrates. Advanced analytics are part of Pro.",
+  },
+  {
+    id: "product-reports",
+    title: "Reports",
+    description: "Free accounts get basic proof summaries. Pro unlocks deeper career reports and packaging designed for review cycles, promotion conversations, interviews, exports, and repeatable career storytelling.",
+  },
+  {
+    id: "product-public-profiles",
+    title: "Public Proof Profiles",
+    description: "Your account is private by default. A public proof profile only exposes the entries and Impact Receipts you intentionally mark public, so you can share selected evidence without publishing your entire work history.",
+  },
+  {
+    id: "product-pricing",
+    title: "Pricing",
+    description: "Free includes 5 proof entries and 1 Impact Receipt. Pro is $9/month and unlocks unlimited proof, advanced reports, review and promotion builders, PDF exports, integrations, and advanced profile capabilities.",
+  },
+];
+
+const solutionDetails = [
+  {
+    id: "solution-performance-reviews",
+    title: "Performance Reviews",
+    description: "Capture wins throughout the cycle, then use the evidence later instead of reconstructing months of work from memory. Pro review builders organize documented impact into review-ready material.",
+  },
+  {
+    id: "solution-promotions",
+    title: "Promotions",
+    description: "Build a record of scope, ownership, outcomes, leadership, and growth. Promotion packets help organize those receipts into a clearer case for the next level.",
+  },
+  {
+    id: "solution-interviews",
+    title: "Interviews",
+    description: "Keep real situations, actions, outcomes, skills, and metrics close at hand so interview stories come from documented work rather than last-minute memory searches.",
+  },
+  {
+    id: "solution-freelancers",
+    title: "Freelancers",
+    description: "Track project outcomes, client value, measurable results, testimonials or evidence references, and reusable case-study material across engagements.",
+  },
+  {
+    id: "solution-teams",
+    title: "Teams",
+    description: "The planned Team tier focuses on shared review templates, optional verification, review-cycle packets, organization-level analytics, and centralized billing without turning BragStack into employee surveillance.",
   },
 ];
 
@@ -146,11 +202,9 @@ function LandingPage() {
 
       <section className="landing-workflow premium-workflow" id="how-it-works">
         <div className="landing-section-heading"><p>HOW IT WORKS</p><h2>Capture once. Turn it into career leverage again and again.</h2><span>BragStack connects the daily work you are already doing to the career artifacts you usually scramble to create later.</span></div>
-
         <div className="career-flow" aria-label="BragStack career proof workflow">
           <span>Daily work</span><ArrowRight size={18} /><span>Proof entries</span><ArrowRight size={18} /><span>Impact Receipts</span><ArrowRight size={18} /><span>Career analytics</span><ArrowRight size={18} /><span>Reviews · promotions · interviews</span>
         </div>
-
         <div className="premium-workflow-grid">{workflowSteps.map((step) => <article className="workflow-card premium-workflow-card" key={step.number}><span className="workflow-number">{step.number}</span><h3>{step.title}</h3><p>{step.description}</p></article>)}</div>
 
         <div className="career-intelligence-demo">
@@ -188,6 +242,35 @@ function LandingPage() {
         <div className="feature-dashboard-preview"><div className="feature-preview-header"><div><span>Entries this quarter</span><strong>12</strong></div><div><span>Evidence coverage</span><strong>83%</strong></div></div><div className="feature-preview-entry"><div><span className="feature-preview-badge">Impact Receipt</span><small>Reliability · Current Job</small></div><h3>Improved escalation response process</h3><p>Reduced repeated troubleshooting and gave the team a clearer path for complex customer cases.</p><div className="feature-preview-tags"><span>Leadership</span><span>Communication</span><span>Process</span></div></div></div>
       </section>
 
+      <section className="landing-use-cases" id="product">
+        <div className="landing-section-heading"><p>PRODUCT</p><h2>Career proof that stays useful after the moment passes.</h2><span>Each part of BragStack is designed to move from private capture to reusable evidence without forcing you to publish your whole work history.</span></div>
+        <div className="use-case-grid">{productDetails.map((item) => <article className="use-case-card" id={item.id} key={item.id}><div className="use-case-icon"><ReceiptText size={21} /></div><h3>{item.title}</h3><p>{item.description}</p></article>)}</div>
+      </section>
+
+      <section className="landing-use-cases" id="solutions">
+        <div className="landing-section-heading"><p>SOLUTIONS</p><h2>Use the same proof across the moments that shape your career.</h2><span>Capture once, then organize the evidence differently depending on the conversation in front of you.</span></div>
+        <div className="use-case-grid">{solutionDetails.map((item) => <article className="use-case-card" id={item.id} key={item.id}><div className="use-case-icon"><Target size={21} /></div><h3>{item.title}</h3><p>{item.description}</p></article>)}</div>
+      </section>
+
+      <section className="landing-feature-section" id="security">
+        <div className="landing-feature-copy">
+          <p className="landing-mini-label">PRIVACY & SECURITY</p>
+          <h2>Your career record starts private.</h2>
+          <p>BragStack stores the account information and career-proof content you submit so the app can provide your private workspace. Proof entries and Impact Receipts are private by default. Content only appears on a public proof profile when you intentionally mark that item public.</p>
+          <div className="landing-feature-list">
+            <div><ShieldCheck size={17} /> Authentication is required for private account data and private proof APIs.</div>
+            <div><ShieldCheck size={17} /> Google and GitHub sign-in use OAuth; BragStack does not need your provider password.</div>
+            <div><ShieldCheck size={17} /> BragStack stores billing status and Stripe identifiers needed to enforce your plan; card details are entered with Stripe and are not stored in the BragStack database.</div>
+            <div><ShieldCheck size={17} /> Paid features are enforced on the server, so hiding a button is not the security boundary.</div>
+            <div><ShieldCheck size={17} /> Public sharing is opt-in at the item level; your unshared entries and receipts remain behind authentication.</div>
+          </div>
+        </div>
+        <div className="feature-dashboard-preview">
+          <div className="feature-preview-header"><div><span>Default visibility</span><strong>Private</strong></div><div><span>Public sharing</span><strong>User controlled</strong></div></div>
+          <div className="feature-preview-entry"><div><span className="feature-preview-badge">Security note</span><small>Specific, not inflated</small></div><h3>We do not claim certifications we have not earned.</h3><p>As the product matures, formal security documentation, retention controls, audit features, and enterprise identity capabilities can be added and documented when they are actually implemented.</p><div className="feature-preview-tags"><span>Private by default</span><span>OAuth</span><span>Stripe-hosted payment</span></div></div>
+        </div>
+      </section>
+
       <section className="landing-pricing" id="pricing">
         <div className="landing-section-heading"><p>PRICING</p><h2>Start with proof. Upgrade when you want leverage.</h2><span>Free lets you experience the workflow. Pro unlocks the tools designed to turn a growing work history into reviews, promotion evidence, analytics, exports, and integrations.</span></div>
         <div className="pricing-grid pricing-grid-four">{plans.map((plan) => <article className={`pricing-card ${plan.featured ? "pricing-card-featured pricing-card-pro" : ""}`} key={plan.name}>{plan.badge && <div className="pricing-popular-label">{plan.badge}</div>}<div className="pricing-card-header"><div><p>{plan.name}</p><h3>{plan.price}{plan.suffix && <span>{plan.suffix}</span>}</h3></div></div><p className="pricing-tagline">{plan.tagline}</p><ul>{plan.features.map((feature) => <li key={feature}><Check size={17} />{feature}</li>)}</ul><a className={`landing-btn pricing-button ${plan.featured ? "" : "landing-btn-secondary"}`} href={plan.href}>{plan.cta}{plan.featured && <ArrowRight size={17} />}</a></article>)}</div>
@@ -199,10 +282,10 @@ function LandingPage() {
       <footer className="mega-footer">
         <div className="mega-footer-brand"><a className="landing-logo" href="/">BragStack</a><p>Turn everyday work into career proof you can use when it matters.</p><a className="footer-cta" href="/register">Start building proof <ArrowRight size={15} /></a></div>
         <div className="mega-footer-columns">
-          <div><h3>Product</h3><a href="#how-it-works">Impact Receipts</a><a href="#how-it-works">Career Analytics</a><a href="#how-it-works">Reports</a><a href="#how-it-works">Public Proof Profiles</a><a href="#pricing">Pricing</a></div>
-          <div><h3>Solutions</h3><a href="#use-cases">Performance Reviews</a><a href="#use-cases">Promotions</a><a href="#use-cases">Interviews</a><a href="#use-cases">Freelancers</a><a href="#pricing">Teams</a></div>
+          <div><h3>Product</h3><a href="#product-impact-receipts">Impact Receipts</a><a href="#product-career-analytics">Career Analytics</a><a href="#product-reports">Reports</a><a href="#product-public-profiles">Public Proof Profiles</a><a href="#pricing">Pricing</a></div>
+          <div><h3>Solutions</h3><a href="#solution-performance-reviews">Performance Reviews</a><a href="#solution-promotions">Promotions</a><a href="#solution-interviews">Interviews</a><a href="#solution-freelancers">Freelancers</a><a href="#solution-teams">Teams</a></div>
           <div><h3>Resources</h3><a href="#how-it-works">How it works</a><a href="#use-cases">Use cases</a><a href="/login">Sign in</a><a href="/register">Create account</a><span>Docs · coming soon</span></div>
-          <div><h3>Company</h3><a href="mailto:hello@bragstack.app">Contact</a><a href="mailto:hello@bragstack.app?subject=BragStack%20Team%20waitlist">Team waitlist</a><a href="mailto:hello@bragstack.app?subject=BragStack%20Enterprise">Enterprise</a><span>Changelog · coming soon</span><span>Security · coming soon</span></div>
+          <div><h3>Company</h3><a href="mailto:hello@bragstack.app">Contact</a><a href="mailto:hello@bragstack.app?subject=BragStack%20Team%20waitlist">Team waitlist</a><a href="mailto:hello@bragstack.app?subject=BragStack%20Enterprise">Enterprise</a><span>Changelog · coming soon</span><a href="#security">Security</a></div>
         </div>
         <div className="mega-footer-bottom"><span>© 2026 BragStack</span><span>Private by default · Your proof stays yours.</span><div><a href="/login">Log in</a><a href="/register">Start free</a></div></div>
       </footer>

--- a/frontend/src/ProductPolish.css
+++ b/frontend/src/ProductPolish.css
@@ -4,6 +4,10 @@
   padding: 34px 0 72px;
 }
 
+body[data-bragstack-plan="free"] a[href="/app/reports"] {
+  display: none !important;
+}
+
 .product-page-hero {
   display: flex;
   justify-content: space-between;

--- a/frontend/src/RootContent.jsx
+++ b/frontend/src/RootContent.jsx
@@ -1,11 +1,54 @@
+import { useEffect, useState } from "react";
+
 import AccomplishmentsPage from "./AccomplishmentsPage.jsx";
 import App from "./App.jsx";
 import AppSidebar from "./AppSidebar.jsx";
 import ImpactReceiptsPage from "./ImpactReceiptsPage.jsx";
+import { getCurrentUser } from "./api.js";
+
+function ProRequired() {
+  return (
+    <main className="page">
+      <section className="notice">
+        <strong>BragStack Pro</strong>
+        <span>This feature is available on Pro. Upgrade to unlock advanced reports and career packaging.</span>
+        <a className="btn primary" href="/upgrade">Upgrade to Pro</a>
+      </section>
+    </main>
+  );
+}
 
 function RootContent() {
   const path = window.location.pathname;
   const isAuthenticatedApp = path.startsWith("/app");
+  const [user, setUser] = useState(null);
+  const [planLoaded, setPlanLoaded] = useState(!isAuthenticatedApp);
+
+  useEffect(() => {
+    if (!isAuthenticatedApp) return undefined;
+
+    let active = true;
+    async function loadPlan() {
+      try {
+        const data = await getCurrentUser();
+        if (active) {
+          setUser(data);
+          document.body.dataset.bragstackPlan = data.plan || "free";
+        }
+      } catch (error) {
+        if (error.response?.status === 401) {
+          localStorage.removeItem("bragstack_token");
+          window.location.assign("/login");
+          return;
+        }
+      } finally {
+        if (active) setPlanLoaded(true);
+      }
+    }
+
+    void loadPlan();
+    return () => { active = false; };
+  }, [isAuthenticatedApp]);
 
   let Content = App;
 
@@ -13,10 +56,16 @@ function RootContent() {
     Content = AccomplishmentsPage;
   } else if (path === "/app/impact-receipts") {
     Content = ImpactReceiptsPage;
+  } else if (path === "/app/reports" && planLoaded && !user?.entitlements?.advanced_reports) {
+    Content = ProRequired;
   }
 
   if (!isAuthenticatedApp) {
     return <Content />;
+  }
+
+  if (!planLoaded) {
+    return <div className="app-shell"><div className="authenticated-content" /></div>;
   }
 
   return (


### PR DESCRIPTION
Production patch for BragStack billing and plan enforcement.

- add Stripe Checkout for Pro ($9/month)
- add signed Stripe webhook handling for subscription lifecycle
- store billing status and Stripe customer/subscription IDs on the user
- enforce Free limits server-side: 5 proof entries and 1 Impact Receipt
- enforce Pro-only report/packet/export endpoints server-side
- hide/gate Pro navigation and direct Pro routes for Free users
- add /upgrade Stripe handoff page
- point Pro pricing CTA to upgrade flow
- fill existing Product, Solutions, and Privacy/Security sections with specific copy
- document Stripe backend environment variables

Render backend env required before checkout can work:
STRIPE_SECRET_KEY
STRIPE_PRO_PRICE_ID
STRIPE_WEBHOOK_SECRET

Stripe webhook endpoint:
https://api.usebragstack.com/billing/webhook

The separate production /register 404 is a Render Static Site SPA rewrite setting: configure /* -> /index.html as a Rewrite in the frontend service.