### PR TITLE
Add NDA-safe guidance and footer link

### DIFF
--- a/frontend/public/sitemap.xml
+++ b/frontend/public/sitemap.xml
@@ -2,6 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url><loc>https://usebragstack.com/</loc><changefreq>weekly</changefreq><priority>1.0</priority></url>
   <url><loc>https://usebragstack.com/docs</loc><changefreq>weekly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://usebragstack.com/nda-safety</loc><changefreq>monthly</changefreq><priority>0.7</priority></url>
   <url><loc>https://usebragstack.com/resume-accomplishments</loc><changefreq>weekly</changefreq><priority>0.9</priority></url>
   <url><loc>https://usebragstack.com/career-portfolio</loc><changefreq>weekly</changefreq><priority>0.9</priority></url>
   <url><loc>https://usebragstack.com/performance-reviews</loc><changefreq>weekly</changefreq><priority>0.9</priority></url>

--- a/frontend/src/NDAGuidancePage.jsx
+++ b/frontend/src/NDAGuidancePage.jsx
@@ -1,0 +1,71 @@
+import { LockKeyhole, ShieldCheck, FileText, EyeOff } from "lucide-react";
+
+function NDAGuidancePage() {
+  return (
+    <main className="landing-page" style={{ minHeight: "100vh", paddingBottom: 56 }}>
+      <header className="landing-nav">
+        <a className="landing-logo" href="/">BragStack</a>
+        <div className="landing-nav-actions">
+          <a className="landing-login-link" href="/docs">Docs</a>
+          <a className="landing-btn landing-btn-small" href="/register">Start free</a>
+        </div>
+      </header>
+
+      <section className="landing-hero" style={{ minHeight: "auto", paddingBottom: 36 }}>
+        <div className="landing-hero-copy" style={{ maxWidth: 880 }}>
+          <div className="landing-eyebrow"><LockKeyhole size={16} />NDA-safe career proof</div>
+          <h1>Use BragStack without turning confidential work into public content.</h1>
+          <p className="landing-hero-description">
+            BragStack is designed for career evidence, but an NDA, confidentiality agreement, employer policy, client agreement, security rule, or legal obligation always comes first. BragStack does not override those obligations and cannot determine what your specific agreement allows.
+          </p>
+        </div>
+      </section>
+
+      <section className="landing-problem-section" style={{ paddingTop: 16 }}>
+        <div className="landing-section-heading">
+          <p>SAFE PRACTICES</p>
+          <h2>Capture the impact without exposing protected information.</h2>
+          <span>When work is confidential, preserve the career signal while removing the details that could identify a client, system, product, incident, roadmap, dataset, customer, or internal process.</span>
+        </div>
+
+        <div className="problem-card-grid">
+          <article className="problem-card">
+            <ShieldCheck size={22} />
+            <h3>Generalize sensitive context</h3>
+            <p>Use descriptions such as “enterprise customer,” “internal platform,” or “regulated workload” instead of confidential names, code names, URLs, repository names, architecture details, or customer identifiers.</p>
+          </article>
+          <article className="problem-card">
+            <FileText size={22} />
+            <h3>Redact restricted evidence</h3>
+            <p>Do not upload screenshots, tickets, logs, source code, documents, messages, contracts, credentials, customer data, or attachments unless you are authorized to store and reuse them outside the original system.</p>
+          </article>
+          <article className="problem-card">
+            <EyeOff size={22} />
+            <h3>Keep confidential proof private</h3>
+            <p>Do not make an accomplishment or Impact Receipt public unless the underlying information is approved for external disclosure. Private-by-default controls are not a substitute for following your NDA or employer policy.</p>
+          </article>
+        </div>
+      </section>
+
+      <section className="landing-feature-section">
+        <div className="landing-feature-copy" style={{ maxWidth: 920 }}>
+          <p className="landing-mini-label">WHAT TO WRITE INSTEAD</p>
+          <h2>Focus on your contribution, transferable skill, and outcome.</h2>
+          <p>For example, instead of naming a confidential client or internal system, record: “Improved deployment reliability for a high-volume production service by standardizing container diagnostics and reducing repeat escalations.” If an exact metric is confidential, use an approved range, relative improvement, or qualitative result only when your agreement permits it.</p>
+          <p>When in doubt, leave the sensitive detail out. You can still capture leadership, troubleshooting, ownership, collaboration, scale, complexity, and the type of impact without revealing protected information.</p>
+        </div>
+      </section>
+
+      <section className="landing-feature-section">
+        <div className="landing-feature-copy" style={{ maxWidth: 920 }}>
+          <p className="landing-mini-label">YOUR RESPONSIBILITY</p>
+          <h2>You decide what you are permitted to record and share.</h2>
+          <p>BragStack does not review your NDA, verify disclosure permissions, or provide legal advice. If you are unsure whether information can be stored, exported, placed on a résumé, shown in a portfolio, or shared publicly, consult the agreement, your employer or client policy, an authorized manager or security/legal contact, or qualified legal counsel.</p>
+          <p>For questions about BragStack itself, contact Tobias.scott@usebragstack.com.</p>
+        </div>
+      </section>
+    </main>
+  );
+}
+
+export default NDAGuidancePage;

