### PR TITLE
Add favicon, social preview, and search discovery assets

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,10 +2,18 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <link rel="stylesheet" href="/bragstack-polish.css" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="theme-color" content="#070b14" />
+    <meta name="application-name" content="BragStack" />
+    <meta name="apple-mobile-web-app-title" content="BragStack" />
+    <meta name="color-scheme" content="dark light" />
+
+    <link rel="icon" type="image/svg+xml" sizes="any" href="/favicon.svg" />
+    <link rel="shortcut icon" href="/favicon.svg" />
+    <link rel="apple-touch-icon" href="/favicon.svg" />
+    <link rel="mask-icon" href="/favicon.svg" color="#3478FF" />
+    <link rel="manifest" href="/site.webmanifest" />
+    <link rel="stylesheet" href="/bragstack-polish.css" />
 
     <title>BragStack | Resume Accomplishments, Career Portfolio & Job Search Proof</title>
     <meta name="description" content="BragStack helps professionals capture work accomplishments, build evidence-backed resume bullets, create career portfolios, prepare for interviews, performance reviews, promotions, and job searches." />
@@ -16,42 +24,63 @@
 
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="BragStack" />
+    <meta property="og:locale" content="en_US" />
     <meta property="og:title" content="BragStack | Turn Work Accomplishments Into Career Proof" />
     <meta property="og:description" content="Capture accomplishments once and reuse them for resumes, portfolios, interviews, performance reviews, promotions, and job searches." />
     <meta property="og:url" content="https://usebragstack.com/" />
-    <meta property="og:image" content="https://usebragstack.com/favicon.svg" />
+    <meta property="og:image" content="https://usebragstack.com/social-card.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="BragStack — Turn your work into opportunities. Capture accomplishments, attach evidence, and build career proof." />
 
-    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="BragStack | Career Proof for Resumes, Portfolios & Hiring" />
     <meta name="twitter:description" content="Build evidence-backed career proof for resumes, portfolios, interviews, reviews, promotions, and job searches." />
