### PR TITLE
Fix production auth flow and add password reset

### DIFF
--- a/backend/app/auth_routes.py
+++ b/backend/app/auth_routes.py
@@ -1,7 +1,10 @@
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
+import hashlib
+import os
 import re
 import secrets
 
+import httpx
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.security import OAuth2PasswordRequestForm
 from pydantic import BaseModel, EmailStr, Field
@@ -17,6 +20,10 @@ from app.database import users_collection
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 
+FRONTEND_URL = os.getenv("FRONTEND_URL", "http://localhost:5173").rstrip("/")
+RESEND_API_KEY = os.getenv("RESEND_API_KEY", "")
+PASSWORD_RESET_FROM = os.getenv("PASSWORD_RESET_FROM", "BragStack <noreply@usebragstack.com>")
+
 
 class RegisterRequest(BaseModel):
     name: str = Field(..., min_length=1, max_length=80)
@@ -24,9 +31,13 @@ class RegisterRequest(BaseModel):
     password: str = Field(..., min_length=8)
 
 
-class LoginRequest(BaseModel):
+class PasswordResetRequest(BaseModel):
     email: EmailStr
-    password: str
+
+
+class PasswordResetConfirm(BaseModel):
+    token: str = Field(..., min_length=20, max_length=300)
+    password: str = Field(..., min_length=8, max_length=256)
 
 
 class ProfileUpdateRequest(BaseModel):
@@ -51,6 +62,46 @@ def generate_unique_public_slug(name: str) -> str:
         slug = f"{base_slug}-{random_suffix}"
         if not users_collection.find_one({"public_slug": slug}):
             return slug
+
+
+def _hash_reset_token(token: str) -> str:
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+async def _send_password_reset_email(email: str, reset_url: str) -> None:
+    if not RESEND_API_KEY:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Password reset email is not configured yet.",
+        )
+
+    payload = {
+        "from": PASSWORD_RESET_FROM,
+        "to": [email],
+        "subject": "Reset your BragStack password",
+        "html": (
+            "<div style='font-family:Arial,sans-serif;line-height:1.6'>"
+            "<h2>Reset your BragStack password</h2>"
+            "<p>We received a request to reset your password.</p>"
+            f"<p><a href='{reset_url}'>Reset password</a></p>"
+            "<p>This link expires in 30 minutes. If you did not request it, you can ignore this email.</p>"
+            "</div>"
+        ),
+    }
+    async with httpx.AsyncClient(timeout=15.0) as client:
+        response = await client.post(
+            "https://api.resend.com/emails",
+            headers={
+                "Authorization": f"Bearer {RESEND_API_KEY}",
+                "Content-Type": "application/json",
+            },
+            json=payload,
+        )
+    if response.status_code >= 400:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Password reset email could not be sent.",
+        )
 
 
 @router.post("/register")
@@ -98,6 +149,70 @@ def login_user(form_data: OAuth2PasswordRequestForm = Depends()):
         "token_type": "bearer",
         "user": serialize_user(user),
     }
+
+
+@router.post("/password-reset/request")
+async def request_password_reset(payload: PasswordResetRequest):
+    normalized_email = payload.email.lower().strip()
+    user = users_collection.find_one({"email": normalized_email})
+
+    # Do not reveal whether an account exists.
+    if not user:
+        return {"message": "If that email belongs to an account, a reset link has been sent."}
+
+    raw_token = secrets.token_urlsafe(48)
+    expires_at = datetime.now(timezone.utc) + timedelta(minutes=30)
+    users_collection.update_one(
+        {"_id": user["_id"]},
+        {
+            "$set": {
+                "password_reset_token_hash": _hash_reset_token(raw_token),
+                "password_reset_expires_at": expires_at.isoformat(),
+            }
+        },
+    )
+    reset_url = f"{FRONTEND_URL}/login#reset_token={raw_token}"
+
+    try:
+        await _send_password_reset_email(normalized_email, reset_url)
+    except HTTPException:
+        users_collection.update_one(
+            {"_id": user["_id"]},
+            {"$unset": {"password_reset_token_hash": "", "password_reset_expires_at": ""}},
+        )
+        raise
+
+    return {"message": "If that email belongs to an account, a reset link has been sent."}
+
+
+@router.post("/password-reset/confirm")
+def confirm_password_reset(payload: PasswordResetConfirm):
+    token_hash = _hash_reset_token(payload.token)
+    user = users_collection.find_one({"password_reset_token_hash": token_hash})
+    if not user:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="This reset link is invalid or expired.")
+
+    expires_raw = user.get("password_reset_expires_at")
+    try:
+        expires_at = datetime.fromisoformat(expires_raw)
+    except (TypeError, ValueError):
+        expires_at = datetime.min.replace(tzinfo=timezone.utc)
+
+    if expires_at < datetime.now(timezone.utc):
+        users_collection.update_one(
+            {"_id": user["_id"]},
+            {"$unset": {"password_reset_token_hash": "", "password_reset_expires_at": ""}},
+        )
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="This reset link is invalid or expired.")
+
+    users_collection.update_one(
+        {"_id": user["_id"]},
+        {
+            "$set": {"hashed_password": hash_password(payload.password)},
+            "$unset": {"password_reset_token_hash": "", "password_reset_expires_at": ""},
+        },
+    )
+    return {"message": "Password updated. You can now sign in."}
 
 
 @router.get("/me")