--- a/frontend/src/RootContent.jsx
+++ b/frontend/src/RootContent.jsx
@@ -5,6 +5,7 @@ import App from "./App.jsx";
 import AppSidebar from "./AppSidebar.jsx";
 import DocsPage from "./DocsPage.jsx";
 import ImpactReceiptsPage from "./ImpactReceiptsPage.jsx";
+import NDAGuidancePage from "./NDAGuidancePage.jsx";
 import SeoLandingPage from "./SeoLandingPages.jsx";
 import UpgradePage from "./UpgradePage.jsx";
 import { getCurrentUser } from "./api.js";
@@ -22,11 +23,22 @@ function ProRequired() {
   );
 }
 
+function PublicLegalFooter() {
+  return (
+    <footer style={{ borderTop: "1px solid rgba(148,163,184,.16)", padding: "20px 24px 28px", textAlign: "center", fontSize: 14, opacity: .9 }}>
+      <a href="/docs" style={{ marginRight: 18 }}>Docs</a>
+      <a href="/nda-safety" style={{ marginRight: 18 }}>NDA & confidential work</a>
+      <a href="mailto:Tobias.scott@usebragstack.com">Support</a>
+    </footer>
+  );
+}
+
 function RootContent() {
   const path = window.location.pathname.replace(/\/$/, "") || "/";
   const seoLandingContent = getSeoLandingPage(path);
   const isUpgradePage = path === "/upgrade";
   const isDocsPage = path === "/docs";
+  const isNdaPage = path === "/nda-safety";
   const isAuthenticatedApp = path.startsWith("/app");
   const [user, setUser] = useState(null);
   const [planLoaded, setPlanLoaded] = useState(!isAuthenticatedApp);
@@ -58,8 +70,9 @@ function RootContent() {
   }, [isAuthenticatedApp]);
 
   if (isUpgradePage) return <UpgradePage />;
-  if (isDocsPage) return <DocsPage />;
-  if (seoLandingContent) return <SeoLandingPage content={seoLandingContent} />;
+  if (isDocsPage) return <><DocsPage /><PublicLegalFooter /></>;
+  if (isNdaPage) return <><NDAGuidancePage /><PublicLegalFooter /></>;
+  if (seoLandingContent) return <><SeoLandingPage content={seoLandingContent} /><PublicLegalFooter /></>;
 
   let Content = App;
   if (path === "/app/accomplishments") {
@@ -70,7 +83,7 @@ function RootContent() {
     Content = ProRequired;
   }
 
-  if (!isAuthenticatedApp) return <Content />;
+  if (!isAuthenticatedApp) return <><Content /><PublicLegalFooter /></>;
   if (!planLoaded) return <div className="app-shell"><div className="authenticated-content" /></div>;
 
   return (


### PR DESCRIPTION
Adds a customer-facing NDA & confidential-work guidance page at /nda-safety, links it from the public footer, adds it to the sitemap, and keeps support routed to Tobias.scott@usebragstack.com. The page explains how users can generalize sensitive work, avoid uploading restricted evidence, keep confidential proof private, and defer to their NDA/employer/client policies. It explicitly states BragStack does not override NDAs or provide legal advice.