### PR TITLE
Show saved profile image in BragStack sidebar

### DIFF
--- a/frontend/src/AppShell.css
+++ b/frontend/src/AppShell.css
@@ -19,8 +19,13 @@
 .sidebar-nav a,
 .sidebar-add,
 .mobile-brand,
-.sidebar-user {
-  text-decoration: none;
+.sidebar-user,
+.sidebar-user:hover,
+.sidebar-user:focus,
+.sidebar-user:visited,
+.sidebar-user strong,
+.sidebar-user small {
+  text-decoration: none !important;
 }
 
 .sidebar-brand {
@@ -158,6 +163,17 @@
   align-items: center;
   gap: 10px;
   min-width: 0;
+  padding: 8px;
+  margin: -8px;
+  border-radius: 10px;
+  color: inherit;
+  transition: background 150ms ease;
+}
+
+.sidebar-user:hover,
+.sidebar-user:focus-visible {
+  background: rgba(255,255,255,.05);
+  outline: none;
 }
 
 .sidebar-user-avatar { width: 34px; height: 34px; border-radius: 8px; }

--- a/frontend/src/AppShell.css
+++ b/frontend/src/AppShell.css
@@ -18,7 +18,8 @@
 .sidebar-brand,
 .sidebar-nav a,
 .sidebar-add,
-.mobile-brand {
+.mobile-brand,
+.sidebar-user {
   text-decoration: none;
 }
 
@@ -67,6 +68,7 @@
 
 .sidebar-logo { object-fit: contain; background: #111; }
 .sidebar-user-avatar { color: #0b0b0b; background: #ffb184; }
+.sidebar-user-avatar-image { object-fit: cover; overflow: hidden; }
 
 .sidebar-plan-row {
   display: flex;

--- a/frontend/src/AppSidebar.jsx
+++ b/frontend/src/AppSidebar.jsx
@@ -88,7 +88,11 @@ function AppSidebar() {
 
         <div className="sidebar-footer">
           <a className="sidebar-user" href="/app/profile" aria-label="Edit profile">
-            <span className="sidebar-user-avatar">{user?.name?.charAt(0).toUpperCase() || "B"}</span>
+            {user?.avatar_url ? (
+              <img className="sidebar-user-avatar sidebar-user-avatar-image" src={user.avatar_url} alt="" />
+            ) : (
+              <span className="sidebar-user-avatar">{user?.name?.charAt(0).toUpperCase() || "B"}</span>
+            )}
             <span><strong>{user?.name || "BragStack member"}</strong><small>{user?.plan === "pro" ? "Pro plan · Edit profile" : "Free plan · Edit profile"}</small></span>
           </a>
           <button type="button" onClick={logout}><LogOut size={17} />Sign out</button>


### PR DESCRIPTION
Finishes the profile-avatar experience after PR #57 landed.

- uses the saved `avatar_url` from Edit Profile
- shows the real profile photo in the authenticated sidebar
- falls back to the user's initial when no image is set
- keeps the image cropped cleanly inside the existing avatar frame

The profile settings page and avatar persistence endpoint are already in main from PR #57. This follow-up only finishes displaying the saved avatar in the app shell.