--- a/backend/app/oauth_routes.py
+++ b/backend/app/oauth_routes.py
@@ -92,7 +92,7 @@ def _find_or_create_oauth_user(
 def _frontend_success_redirect(user: dict) -> RedirectResponse:
     token = create_access_token({"sub": str(user["_id"])})
     return RedirectResponse(
-        url=f"{FRONTEND_URL}/auth/callback#token={token}",
+        url=f"{FRONTEND_URL}/login#oauth_token={token}",
         status_code=status.HTTP_302_FOUND,
     )
 
@@ -223,7 +223,7 @@ async def github_callback(request: Request, code: str, state: str | None = None)
 
     verified_emails = [item for item in emails if item.get("verified") and item.get("email")]
     primary = next((item for item in verified_emails if item.get("primary")), None)
-    selected_email = (primary or (verified_emails[0] if verified_emails else None))
+    selected_email = primary or (verified_emails[0] if verified_emails else None)
     if not selected_email:
         raise HTTPException(status_code=400, detail="GitHub account must have a verified email")
 

--- a/frontend/src/AuthPage.css
+++ b/frontend/src/AuthPage.css
@@ -130,11 +130,17 @@
   border: 1px solid transparent;
   font-weight: 900;
   text-decoration: none;
+  cursor: pointer;
   transition: transform 150ms ease, box-shadow 150ms ease, border-color 150ms ease, background 150ms ease;
 }
 
-.auth-oauth-button:hover {
+.auth-oauth-button:hover:not(:disabled) {
   transform: translateY(-1px);
+}
+
+.auth-oauth-button:disabled {
+  cursor: wait;
+  opacity: 0.72;
 }
 
 .auth-oauth-google {
@@ -144,7 +150,7 @@
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.16);
 }
 
-.auth-oauth-google:hover {
+.auth-oauth-google:hover:not(:disabled) {
   background: #f8f9fa;
   border-color: #c7c9cc;
   box-shadow: 0 10px 28px rgba(66, 133, 244, 0.18);
@@ -178,7 +184,7 @@
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.28);
 }
 
-.auth-oauth-github:hover {
+.auth-oauth-github:hover:not(:disabled) {
   background: #161b22;
   border-color: #8b949e;
   box-shadow: 0 10px 28px rgba(0, 0, 0, 0.34);
@@ -188,7 +194,7 @@
   display: flex;
   align-items: center;
   gap: 12px;
-  margin: 4px 0 18px;
+  margin: 20px 0 18px;
   color: #64748b;
   font-size: 0.78rem;
   font-weight: 800;
@@ -254,9 +260,84 @@
   color: #64748b;
 }
 
+.auth-forgot-link {
+  display: block;
+  margin: -4px 0 4px auto;
+  border: 0;
+  padding: 4px 0;
+  background: transparent;
+  color: #bae6fd;
+  cursor: pointer;
+  font-weight: 850;
+}
+
 .auth-submit {
   width: 100%;
   margin-top: 8px;
+}
+
+.auth-reset-panel {
+  margin-top: 16px;
+  padding: 16px;
+  border: 1px solid rgba(147, 197, 253, 0.18);
+  border-radius: 18px;
+  background: rgba(2, 6, 23, 0.46);
+}
+
+.auth-reset-panel strong {
+  color: #f8fafc;
+}
+
+.auth-reset-panel p {
+  margin: 6px 0 12px;
+  color: #94a3b8;
+  font-size: 0.85rem;
+  line-height: 1.5;
+}
+
+.auth-reset-row,
+.auth-reset-stack {
+  display: flex;
+  gap: 8px;
+}
+
+.auth-reset-stack {
+  flex-direction: column;
+}
+
+.auth-reset-panel input {
+  min-width: 0;
+  flex: 1;
+  min-height: 44px;
+  padding: 0 12px;
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  border-radius: 12px;
+  outline: none;
+  background: rgba(15, 23, 42, 0.9);
+  color: #f8fafc;
+}
+
+.auth-reset-panel button {
+  min-height: 44px;
+  padding: 0 14px;
+  border: 0;
+  border-radius: 12px;
+  background: #bae6fd;
+  color: #020617;
+  cursor: pointer;
+  font-weight: 900;
+}
+
+.auth-reset-panel button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.auth-reset-panel small {
+  display: block;
+  margin-top: 10px;
+  color: #cbd5e1;
+  line-height: 1.45;
 }
 
 .auth-switch {
@@ -292,7 +373,20 @@
     padding: 26px;
   }
 
+  .auth-card {
+    padding: 22px;
+  }
+
   .auth-copy h1 {
     font-size: clamp(2.6rem, 16vw, 4rem);
+  }
+
+  .auth-reset-row {
+    flex-direction: column;
+  }
+
+  .auth-reset-row button,
+  .auth-reset-stack button {
+    width: 100%;
   }
 }

