### PR TITLE
Fix landing brand spacing and role-based contact emails

### DIFF
--- a/frontend/public/production-patches.js
+++ b/frontend/public/production-patches.js
@@ -1,6 +1,12 @@
 (() => {
   const SITE_URL = "https://usebragstack.com";
-  const SUPPORT_EMAIL = "Tobias.scott@usebragstack.com";
+  const PERSONAL_EMAIL = "Tobias.scott@usebragstack.com";
+  const CONTACT_EMAIL = "contact@usebragstack.com";
+  const SUPPORT_EMAIL = "support@usebragstack.com";
+  const PRIVACY_EMAIL = "privacy@usebragstack.com";
+  const LEGAL_EMAIL = "legal@usebragstack.com";
+  const SECURITY_EMAIL = "security@usebragstack.com";
+  const BILLING_EMAIL = "billing@usebragstack.com";
 
   const routeMeta = {
     "/": ["BragStack | Resume Accomplishments, Career Portfolio & Job Search Proof", "Capture work accomplishments and turn them into evidence-backed resume bullets, career portfolios, interview stories, performance reviews, promotion packets, and job-search proof."],
@@ -92,13 +98,27 @@
     footer.dataset.legalLinksPatched = "true";
   }
 
+  function roleEmailForLink(link) {
+    const path = window.location.pathname.replace(/\/$/, "") || "/";
+    const text = (link.textContent || "").trim().toLowerCase();
+    const href = (link.getAttribute("href") || "").toLowerCase();
+    if (path === "/privacy" || text.includes("privacy") || href.includes("privacy")) return PRIVACY_EMAIL;
+    if (path === "/terms" || text.includes("legal") || href.includes("legal")) return LEGAL_EMAIL;
+    if (text.includes("security") || href.includes("security")) return SECURITY_EMAIL;
+    if (text.includes("billing") || href.includes("billing")) return BILLING_EMAIL;
+    if (path === "/docs" || text.includes("support") || href.includes("support")) return SUPPORT_EMAIL;
+    return CONTACT_EMAIL;
+  }
+
   function patchLinks(root = document) {
     root.querySelectorAll?.("a[href]").forEach((link) => {
       const href = link.getAttribute("href") || "";
       const text = (link.textContent || "").trim().toLowerCase();
-      if (href.startsWith("mailto:")) {
+      if (href.toLowerCase().startsWith(`mailto:${PERSONAL_EMAIL.toLowerCase()}`)) {
         const query = href.includes("?") ? href.slice(href.indexOf("?")) : "";
-        link.setAttribute("href", `mailto:${SUPPORT_EMAIL}${query}`);
+        const roleEmail = roleEmailForLink(link);
+        link.setAttribute("href", `mailto:${roleEmail}${query}`);
+        if ((link.textContent || "").trim().toLowerCase() === PERSONAL_EMAIL.toLowerCase()) link.textContent = roleEmail;
       }
       if (href === "http://localhost:8000/docs" || href === "https://api.usebragstack.com/docs") {
         link.setAttribute("href", "/docs"); link.removeAttribute("target"); link.removeAttribute("rel"); if (text.includes("api docs")) link.textContent = "Docs";

--- a/frontend/src/LandingPageMonetization.css
+++ b/frontend/src/LandingPageMonetization.css
@@ -24,412 +24,69 @@
   font-weight: 850;
 }
 
-.career-flow svg {
-  color: var(--landing-purple);
-}
-
-.premium-workflow-grid {
-  display: grid;
-  grid-template-columns: repeat(5, minmax(0, 1fr));
-  gap: 0.85rem;
-}
-
-.premium-workflow-card {
-  min-height: 300px;
-}
-
-.premium-workflow-card h3 {
-  margin-top: 3.5rem;
-}
-
-.career-intelligence-demo {
-  margin-top: 2rem;
-  padding: 2rem;
-  display: grid;
-  grid-template-columns: minmax(0, 0.85fr) minmax(420px, 1.15fr);
-  gap: 2rem;
-  border: 1px solid rgba(173, 145, 255, 0.32);
-  border-radius: 30px;
-  background:
-    radial-gradient(circle at 90% 10%, rgba(173, 145, 255, 0.15), transparent 24rem),
-    rgba(11, 18, 33, 0.92);
-}
-
-.career-intelligence-copy h2 {
-  margin: 0;
-  font-size: clamp(2rem, 4vw, 3.6rem);
-  line-height: 1.03;
-  letter-spacing: -0.055em;
-}
-
-.career-intelligence-copy > p:not(.landing-mini-label) {
-  color: var(--landing-muted);
-  line-height: 1.7;
-}
-
-.career-output-list {
-  margin-top: 1.4rem;
-  display: grid;
-  gap: 0.85rem;
-}
-
-.career-output-list span {
-  display: flex;
-  align-items: center;
-  gap: 0.7rem;
-  font-weight: 750;
-}
-
-.career-output-list svg {
-  color: var(--landing-blue);
-}
-
-.mock-analytics-panel {
-  padding: 1rem;
-  border: 1px solid rgba(166, 220, 255, 0.18);
-  border-radius: 24px;
-  background: rgba(5, 10, 20, 0.78);
-  box-shadow: 0 30px 70px rgba(0, 0, 0, 0.32);
-}
-
-.mock-analytics-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-  padding: 0.6rem;
-  color: var(--landing-muted);
-  font-size: 0.74rem;
-  text-transform: uppercase;
-}
-
-.mock-analytics-header strong {
-  color: var(--landing-blue);
-}
-
-.mock-stat-row {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 0.65rem;
-}
-
-.mock-stat-row > div {
-  padding: 0.9rem;
-  border: 1px solid var(--landing-border);
-  border-radius: 16px;
-  background: rgba(19, 30, 51, 0.74);
-}
-
-.mock-stat-row span,
-.mock-signal span {
-  display: block;
-  color: var(--landing-muted);
-  font-size: 0.7rem;
-  font-weight: 800;
-  text-transform: uppercase;
-}
-
-.mock-stat-row strong {
-  display: block;
-  margin-top: 0.45rem;
-  font-size: 1.7rem;
-}
-
-.mock-chart {
-  height: 220px;
-  margin-top: 0.8rem;
-  padding: 1rem 1rem 0.7rem;
-  display: grid;
-  grid-template-columns: repeat(6, 1fr);
-  align-items: end;
-  gap: 0.65rem;
-  border: 1px solid var(--landing-border);
-  border-radius: 18px;
-  background: rgba(12, 20, 36, 0.7);
-}
-
-.mock-chart > div {
-  height: 100%;
-  display: grid;
-  grid-template-rows: 1fr auto;
-  align-items: end;
-  gap: 0.45rem;
-  text-align: center;
-}
-
-.mock-chart > div > span {
-  width: 100%;
-  min-height: 16px;
-  align-self: end;
-  border-radius: 8px 8px 3px 3px;
-  background: linear-gradient(180deg, var(--landing-purple), var(--landing-blue));
-  box-shadow: 0 10px 24px rgba(134, 151, 255, 0.15);
-}
-
-.mock-chart small {
-  color: #8190a7;
-  font-size: 0.68rem;
-}
-
-.mock-signal {
-  margin-top: 0.8rem;
-  padding: 1rem;
-  border: 1px solid rgba(105, 228, 246, 0.18);
-  border-radius: 16px;
-  background: rgba(39, 117, 158, 0.08);
-}
-
-.mock-signal strong,
-.mock-signal em {
-  display: block;
-  margin-top: 0.35rem;
-}
-
-.mock-signal em {
-  color: var(--landing-muted);
-  font-size: 0.74rem;
-}
-
-.pro-output-grid {
-  margin-top: 1rem;
-  display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 0.8rem;
-}
-
-.pro-output-grid article {
-  min-height: 220px;
-  padding: 1.2rem;
-  border: 1px solid rgba(173, 145, 255, 0.2);
-  border-radius: 20px;
-  background: linear-gradient(145deg, rgba(24, 30, 55, 0.88), rgba(10, 17, 31, 0.88));
-}
-
-.pro-output-grid svg {
-  color: var(--landing-purple);
-}
-
-.pro-output-grid small {
-  display: block;
-  margin-top: 1rem;
-  color: var(--landing-purple);
-  font-weight: 950;
-  letter-spacing: 0.12em;
-}
-
-.pro-output-grid h3 {
-  margin: 0.6rem 0;
-}
-
-.pro-output-grid p {
-  margin: 0;
-  color: var(--landing-muted);
-  line-height: 1.6;
-}
-
-.pricing-grid-four {
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  align-items: stretch;
-}
-
-.pricing-grid-four .pricing-card {
-  display: flex;
-  flex-direction: column;
-}
-
-.pricing-grid-four .pricing-card-header {
-  min-height: 84px;
-  align-items: flex-end;
-}
-
-.pricing-grid-four .pricing-card-header h3 {
-  font-size: 2.25rem;
-}
-
-.pricing-grid-four .pricing-card-header h3 span {
-  display: block;
-  margin-top: 0.2rem;
-}
-
-.pricing-tagline {
-  min-height: 48px;
-  margin: 0.9rem 0 0;
-  color: var(--landing-muted);
-  line-height: 1.45;
-}
-
-.pricing-grid-four .pricing-card ul {
-  flex: 1;
-  margin-top: 1.4rem;
-}
-
-.pricing-card-pro {
-  transform: translateY(-10px);
-  box-shadow: 0 28px 70px rgba(116, 101, 255, 0.18);
-}
-
-.pricing-conversion-note {
-  margin-top: 1rem;
-  padding: 1rem 1.2rem;
-  display: flex;
-  align-items: center;
-  gap: 0.9rem;
-  border: 1px solid rgba(166, 220, 255, 0.2);
-  border-radius: 18px;
-  background: rgba(13, 21, 38, 0.72);
-}
-
-.pricing-conversion-note svg {
-  flex: 0 0 auto;
-  color: var(--landing-blue);
-}
-
-.pricing-conversion-note strong,
-.pricing-conversion-note span {
-  display: block;
-}
-
-.pricing-conversion-note span {
-  margin-top: 0.25rem;
-  color: var(--landing-muted);
-  font-size: 0.85rem;
-}
-
-.mega-footer {
-  width: min(1180px, calc(100% - 2rem));
-  margin: 6rem auto 0;
-  padding: 3rem 0 2rem;
-  border-top: 1px solid var(--landing-border);
-}
-
-.mega-footer-brand {
-  padding-bottom: 2rem;
-  display: grid;
-  grid-template-columns: 1fr 2fr auto;
-  align-items: center;
-  gap: 2rem;
-  border-bottom: 1px solid var(--landing-border);
-}
-
-.mega-footer-brand p {
-  margin: 0;
-  color: var(--landing-muted);
-  line-height: 1.6;
-}
-
-.footer-cta {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.45rem;
-  color: var(--landing-blue) !important;
-  font-weight: 850;
-}
-
-.mega-footer-columns {
-  padding: 2.4rem 0;
-  display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 2rem;
-}
-
-.mega-footer-columns > div {
-  display: grid;
-  align-content: start;
-  gap: 0.75rem;
-}
-
-.mega-footer-columns h3 {
-  margin: 0 0 0.35rem;
-  font-size: 0.84rem;
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
-}
-
-.mega-footer-columns a,
-.mega-footer-columns span {
-  color: var(--landing-muted);
-  font-size: 0.86rem;
-}
-
-.mega-footer-columns a:hover {
-  color: var(--landing-text);
-}
-
-.mega-footer-columns span {
-  opacity: 0.58;
-}
-
-.mega-footer-bottom {
-  padding-top: 1.4rem;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-  border-top: 1px solid var(--landing-border);
-  color: #7f8ca0;
-  font-size: 0.78rem;
-}
-
-.mega-footer-bottom > div {
-  display: flex;
-  gap: 1rem;
-}
-
-@media (max-width: 1080px) {
-  .premium-workflow-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
-  .pricing-grid-four,
-  .pro-output-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
-  .career-intelligence-demo {
-    grid-template-columns: 1fr;
-  }
-
-  .pricing-card-pro {
-    transform: none;
-  }
-}
-
-@media (max-width: 720px) {
-  .career-flow svg {
-    transform: rotate(90deg);
-  }
-
-  .career-flow {
-    flex-direction: column;
-  }
-
-  .premium-workflow-grid,
-  .pricing-grid-four,
-  .pro-output-grid,
-  .mega-footer-columns,
-  .mock-stat-row {
-    grid-template-columns: 1fr;
-  }
-
-  .career-intelligence-demo {
-    padding: 1rem;
-  }
-
-  .mock-chart {
-    height: 180px;
-    gap: 0.35rem;
-  }
-
-  .mega-footer {
-    width: calc(100% - 1.25rem);
-  }
-
-  .mega-footer-brand {
-    grid-template-columns: 1fr;
-  }
-
-  .mega-footer-bottom {
-    align-items: flex-start;
-    flex-direction: column;
-  }
-}
+.career-flow svg { color: var(--landing-purple); }
+.premium-workflow-grid { display:grid; grid-template-columns:repeat(5,minmax(0,1fr)); gap:.85rem; }
+.premium-workflow-card { min-height:300px; }
+.premium-workflow-card h3 { margin-top:3.5rem; }
+.career-intelligence-demo { margin-top:2rem; padding:2rem; display:grid; grid-template-columns:minmax(0,.85fr) minmax(420px,1.15fr); gap:2rem; border:1px solid rgba(173,145,255,.32); border-radius:30px; background:radial-gradient(circle at 90% 10%,rgba(173,145,255,.15),transparent 24rem),rgba(11,18,33,.92); }
+.career-intelligence-copy h2 { margin:0; font-size:clamp(2rem,4vw,3.6rem); line-height:1.03; letter-spacing:-.055em; }
+.career-intelligence-copy > p:not(.landing-mini-label) { color:var(--landing-muted); line-height:1.7; }
+.career-output-list { margin-top:1.4rem; display:grid; gap:.85rem; }
+.career-output-list span { display:flex; align-items:center; gap:.7rem; font-weight:750; }
+.career-output-list svg { color:var(--landing-blue); }
+.mock-analytics-panel { padding:1rem; border:1px solid rgba(166,220,255,.18); border-radius:24px; background:rgba(5,10,20,.78); box-shadow:0 30px 70px rgba(0,0,0,.32); }
+.mock-analytics-header { display:flex; align-items:center; justify-content:space-between; gap:1rem; padding:.6rem; color:var(--landing-muted); font-size:.74rem; text-transform:uppercase; }
+.mock-analytics-header strong { color:var(--landing-blue); }
+.mock-stat-row { display:grid; grid-template-columns:repeat(3,1fr); gap:.65rem; }
+.mock-stat-row > div { padding:.9rem; border:1px solid var(--landing-border); border-radius:16px; background:rgba(19,30,51,.74); }
+.mock-stat-row span,.mock-signal span { display:block; color:var(--landing-muted); font-size:.7rem; font-weight:800; text-transform:uppercase; }
+.mock-stat-row strong { display:block; margin-top:.45rem; font-size:1.7rem; }
+.mock-chart { height:220px; margin-top:.8rem; padding:1rem 1rem .7rem; display:grid; grid-template-columns:repeat(6,1fr); align-items:end; gap:.65rem; border:1px solid var(--landing-border); border-radius:18px; background:rgba(12,20,36,.7); }
+.mock-chart > div { height:100%; display:grid; grid-template-rows:1fr auto; align-items:end; gap:.45rem; text-align:center; }
+.mock-chart > div > span { width:100%; min-height:16px; align-self:end; border-radius:8px 8px 3px 3px; background:linear-gradient(180deg,var(--landing-purple),var(--landing-blue)); box-shadow:0 10px 24px rgba(134,151,255,.15); }
+.mock-chart small { color:#8190a7; font-size:.68rem; }
+.mock-signal { margin-top:.8rem; padding:1rem; border:1px solid rgba(105,228,246,.18); border-radius:16px; background:rgba(39,117,158,.08); }
+.mock-signal strong,.mock-signal em { display:block; margin-top:.35rem; }
+.mock-signal em { color:var(--landing-muted); font-size:.74rem; }
+.pro-output-grid { margin-top:1rem; display:grid; grid-template-columns:repeat(4,minmax(0,1fr)); gap:.8rem; }
+.pro-output-grid article { min-height:220px; padding:1.2rem; border:1px solid rgba(173,145,255,.2); border-radius:20px; background:linear-gradient(145deg,rgba(24,30,55,.88),rgba(10,17,31,.88)); }
+.pro-output-grid svg { color:var(--landing-purple); }
+.pro-output-grid small { display:block; margin-top:1rem; color:var(--landing-purple); font-weight:950; letter-spacing:.12em; }
+.pro-output-grid h3 { margin:.6rem 0; }
+.pro-output-grid p { margin:0; color:var(--landing-muted); line-height:1.6; }
+.pricing-grid-four { grid-template-columns:repeat(4,minmax(0,1fr)); align-items:stretch; }
+.pricing-grid-four .pricing-card { display:flex; flex-direction:column; }
+.pricing-grid-four .pricing-card-header { min-height:84px; align-items:flex-end; }
+.pricing-grid-four .pricing-card-header h3 { font-size:2.25rem; }
+.pricing-grid-four .pricing-card-header h3 span { display:block; margin-top:.2rem; }
+.pricing-tagline { min-height:48px; margin:.9rem 0 0; color:var(--landing-muted); line-height:1.45; }
+.pricing-grid-four .pricing-card ul { flex:1; margin-top:1.4rem; }
+.pricing-card-pro { transform:translateY(-10px); box-shadow:0 28px 70px rgba(116,101,255,.18); }
+.pricing-conversion-note { margin-top:1rem; padding:1rem 1.2rem; display:flex; align-items:center; gap:.9rem; border:1px solid rgba(166,220,255,.2); border-radius:18px; background:rgba(13,21,38,.72); }
+.pricing-conversion-note svg { flex:0 0 auto; color:var(--landing-blue); }
+.pricing-conversion-note strong,.pricing-conversion-note span { display:block; }
+.pricing-conversion-note span { margin-top:.25rem; color:var(--landing-muted); font-size:.85rem; }
+.mega-footer { width:min(1180px,calc(100% - 2rem)); margin:6rem auto 0; padding:3rem 0 2rem; border-top:1px solid var(--landing-border); }
+.mega-footer-brand { padding-bottom:2rem; display:grid; grid-template-columns:1fr 2fr auto; align-items:center; gap:2rem; border-bottom:1px solid var(--landing-border); }
+.mega-footer-brand p { margin:0; color:var(--landing-muted); line-height:1.6; }
+.footer-cta { display:inline-flex; align-items:center; gap:.45rem; color:var(--landing-blue)!important; font-weight:850; }
+.mega-footer-columns { padding:2.4rem 0; display:grid; grid-template-columns:repeat(4,minmax(0,1fr)); gap:2rem; }
+.mega-footer-columns > div { display:grid; align-content:start; gap:.75rem; }
+.mega-footer-columns h3 { margin:0 0 .35rem; font-size:.84rem; text-transform:uppercase; letter-spacing:.1em; }
+.mega-footer-columns a,.mega-footer-columns span { color:var(--landing-muted); font-size:.86rem; }
+.mega-footer-columns a:hover { color:var(--landing-text); }
+.mega-footer-columns span { opacity:.58; }
+.mega-footer-bottom { padding-top:1.4rem; display:flex; align-items:center; justify-content:space-between; gap:1rem; border-top:1px solid var(--landing-border); color:#7f8ca0; font-size:.78rem; }
+.mega-footer-bottom > div { display:flex; gap:1rem; }
+
+/* Keep the landing page moving. Large empty gaps make sections feel disconnected. */
+.landing-use-strip { margin-bottom: 2.75rem; }
+.landing-problem-section,
+.landing-use-cases,
+.landing-workflow,
+.landing-pricing { padding-top: 3.75rem; padding-bottom: 3.75rem; }
+.premium-workflow { padding-top: 3.75rem; }
+.landing-feature-section { margin-top: 1.5rem; margin-bottom: 1.5rem; }
+
+@media (max-width:1080px){.premium-workflow-grid{grid-template-columns:repeat(2,minmax(0,1fr))}.pricing-grid-four,.pro-output-grid{grid-template-columns:repeat(2,minmax(0,1fr))}.career-intelligence-demo{grid-template-columns:1fr}.pricing-card-pro{transform:none}}
+@media (max-width:720px){.career-flow svg{transform:rotate(90deg)}.career-flow{flex-direction:column}.premium-workflow-grid,.pricing-grid-four,.pro-output-grid,.mega-footer-columns,.mock-stat-row{grid-template-columns:1fr}.career-intelligence-demo{padding:1rem}.mock-chart{height:180px;gap:.35rem}.mega-footer{width:calc(100% - 1.25rem)}.mega-footer-brand{grid-template-columns:1fr}.mega-footer-bottom{align-items:flex-start;flex-direction:column}.landing-use-strip{margin-bottom:2rem}.landing-problem-section,.landing-use-cases,.landing-workflow,.landing-pricing{padding-top:2.75rem;padding-bottom:2.75rem}.premium-workflow{padding-top:2.75rem}}

--- a/frontend/src/ProfilePage.jsx
+++ b/frontend/src/ProfilePage.jsx
@@ -13,7 +13,21 @@ function ProfilePage() {
   function handleChange(e){const{name,value}=e.target;setForm(c=>({...c,[name]:value}));}
   function selectTheme(id){setForm(c=>({...c,profile_theme:id,profile_primary_color:"",profile_secondary_color:"",profile_background_color:""}));}
   function resetColors(){setForm(c=>({...c,profile_primary_color:"",profile_secondary_color:"",profile_background_color:""}));}
-  async function handleSubmit(e){e.preventDefault();setSaving(true);setMessage("");setError("");try{const{avatar_url:avatarUrl,id,email,email_verified,public_slug,plan,entitlements,created_at,...profileFields}=form;await updateCurrentUserProfile(profileFields);const updated=await updateProfileAvatar(avatarUrl);setUser(updated);setForm(c=>({...c,...updated,avatar_url:updated.avatar_url??avatarUrl}));setMessage("Profile and appearance saved.");}catch(err){setError(err.response?.data?.detail||"Your profile could not be saved.");}finally{setSaving(false);}}
+  async function handleSubmit(e){
+    e.preventDefault();setSaving(true);setMessage("");setError("");
+    try{
+      const avatarUrl=form.avatar_url;
+      const profileFields={
+        name:form.name,headline:form.headline,bio:form.bio,location:form.location,
+        github_url:form.github_url,portfolio_url:form.portfolio_url,resume_url:form.resume_url,
+        profile_theme:form.profile_theme,profile_primary_color:form.profile_primary_color,
+        profile_secondary_color:form.profile_secondary_color,profile_background_color:form.profile_background_color,
+      };
+      await updateCurrentUserProfile(profileFields);
+      const updated=await updateProfileAvatar(avatarUrl);
+      setUser(updated);setForm(c=>({...c,...updated,avatar_url:updated.avatar_url??avatarUrl}));setMessage("Profile and appearance saved.");
+    }catch(err){setError(err.response?.data?.detail||"Your profile could not be saved.");}finally{setSaving(false);}
+  }
   if(loading)return <main className="profile-settings"><div className="profile-loading">Loading profile…</div></main>;
   const avatarLetter=form.name?.charAt(0).toUpperCase()||"B"; const theme=getProfileTheme(form.profile_theme); const primary=form.profile_primary_color||theme.primary; const secondary=form.profile_secondary_color||theme.secondary; const background=form.profile_background_color||theme.background;
   return <main className="profile-settings">

--- a/frontend/src/ProfileThemeCustomizer.jsx
+++ b/frontend/src/ProfileThemeCustomizer.jsx
@@ -1,23 +1,11 @@
 import { useEffect, useMemo, useState } from "react";
 import { getCurrentUser, updateCurrentUserProfile } from "./api";
+import { PROFILE_THEMES as THEME_OBJECTS } from "./profileThemes";
 
-export const PROFILE_THEMES = [
-  ["default", "BragStack Default"], ["clinical", "Clinical"], ["educator", "Educator"],
-  ["engineer", "Engineer"], ["designer", "Designer"], ["executive", "Executive"],
-  ["trades", "Trades"], ["creator", "Creator"], ["hospitality", "Hospitality"],
-  ["finance", "Finance"], ["legal", "Legal"], ["public-service", "Public Service"],
-];
+const PROFILE_THEMES = THEME_OBJECTS.map((theme) => [theme.id, theme.name]);
+const THEME_COLORS = Object.fromEntries(THEME_OBJECTS.map((theme) => [theme.id, [theme.primary, theme.secondary, theme.background]]));
 
-const THEME_COLORS = {
-  default:["#7dd3fc","#c4b5fd","#050816"], clinical:["#5eead4","#67e8f9","#06151a"],
-  educator:["#fbbf24","#fb7185","#181006"], engineer:["#60a5fa","#94a3b8","#07111f"],
-  designer:["#f472b6","#c084fc","#17091a"], executive:["#d4af37","#e2e8f0","#090b10"],
-  trades:["#fb923c","#facc15","#171008"], creator:["#a78bfa","#22d3ee","#10091c"],
-  hospitality:["#fb7185","#fda4af","#190b10"], finance:["#34d399","#93c5fd","#07150f"],
-  legal:["#c4b5fd","#e5e7eb","#0d0b16"], "public-service":["#38bdf8","#f8fafc","#07121b"],
-};
-
-export function getProfileThemeStyle(profile) {
+function getProfileThemeStyle(profile) {
   const defaults = THEME_COLORS[profile?.profile_theme] || THEME_COLORS.default;
   return {
     "--theme-accent": profile?.profile_primary_color || defaults[0],
@@ -35,14 +23,12 @@ export default function ProfileThemeCustomizer({ publicSlug, profile, onSaved })
   useEffect(() => {
     if (!localStorage.getItem("bragstack_token")) return;
     getCurrentUser().then((user) => {
-      if (user.public_slug === publicSlug) setOwner(user);
+      if (user.public_slug === publicSlug) {
+        setOwner(user);
+        setForm({ ...user });
+      }
     }).catch(() => {});
   }, [publicSlug]);
-
-  useEffect(() => {
-    if (!owner) return;
-    setForm({ ...owner });
-  }, [owner]);
 
   const previewStyle = useMemo(() => getProfileThemeStyle(form || profile), [form, profile]);
   if (!owner || !form) return null;
@@ -65,7 +51,7 @@ export default function ProfileThemeCustomizer({ publicSlug, profile, onSaved })
         profile_theme: form.profile_theme, profile_primary_color: form.profile_primary_color,
         profile_secondary_color: form.profile_secondary_color, profile_background_color: form.profile_background_color,
       });
-      setOwner(updated); onSaved?.(updated); setOpen(false);
+      setOwner(updated); setForm({ ...updated }); onSaved?.(updated); setOpen(false);
     } finally { setSaving(false); }
   }
 

--- a/frontend/src/ReferencePolish.css
+++ b/frontend/src/ReferencePolish.css
@@ -1,24 +1,25 @@
-/* Reference-driven polish: brand lockup, BragStack gradients, mobile nav placement. */
-:root{--brag-blue:#18a8ff;--brag-cyan:#18d7f3;--brag-purple:#8f4dff;--brag-indigo:#4f5dff}
+/* Reference-driven polish: BragStack brand lockup, gradients, and responsive layout. */
+:root{--brag-blue:#00C6FF;--brag-cyan:#00D9FF;--brag-purple:#7B5CFF;--brag-violet:#B86BFF;--brag-navy:#0B1020}
 
 /* Landing brand lockup */
 .landing-logo{position:relative;display:inline-flex;align-items:center;min-height:44px;padding-left:52px;font-size:1.08rem!important;font-weight:950!important;letter-spacing:-.035em!important;text-transform:none!important;background:linear-gradient(90deg,#fff 0 38%,var(--brag-cyan) 55%,var(--brag-purple) 100%);-webkit-background-clip:text;background-clip:text;color:transparent!important}
 .landing-logo::before{content:"";position:absolute;left:0;width:42px;height:42px;background:url('/brandmark.svg') center/contain no-repeat;filter:drop-shadow(0 5px 14px rgba(49,119,255,.3))}
 .landing-nav{border-color:rgba(44,164,255,.18)!important;background:rgba(4,10,24,.86)!important}
 
-/* Hero brand lockup: keep the tagline clearly below the wordmark and leave breathing room for the headline. */
-.landing-hero{align-items:center!important;padding-top:5.5rem!important;overflow:visible!important}
-.landing-hero-copy{position:relative;padding-top:122px;overflow:visible!important}
-.landing-hero-copy::before{content:"BragStack";position:absolute;top:0;left:0;padding-left:86px;min-height:72px;display:flex;align-items:center;background:linear-gradient(90deg,#fff 0 45%,var(--brag-cyan) 64%,var(--brag-purple) 100%);-webkit-background-clip:text;background-clip:text;color:transparent;font-size:clamp(2.8rem,5vw,5.2rem);font-weight:950;letter-spacing:-.065em;line-height:1}
-.landing-hero-copy::after{content:"";position:absolute;top:-2px;left:0;width:70px;height:70px;background:url('/brandmark.svg') center/contain no-repeat;filter:drop-shadow(0 12px 28px rgba(70,80,255,.35))}
-.landing-eyebrow{position:absolute;top:82px;left:87px;margin:0!important;padding:0!important;border:0!important;background:transparent!important;color:#bcc7dc!important;font-size:.66rem!important;letter-spacing:.26em!important;line-height:1.4!important;white-space:nowrap}
-.landing-eyebrow svg{display:none}
-.landing-eyebrow{font-size:0!important}.landing-eyebrow::before{content:"PROVE  •  GROW  •  GET HIRED";font-size:.66rem}
-.landing-hero-copy h1{margin-top:22px!important;margin-bottom:24px!important;padding-bottom:.12em!important;font-size:0!important;line-height:1.06!important;letter-spacing:-.06em!important;overflow:visible!important}
-.landing-hero-copy h1::before{content:"Turn Your Work";display:block;color:#fff;font-size:clamp(3.2rem,6vw,6.2rem);font-weight:950;line-height:1.04}
-.landing-hero-copy h1::after{content:"Into Opportunities.";display:block;padding-bottom:.12em;background:linear-gradient(90deg,var(--brag-blue),var(--brag-cyan) 48%,var(--brag-purple));-webkit-background-clip:text;background-clip:text;color:transparent;font-size:clamp(3.2rem,6vw,6.2rem);font-weight:950;line-height:1.08;overflow:visible}
+/* Hero brand lockup */
+.landing-hero{grid-template-columns:minmax(0,1.18fr) minmax(360px,.82fr)!important;align-items:center!important;padding-top:4.25rem!important;padding-bottom:3.5rem!important;gap:2.5rem!important;overflow:visible!important}
+.landing-hero-copy{position:relative;min-width:0;padding-top:112px;overflow:visible!important}
+.landing-hero-copy::before{content:"BragStack";position:absolute;top:0;left:0;padding-left:78px;min-height:66px;display:flex;align-items:center;background:linear-gradient(90deg,#fff 0 43%,var(--brag-cyan) 61%,var(--brag-purple) 100%);-webkit-background-clip:text;background-clip:text;color:transparent;font-size:clamp(2.65rem,4.6vw,4.7rem);font-weight:950;letter-spacing:-.065em;line-height:1;white-space:nowrap}
+.landing-hero-copy::after{content:"";position:absolute;top:0;left:0;width:64px;height:64px;background:url('/brandmark.svg') center/contain no-repeat;filter:drop-shadow(0 12px 28px rgba(70,80,255,.35))}
+.landing-eyebrow{position:absolute;top:73px;left:79px;margin:0!important;padding:0!important;border:0!important;background:transparent!important;color:#aebbd2!important;font-size:0!important;letter-spacing:.22em!important;line-height:1.4!important;white-space:nowrap}
+.landing-eyebrow svg{display:none!important}
+.landing-eyebrow::before{content:"PROVE  •  GROW  •  GET HIRED";font-size:.66rem;font-weight:900}
+
+.landing-hero-copy h1{max-width:760px!important;margin:18px 0 20px!important;padding:0 0 .1em!important;font-size:0!important;line-height:1.03!important;letter-spacing:-.06em!important;overflow:visible!important}
+.landing-hero-copy h1::before{content:"Turn Your Work";display:block;color:#fff;font-size:clamp(3rem,5.2vw,5.25rem);font-weight:950;line-height:1.02}
+.landing-hero-copy h1::after{content:"Into Opportunities.";display:block;max-width:100%;padding:0 0 .08em;background:linear-gradient(90deg,var(--brag-blue),var(--brag-cyan) 48%,var(--brag-purple));-webkit-background-clip:text;background-clip:text;color:transparent;font-size:clamp(3rem,5.2vw,5.25rem);font-weight:950;line-height:1.04;letter-spacing:-.055em;overflow:visible;white-space:normal}
 .landing-hero-copy h1 span{display:none!important}
-.landing-hero-description{max-width:610px!important}
+.landing-hero-description{max-width:650px!important;margin-top:1.4rem!important}
 .landing-btn{background:linear-gradient(100deg,var(--brag-purple),var(--brag-blue),var(--brag-cyan))!important;color:white!important;box-shadow:0 14px 38px rgba(64,101,255,.28)!important}
 .landing-btn-secondary{background:rgba(6,15,35,.72)!important;border-color:rgba(73,175,255,.28)!important}
 
@@ -29,18 +30,21 @@
 .sidebar-plan-row>span.pro{background:linear-gradient(90deg,var(--brag-purple),var(--brag-blue))!important;border-color:transparent!important;color:#fff!important}
 .sidebar-add{background:linear-gradient(90deg,var(--brag-purple),var(--brag-blue),var(--brag-cyan))!important;color:#fff!important}
 
-/* Mobile/tablet: hamburger belongs on the LEFT. */
+/* Tablet/mobile */
 @media(max-width:980px){
   .mobile-app-bar{justify-content:flex-start!important;gap:10px!important}
   .mobile-app-bar>button{order:-1!important;flex:0 0 auto!important}
   .mobile-brand{margin-right:auto!important}
+  .landing-hero{grid-template-columns:1fr!important;padding-top:3.5rem!important;gap:1.5rem!important}
+  .landing-proof-preview{min-height:410px!important}
 }
 
 @media(max-width:700px){
-  .landing-hero-copy{padding-top:108px}
-  .landing-hero-copy::before{padding-left:66px;min-height:58px;font-size:2.6rem}
-  .landing-hero-copy::after{width:54px;height:54px}
-  .landing-eyebrow{top:68px;left:67px;letter-spacing:.18em!important}
-  .landing-hero-copy h1{margin-top:18px!important}
-  .landing-hero-copy h1::before,.landing-hero-copy h1::after{line-height:1.08}
+  .landing-hero-copy{padding-top:100px}
+  .landing-hero-copy::before{padding-left:64px;min-height:54px;font-size:2.45rem}
+  .landing-hero-copy::after{width:52px;height:52px}
+  .landing-eyebrow{top:62px;left:65px;letter-spacing:.16em!important}
+  .landing-eyebrow::before{font-size:.58rem}
+  .landing-hero-copy h1{margin-top:14px!important}
+  .landing-hero-copy h1::before,.landing-hero-copy h1::after{font-size:clamp(2.7rem,13vw,4rem);line-height:1.03}
 }

--- a/frontend/src/ReferencePolish.css
+++ b/frontend/src/ReferencePolish.css
@@ -6,17 +6,17 @@
 .landing-logo::before{content:"";position:absolute;left:0;width:42px;height:42px;background:url('/brandmark.svg') center/contain no-repeat;filter:drop-shadow(0 5px 14px rgba(49,119,255,.3))}
 .landing-nav{border-color:rgba(44,164,255,.18)!important;background:rgba(4,10,24,.86)!important}
 
-/* Make the hero visually match the BragStack concept without disturbing the rest of the page. */
-.landing-hero{align-items:center!important;padding-top:5.5rem!important}
-.landing-hero-copy{position:relative;padding-top:92px}
+/* Hero brand lockup: keep the tagline clearly below the wordmark and leave breathing room for the headline. */
+.landing-hero{align-items:center!important;padding-top:5.5rem!important;overflow:visible!important}
+.landing-hero-copy{position:relative;padding-top:122px;overflow:visible!important}
 .landing-hero-copy::before{content:"BragStack";position:absolute;top:0;left:0;padding-left:86px;min-height:72px;display:flex;align-items:center;background:linear-gradient(90deg,#fff 0 45%,var(--brag-cyan) 64%,var(--brag-purple) 100%);-webkit-background-clip:text;background-clip:text;color:transparent;font-size:clamp(2.8rem,5vw,5.2rem);font-weight:950;letter-spacing:-.065em;line-height:1}
 .landing-hero-copy::after{content:"";position:absolute;top:-2px;left:0;width:70px;height:70px;background:url('/brandmark.svg') center/contain no-repeat;filter:drop-shadow(0 12px 28px rgba(70,80,255,.35))}
-.landing-eyebrow{position:absolute;top:72px;left:87px;margin:0!important;padding:0!important;border:0!important;background:transparent!important;color:#bcc7dc!important;font-size:.66rem!important;letter-spacing:.26em!important}
+.landing-eyebrow{position:absolute;top:82px;left:87px;margin:0!important;padding:0!important;border:0!important;background:transparent!important;color:#bcc7dc!important;font-size:.66rem!important;letter-spacing:.26em!important;line-height:1.4!important;white-space:nowrap}
 .landing-eyebrow svg{display:none}
 .landing-eyebrow{font-size:0!important}.landing-eyebrow::before{content:"PROVE  •  GROW  •  GET HIRED";font-size:.66rem}
-.landing-hero-copy h1{margin-top:38px!important;font-size:0!important;line-height:.98!important;letter-spacing:-.06em!important}
-.landing-hero-copy h1::before{content:"Turn Your Work";display:block;color:#fff;font-size:clamp(3.2rem,6vw,6.2rem);font-weight:950}
-.landing-hero-copy h1::after{content:"Into Opportunities.";display:block;background:linear-gradient(90deg,var(--brag-blue),var(--brag-cyan) 48%,var(--brag-purple));-webkit-background-clip:text;background-clip:text;color:transparent;font-size:clamp(3.2rem,6vw,6.2rem);font-weight:950}
+.landing-hero-copy h1{margin-top:22px!important;margin-bottom:24px!important;padding-bottom:.12em!important;font-size:0!important;line-height:1.06!important;letter-spacing:-.06em!important;overflow:visible!important}
+.landing-hero-copy h1::before{content:"Turn Your Work";display:block;color:#fff;font-size:clamp(3.2rem,6vw,6.2rem);font-weight:950;line-height:1.04}
+.landing-hero-copy h1::after{content:"Into Opportunities.";display:block;padding-bottom:.12em;background:linear-gradient(90deg,var(--brag-blue),var(--brag-cyan) 48%,var(--brag-purple));-webkit-background-clip:text;background-clip:text;color:transparent;font-size:clamp(3.2rem,6vw,6.2rem);font-weight:950;line-height:1.08;overflow:visible}
 .landing-hero-copy h1 span{display:none!important}
 .landing-hero-description{max-width:610px!important}
 .landing-btn{background:linear-gradient(100deg,var(--brag-purple),var(--brag-blue),var(--brag-cyan))!important;color:white!important;box-shadow:0 14px 38px rgba(64,101,255,.28)!important}
@@ -37,9 +37,10 @@
 }
 
 @media(max-width:700px){
-  .landing-hero-copy{padding-top:78px}
+  .landing-hero-copy{padding-top:108px}
   .landing-hero-copy::before{padding-left:66px;min-height:58px;font-size:2.6rem}
   .landing-hero-copy::after{width:54px;height:54px}
-  .landing-eyebrow{top:58px;left:67px}
-  .landing-hero-copy h1{margin-top:34px!important}
+  .landing-eyebrow{top:68px;left:67px;letter-spacing:.18em!important}
+  .landing-hero-copy h1{margin-top:18px!important}
+  .landing-hero-copy h1::before,.landing-hero-copy h1::after{line-height:1.08}
 }


### PR DESCRIPTION
Fixes the landing-brand issues shown in production and cleans up public contact routing.

- prevents the “Into Opportunities.” gradient line from being clipped
- moves “PROVE · GROW · GET HIRED” clearly below the BragStack wordmark instead of overlapping it
- adds more breathing room around the hero lockup on desktop and mobile
- replaces the broad personal-email runtime rewrite with role-based BragStack addresses
- routes privacy/legal/security/billing/support/contact links to their corresponding @usebragstack.com mailboxes

Separately, the updated Workspace Brand + Audit script package adds the actual BragStack logo, BragStack colors, tagline, website, and support address to the primary Gmail signature, and includes Workspace audit exports for login/admin/Drive/OAuth activity.