-    <meta name="twitter:image" content="https://usebragstack.com/favicon.svg" />
+    <meta name="twitter:image" content="https://usebragstack.com/social-card.svg" />
+    <meta name="twitter:image:alt" content="BragStack — Turn your work into opportunities." />
 
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@graph": [
           {
+            "@type": "ImageObject",
+            "@id": "https://usebragstack.com/#logo",
+            "url": "https://usebragstack.com/brandmark.svg",
+            "contentUrl": "https://usebragstack.com/brandmark.svg",
+            "width": 128,
+            "height": 128,
+            "caption": "BragStack"
+          },
+          {
             "@type": "Organization",
             "@id": "https://usebragstack.com/#organization",
             "name": "BragStack",
+            "alternateName": "BragStack Career Proof",
             "url": "https://usebragstack.com/",
             "email": "mailto:Tobias.scott@usebragstack.com",
-            "logo": "https://usebragstack.com/favicon.svg"
+            "logo": { "@id": "https://usebragstack.com/#logo" }
           },
           {
             "@type": "WebSite",
             "@id": "https://usebragstack.com/#website",
             "url": "https://usebragstack.com/",
             "name": "BragStack",
+            "alternateName": "BragStack Career Proof",
             "publisher": { "@id": "https://usebragstack.com/#organization" },
-            "description": "Career proof software for resumes, portfolios, job searches, interviews, performance reviews, promotions, and hiring conversations."
+            "description": "Career proof software for resumes, portfolios, job searches, interviews, performance reviews, promotions, and hiring conversations.",
+            "inLanguage": "en-US"
           },
           {
             "@type": "SoftwareApplication",
+            "@id": "https://usebragstack.com/#app",
             "name": "BragStack",
             "applicationCategory": "BusinessApplication",
             "operatingSystem": "Web",
             "url": "https://usebragstack.com/",
+            "image": "https://usebragstack.com/social-card.svg",
+            "publisher": { "@id": "https://usebragstack.com/#organization" },
             "description": "Capture work accomplishments and evidence, then turn them into resume material, career portfolios, interview stories, performance-review packets, and promotion proof.",
             "offers": [
               { "@type": "Offer", "name": "Free", "price": "0", "priceCurrency": "USD" },

--- a/frontend/public/site.webmanifest
+++ b/frontend/public/site.webmanifest
@@ -1,0 +1,18 @@
+{
+  "name": "BragStack",
+  "short_name": "BragStack",
+  "description": "Turn everyday work into evidence-backed career proof for resumes, reviews, promotions, interviews, and job searches.",
+  "start_url": "/",
+  "scope": "/",
+  "display": "standalone",
+  "background_color": "#070b14",
+  "theme_color": "#070b14",
+  "icons": [
+    {
+      "src": "/favicon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any maskable"
+    }
+  ]
+}

--- a/frontend/public/sitemap.xml
+++ b/frontend/public/sitemap.xml
@@ -3,6 +3,8 @@
   <url><loc>https://usebragstack.com/</loc><changefreq>weekly</changefreq><priority>1.0</priority></url>
   <url><loc>https://usebragstack.com/docs</loc><changefreq>weekly</changefreq><priority>0.8</priority></url>
   <url><loc>https://usebragstack.com/nda-safety</loc><changefreq>monthly</changefreq><priority>0.7</priority></url>
+  <url><loc>https://usebragstack.com/privacy</loc><changefreq>monthly</changefreq><priority>0.5</priority></url>
+  <url><loc>https://usebragstack.com/terms</loc><changefreq>monthly</changefreq><priority>0.5</priority></url>
   <url><loc>https://usebragstack.com/resume-accomplishments</loc><changefreq>weekly</changefreq><priority>0.9</priority></url>
   <url><loc>https://usebragstack.com/career-portfolio</loc><changefreq>weekly</changefreq><priority>0.9</priority></url>
   <url><loc>https://usebragstack.com/performance-reviews</loc><changefreq>weekly</changefreq><priority>0.9</priority></url>

--- a/frontend/public/social-card.svg
+++ b/frontend/public/social-card.svg
@@ -1,0 +1,46 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-labelledby="title desc">
+  <title id="title">BragStack — Turn your work into opportunities</title>
+  <desc id="desc">A BragStack social preview card with the blue and purple brandmark and career-proof messaging.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1200" y2="630" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#07101F"/>
+      <stop offset="0.55" stop-color="#0B1223"/>
+      <stop offset="1" stop-color="#15102B"/>
+    </linearGradient>
+    <linearGradient id="brand" x1="95" y1="100" x2="315" y2="325" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#24D7FF"/>
+      <stop offset="0.52" stop-color="#3478FF"/>
+      <stop offset="1" stop-color="#8B5CF6"/>
+    </linearGradient>
+    <linearGradient id="headline" x1="110" y1="0" x2="980" y2="0" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FFFFFF"/>
+      <stop offset="0.62" stop-color="#BDEBFF"/>
+      <stop offset="1" stop-color="#A78BFA"/>
+    </linearGradient>
+    <filter id="glow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="34"/>
+    </filter>
+  </defs>
+  <rect width="1200" height="630" rx="44" fill="url(#bg)"/>
+  <circle cx="180" cy="118" r="120" fill="#24D7FF" opacity=".13" filter="url(#glow)"/>
+  <circle cx="1050" cy="510" r="150" fill="#8B5CF6" opacity=".16" filter="url(#glow)"/>
+  <g transform="translate(88 78)">
+    <rect width="120" height="120" rx="28" fill="#07101F" stroke="#263756" stroke-width="2"/>
+    <path d="M24 22h44c19 0 29 9 29 23 0 10-5 16-14 20 12 4 19 12 19 24 0 17-12 27-33 27H24V22Z" fill="url(#brand)"/>
+    <path d="M41 39h26c9 0 14 4 14 10s-5 10-14 10H41V39Zm0 36h29c10 0 16 4 16 11s-6 11-16 11H41V75Z" fill="#07101F"/>
+    <path d="M16 90 40 66l12 12 26-29H66V37h35v35H89V59L54 98 41 85l-15 15-10-10Z" fill="#EEF7FF"/>
+  </g>
+  <text x="238" y="126" fill="#FFFFFF" font-family="Inter,Arial,sans-serif" font-size="42" font-weight="800" letter-spacing="-1">BragStack</text>
+  <text x="238" y="162" fill="#8FA4C7" font-family="Inter,Arial,sans-serif" font-size="18" font-weight="700" letter-spacing="3">PROVE • GROW • GET HIRED</text>
+  <text x="88" y="328" fill="url(#headline)" font-family="Inter,Arial,sans-serif" font-size="70" font-weight="850" letter-spacing="-3">Turn your work into opportunities.</text>
+  <text x="88" y="391" fill="#B8C4DA" font-family="Inter,Arial,sans-serif" font-size="28">Capture accomplishments. Attach evidence. Build career proof.</text>
+  <g transform="translate(88 462)">
+    <rect width="306" height="60" rx="30" fill="#101A2E" stroke="#2A4570"/>
+    <text x="28" y="39" fill="#DDF4FF" font-family="Inter,Arial,sans-serif" font-size="22" font-weight="700">Private by default</text>
+  </g>
+  <g transform="translate(414 462)">
+    <rect width="326" height="60" rx="30" fill="#101A2E" stroke="#2A4570"/>
+    <text x="28" y="39" fill="#DDF4FF" font-family="Inter,Arial,sans-serif" font-size="22" font-weight="700">Evidence-backed proof</text>
+  </g>
+  <text x="88" y="578" fill="#6F82A5" font-family="Inter,Arial,sans-serif" font-size="20">usebragstack.com</text>
+</svg>


### PR DESCRIPTION
Builds the BragStack brand/search discovery pass:

- adds a web app manifest and stronger favicon/app-name metadata
- adds a branded 1200x630 social preview card
- points Open Graph and Twitter cards at the branded preview instead of the favicon
- upgrades Twitter to summary_large_image
- strengthens Organization, WebSite, logo, and SoftwareApplication structured data
- keeps private auth/app routes blocked from crawling
- expands the sitemap to include public legal/docs pages
- preserves the existing BragStack SVG favicon/brandmark

After deploy, the remaining manual step is Google Search Console domain verification + sitemap submission/request indexing. Google controls whether/when favicon, sitelinks, and enhanced result treatments appear.