--- a/frontend/src/AuthPage.jsx
+++ b/frontend/src/AuthPage.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Lock, Mail, Sparkles, UserPlus } from "lucide-react";
 import "./AuthPage.css";
 
@@ -9,13 +9,7 @@ function getApiBaseUrl() {
 
 function GitHubMark() {
   return (
-    <svg
-      aria-hidden="true"
-      viewBox="0 0 24 24"
-      width="20"
-      height="20"
-      fill="currentColor"
-    >
+    <svg aria-hidden="true" viewBox="0 0 24 24" width="20" height="20" fill="currentColor">
       <path d="M12 .7a11.5 11.5 0 0 0-3.64 22.41c.58.11.79-.25.79-.56v-2.02c-3.22.7-3.9-1.37-3.9-1.37-.53-1.34-1.29-1.7-1.29-1.7-1.05-.72.08-.7.08-.7 1.17.08 1.78 1.2 1.78 1.2 1.04 1.78 2.72 1.27 3.38.97.1-.75.4-1.27.74-1.56-2.57-.29-5.27-1.29-5.27-5.74 0-1.27.45-2.3 1.2-3.11-.12-.3-.52-1.48.11-3.08 0 0 .98-.31 3.16 1.19a10.9 10.9 0 0 1 5.75 0c2.19-1.5 3.16-1.19 3.16-1.19.63 1.6.23 2.78.11 3.08.75.81 1.2 1.84 1.2 3.11 0 4.46-2.71 5.45-5.29 5.74.42.36.79 1.07.79 2.16v3.02c0 .31.21.68.8.56A11.5 11.5 0 0 0 12 .7Z" />
     </svg>
   );
@@ -25,13 +19,24 @@ function AuthPage({ mode = "login", onLogin, onRegister }) {
   const isRegister = mode === "register";
   const apiBaseUrl = getApiBaseUrl().replace(/\/$/, "");
 
-  const [formData, setFormData] = useState({
-    name: "",
-    email: "",
-    password: "",
-  });
+  const [formData, setFormData] = useState({ name: "", email: "", password: "" });
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [errorMessage, setErrorMessage] = useState("");
+  const [connectingProvider, setConnectingProvider] = useState("");
+  const [showReset, setShowReset] = useState(false);
+  const [resetEmail, setResetEmail] = useState("");
+  const [resetMessage, setResetMessage] = useState("");
+  const [resetSubmitting, setResetSubmitting] = useState(false);
+
+  useEffect(() => {
+    const hash = new URLSearchParams(window.location.hash.slice(1));
+    const oauthToken = hash.get("oauth_token");
+    if (!oauthToken) return;
+
+    localStorage.setItem("bragstack_token", oauthToken);
+    history.replaceState(null, "", "/login");
+    window.location.replace("/app");
+  }, []);
 
   function handleChange(event) {
     const { name, value } = event.target;
@@ -52,12 +57,47 @@ function AuthPage({ mode = "login", onLogin, onRegister }) {
     } catch (error) {
       console.error(error);
       setErrorMessage(
-        isRegister
-          ? "Could not create your account. Try again."
-          : "Could not log you in. Check your email and password."
+        error.response?.data?.detail ||
+          (isRegister
+            ? "Could not create your account. Try again."
+            : "Could not log you in. Check your email and password.")
       );
     } finally {
       setIsSubmitting(false);
+    }
+  }
+
+  async function startOAuth(provider) {
+    setConnectingProvider(provider);
+    setErrorMessage("");
+
+    try {
+      await fetch(`${apiBaseUrl}/`, { method: "GET", mode: "cors", cache: "no-store" });
+    } catch (error) {
+      console.warn("API warm-up request did not complete before OAuth navigation", error);
+    }
+
+    window.location.assign(`${apiBaseUrl}/auth/${provider}/login`);
+  }
+
+  async function handleResetRequest(event) {
+    event.preventDefault();
+    setResetSubmitting(true);
+    setResetMessage("");
+
+    try {
+      const response = await fetch(`${apiBaseUrl}/auth/password-reset/request`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: resetEmail }),
+      });
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok) throw new Error(data.detail || "Password reset is unavailable right now.");
+      setResetMessage("If that email belongs to an account, we sent a password reset link.");
+    } catch (error) {
+      setResetMessage(error.message || "Password reset is unavailable right now.");
+    } finally {
+      setResetSubmitting(false);
     }
   }
 
@@ -87,34 +127,13 @@ function AuthPage({ mode = "login", onLogin, onRegister }) {
             {isRegister ? <UserPlus size={24} /> : <Sparkles size={24} />}
           </div>
 
-          <p className="mini-label">
-            {isRegister ? "Create account" : "Welcome back"}
-          </p>
+          <p className="mini-label">{isRegister ? "Create account" : "Welcome back"}</p>
           <h2>{isRegister ? "Start your BragStack" : "Log in to BragStack"}</h2>
           <p className="auth-muted">
             {isRegister
               ? "Create your private workspace for career proof."
               : "Open your dashboard and keep building your proof."}
           </p>
-
-          <div className="auth-oauth-grid">
-            <a
-              className="auth-oauth-button auth-oauth-google"
-              href={`${apiBaseUrl}/auth/google/login`}
-            >
-              <span className="auth-google-mark" aria-hidden="true">G</span>
-              <span>Continue with Google</span>
-            </a>
-            <a
-              className="auth-oauth-button auth-oauth-github"
-              href={`${apiBaseUrl}/auth/github/login`}
-            >
-              <GitHubMark />
-              <span>Continue with GitHub</span>
-            </a>
-          </div>
-
-          <div className="auth-divider"><span>or use email</span></div>
 
           {errorMessage && <div className="auth-error">{errorMessage}</div>}
 
@@ -123,13 +142,7 @@ function AuthPage({ mode = "login", onLogin, onRegister }) {
               Name
               <div>
                 <UserPlus size={17} />
-                <input
-                  name="name"
-                  value={formData.name}
-                  onChange={handleChange}
-                  placeholder="Tee"
-                  required
-                />
+                <input name="name" value={formData.name} onChange={handleChange} placeholder="Tee" required />
               </div>
             </label>
           )}
@@ -138,14 +151,7 @@ function AuthPage({ mode = "login", onLogin, onRegister }) {
             Email
             <div>
               <Mail size={17} />
-              <input
-                type="email"
-                name="email"
-                value={formData.email}
-                onChange={handleChange}
-                placeholder="you@example.com"
-                required
-              />
+              <input type="email" name="email" value={formData.email} onChange={handleChange} placeholder="you@example.com" required />
             </div>
           </label>
 
@@ -153,27 +159,50 @@ function AuthPage({ mode = "login", onLogin, onRegister }) {
             Password
             <div>
               <Lock size={17} />
-              <input
-                type="password"
-                name="password"
-                value={formData.password}
-                onChange={handleChange}
-                placeholder="••••••••"
-                minLength={8}
-                required
-              />
+              <input type="password" name="password" value={formData.password} onChange={handleChange} placeholder="••••••••" minLength={8} required />
             </div>
           </label>
 
-          <button className="btn primary auth-submit" disabled={isSubmitting}>
+          {!isRegister && (
+            <button type="button" className="auth-forgot-link" onClick={() => setShowReset((current) => !current)}>
+              Forgot password?
+            </button>
+          )}
+
+          <button className="btn primary auth-submit" disabled={isSubmitting || Boolean(connectingProvider)}>
             {isSubmitting ? "Working..." : isRegister ? "Create account" : "Log in"}
           </button>
 
+          {showReset && !isRegister && (
+            <div className="auth-reset-panel">
+              <strong>Reset your password</strong>
+              <p>Enter the email address on your BragStack account.</p>
+              <div className="auth-reset-row">
+                <input type="email" value={resetEmail} onChange={(event) => setResetEmail(event.target.value)} placeholder="you@example.com" required />
+                <button type="button" onClick={handleResetRequest} disabled={resetSubmitting || !resetEmail}>
+                  {resetSubmitting ? "Sending..." : "Send link"}
+                </button>
+              </div>
+              {resetMessage && <small>{resetMessage}</small>}
+            </div>
+          )}
+
+          <div className="auth-divider"><span>or continue with</span></div>
+
+          <div className="auth-oauth-grid">
+            <button type="button" className="auth-oauth-button auth-oauth-google" onClick={() => startOAuth("google")} disabled={Boolean(connectingProvider)}>
+              <span className="auth-google-mark" aria-hidden="true">G</span>
+              <span>{connectingProvider === "google" ? "Connecting to Google..." : "Continue with Google"}</span>
+            </button>
+            <button type="button" className="auth-oauth-button auth-oauth-github" onClick={() => startOAuth("github")} disabled={Boolean(connectingProvider)}>
+              <GitHubMark />
+              <span>{connectingProvider === "github" ? "Connecting to GitHub..." : "Continue with GitHub"}</span>
+            </button>
+          </div>
+
           <p className="auth-switch">
             {isRegister ? "Already have an account?" : "New to BragStack?"}{" "}
-            <a href={isRegister ? "/login" : "/register"}>
-              {isRegister ? "Log in" : "Create one"}
-            </a>
+            <a href={isRegister ? "/login" : "/register"}>{isRegister ? "Log in" : "Create one"}</a>
           </p>
         </form>
       </section>

--- a/frontend/src/AuthPage.jsx
+++ b/frontend/src/AuthPage.jsx
@@ -18,23 +18,23 @@ function GitHubMark() {
 function AuthPage({ mode = "login", onLogin, onRegister }) {
   const isRegister = mode === "register";
   const apiBaseUrl = getApiBaseUrl().replace(/\/$/, "");
+  const initialResetToken = new URLSearchParams(window.location.hash.slice(1)).get("reset_token") || "";
 
   const [formData, setFormData] = useState({ name: "", email: "", password: "" });
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [errorMessage, setErrorMessage] = useState("");
   const [connectingProvider, setConnectingProvider] = useState("");
-  const [showReset, setShowReset] = useState(false);
+  const [showReset, setShowReset] = useState(Boolean(initialResetToken));
   const [resetEmail, setResetEmail] = useState("");
   const [resetMessage, setResetMessage] = useState("");
   const [resetSubmitting, setResetSubmitting] = useState(false);
-  const [resetToken, setResetToken] = useState("");
+  const [resetToken, setResetToken] = useState(initialResetToken);
   const [newPassword, setNewPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
 
   useEffect(() => {
     const hash = new URLSearchParams(window.location.hash.slice(1));
     const oauthToken = hash.get("oauth_token");
-    const passwordResetToken = hash.get("reset_token");
 
     if (oauthToken) {
       localStorage.setItem("bragstack_token", oauthToken);
@@ -43,9 +43,7 @@ function AuthPage({ mode = "login", onLogin, onRegister }) {
       return;
     }
 
-    if (passwordResetToken) {
-      setResetToken(passwordResetToken);
-      setShowReset(true);
+    if (hash.get("reset_token")) {
       history.replaceState(null, "", "/login");
     }
   }, []);

--- a/frontend/src/AuthPage.jsx
+++ b/frontend/src/AuthPage.jsx
@@ -27,15 +27,27 @@ function AuthPage({ mode = "login", onLogin, onRegister }) {
   const [resetEmail, setResetEmail] = useState("");
   const [resetMessage, setResetMessage] = useState("");
   const [resetSubmitting, setResetSubmitting] = useState(false);
+  const [resetToken, setResetToken] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
 
   useEffect(() => {
     const hash = new URLSearchParams(window.location.hash.slice(1));
     const oauthToken = hash.get("oauth_token");
-    if (!oauthToken) return;
+    const passwordResetToken = hash.get("reset_token");
 
-    localStorage.setItem("bragstack_token", oauthToken);
-    history.replaceState(null, "", "/login");
-    window.location.replace("/app");
+    if (oauthToken) {
+      localStorage.setItem("bragstack_token", oauthToken);
+      history.replaceState(null, "", "/login");
+      window.location.replace("/app");
+      return;
+    }
+
+    if (passwordResetToken) {
+      setResetToken(passwordResetToken);
+      setShowReset(true);
+      history.replaceState(null, "", "/login");
+    }
   }, []);
 
   function handleChange(event) {
@@ -96,6 +108,39 @@ function AuthPage({ mode = "login", onLogin, onRegister }) {
       setResetMessage("If that email belongs to an account, we sent a password reset link.");
     } catch (error) {
       setResetMessage(error.message || "Password reset is unavailable right now.");
+    } finally {
+      setResetSubmitting(false);
+    }
+  }
+
+  async function handleResetConfirm(event) {
+    event.preventDefault();
+    setResetMessage("");
+
+    if (newPassword.length < 8) {
+      setResetMessage("Your new password must be at least 8 characters.");
+      return;
+    }
+    if (newPassword !== confirmPassword) {
+      setResetMessage("The passwords do not match.");
+      return;
+    }
+
+    setResetSubmitting(true);
+    try {
+      const response = await fetch(`${apiBaseUrl}/auth/password-reset/confirm`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ token: resetToken, password: newPassword }),
+      });
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok) throw new Error(data.detail || "This reset link is invalid or expired.");
+      setResetMessage("Password updated. You can sign in now.");
+      setResetToken("");
+      setNewPassword("");
+      setConfirmPassword("");
+    } catch (error) {
+      setResetMessage(error.message || "This reset link is invalid or expired.");
     } finally {
       setResetSubmitting(false);
     }
@@ -175,14 +220,30 @@ function AuthPage({ mode = "login", onLogin, onRegister }) {
 
           {showReset && !isRegister && (
             <div className="auth-reset-panel">
-              <strong>Reset your password</strong>
-              <p>Enter the email address on your BragStack account.</p>
-              <div className="auth-reset-row">
-                <input type="email" value={resetEmail} onChange={(event) => setResetEmail(event.target.value)} placeholder="you@example.com" required />
-                <button type="button" onClick={handleResetRequest} disabled={resetSubmitting || !resetEmail}>
-                  {resetSubmitting ? "Sending..." : "Send link"}
-                </button>
-              </div>
+              {resetToken ? (
+                <>
+                  <strong>Choose a new password</strong>
+                  <p>This reset link can be used once and expires after 30 minutes.</p>
+                  <div className="auth-reset-stack">
+                    <input type="password" value={newPassword} onChange={(event) => setNewPassword(event.target.value)} placeholder="New password" minLength={8} />
+                    <input type="password" value={confirmPassword} onChange={(event) => setConfirmPassword(event.target.value)} placeholder="Confirm new password" minLength={8} />
+                    <button type="button" onClick={handleResetConfirm} disabled={resetSubmitting || !newPassword || !confirmPassword}>
+                      {resetSubmitting ? "Updating..." : "Update password"}
+                    </button>
+                  </div>
+                </>
+              ) : (
+                <>
+                  <strong>Reset your password</strong>
+                  <p>Enter the email address on your BragStack account.</p>
+                  <div className="auth-reset-row">
+                    <input type="email" value={resetEmail} onChange={(event) => setResetEmail(event.target.value)} placeholder="you@example.com" />
+                    <button type="button" onClick={handleResetRequest} disabled={resetSubmitting || !resetEmail}>
+                      {resetSubmitting ? "Sending..." : "Send link"}
+                    </button>
+                  </div>
+                </>
+              )}
               {resetMessage && <small>{resetMessage}</small>}
             </div>
           )}


### PR DESCRIPTION
Urgent production auth patch:

- move email/password above Google and GitHub sign-in
- warm the free Render API from the branded frontend before OAuth navigation so users do not land on the Render wake-up screen
- fix Google/GitHub OAuth loop by returning to `/login#oauth_token=...` and consuming the token in the React auth page before redirecting to `/app`
- add Forgot password UI
- add secure one-time password reset tokens with 30 minute expiry
- add Resend-based password reset email delivery
- add new-password confirmation UI on the login page
- preserve generic reset responses so account existence is not disclosed

Password reset email delivery requires `RESEND_API_KEY` and a verified `PASSWORD_RESET_FROM` value in the backend environment.