### PR TITLE
Rebalance landing hero proportions

### DIFF
--- a/frontend/src/ReferencePolish.css
+++ b/frontend/src/ReferencePolish.css
@@ -7,19 +7,21 @@
 .landing-nav{border-color:rgba(44,164,255,.18)!important;background:rgba(4,10,24,.86)!important}
 
 /* Hero brand lockup */
-.landing-hero{grid-template-columns:minmax(0,1.18fr) minmax(360px,.82fr)!important;align-items:center!important;padding-top:4.25rem!important;padding-bottom:3.5rem!important;gap:2.5rem!important;overflow:visible!important}
-.landing-hero-copy{position:relative;min-width:0;padding-top:112px;overflow:visible!important}
-.landing-hero-copy::before{content:"BragStack";position:absolute;top:0;left:0;padding-left:78px;min-height:66px;display:flex;align-items:center;background:linear-gradient(90deg,#fff 0 43%,var(--brag-cyan) 61%,var(--brag-purple) 100%);-webkit-background-clip:text;background-clip:text;color:transparent;font-size:clamp(2.65rem,4.6vw,4.7rem);font-weight:950;letter-spacing:-.065em;line-height:1;white-space:nowrap}
-.landing-hero-copy::after{content:"";position:absolute;top:0;left:0;width:64px;height:64px;background:url('/brandmark.svg') center/contain no-repeat;filter:drop-shadow(0 12px 28px rgba(70,80,255,.35))}
-.landing-eyebrow{position:absolute;top:73px;left:79px;margin:0!important;padding:0!important;border:0!important;background:transparent!important;color:#aebbd2!important;font-size:0!important;letter-spacing:.22em!important;line-height:1.4!important;white-space:nowrap}
+.landing-hero{grid-template-columns:minmax(0,1.05fr) minmax(390px,.95fr)!important;align-items:center!important;padding-top:3.5rem!important;padding-bottom:3rem!important;gap:3rem!important;overflow:visible!important}
+.landing-hero-copy{position:relative;min-width:0;padding-top:102px;overflow:visible!important}
+.landing-hero-copy::before{content:"BragStack";position:absolute;top:0;left:0;padding-left:70px;min-height:58px;display:flex;align-items:center;background:linear-gradient(90deg,#fff 0 43%,var(--brag-cyan) 61%,var(--brag-purple) 100%);-webkit-background-clip:text;background-clip:text;color:transparent;font-size:clamp(2.35rem,3.8vw,3.9rem);font-weight:950;letter-spacing:-.06em;line-height:1;white-space:nowrap}
+.landing-hero-copy::after{content:"";position:absolute;top:1px;left:0;width:56px;height:56px;background:url('/brandmark.svg') center/contain no-repeat;filter:drop-shadow(0 10px 24px rgba(70,80,255,.32))}
+.landing-eyebrow{position:absolute;top:64px;left:71px;margin:0!important;padding:0!important;border:0!important;background:transparent!important;color:#aebbd2!important;font-size:0!important;letter-spacing:.2em!important;line-height:1.4!important;white-space:nowrap}
 .landing-eyebrow svg{display:none!important}
-.landing-eyebrow::before{content:"PROVE  •  GROW  •  GET HIRED";font-size:.66rem;font-weight:900}
+.landing-eyebrow::before{content:"PROVE  •  GROW  •  GET HIRED";font-size:.61rem;font-weight:900}
 
-.landing-hero-copy h1{max-width:760px!important;margin:18px 0 20px!important;padding:0 0 .1em!important;font-size:0!important;line-height:1.03!important;letter-spacing:-.06em!important;overflow:visible!important}
-.landing-hero-copy h1::before{content:"Turn Your Work";display:block;color:#fff;font-size:clamp(3rem,5.2vw,5.25rem);font-weight:950;line-height:1.02}
-.landing-hero-copy h1::after{content:"Into Opportunities.";display:block;max-width:100%;padding:0 0 .08em;background:linear-gradient(90deg,var(--brag-blue),var(--brag-cyan) 48%,var(--brag-purple));-webkit-background-clip:text;background-clip:text;color:transparent;font-size:clamp(3rem,5.2vw,5.25rem);font-weight:950;line-height:1.04;letter-spacing:-.055em;overflow:visible;white-space:normal}
+.landing-hero-copy h1{max-width:690px!important;margin:24px 0 18px!important;padding:0 0 .08em!important;font-size:0!important;line-height:1.02!important;letter-spacing:-.055em!important;overflow:visible!important}
+.landing-hero-copy h1::before{content:"Turn Your Work";display:block;color:#fff;font-size:clamp(3.05rem,4.35vw,4.55rem);font-weight:950;line-height:1.02;white-space:nowrap}
+.landing-hero-copy h1::after{content:"Into Opportunities.";display:block;padding:0 0 .08em;background:linear-gradient(90deg,var(--brag-blue),var(--brag-cyan) 48%,var(--brag-purple));-webkit-background-clip:text;background-clip:text;color:transparent;font-size:clamp(3.05rem,4.35vw,4.55rem);font-weight:950;line-height:1.03;letter-spacing:-.05em;overflow:visible;white-space:nowrap}
 .landing-hero-copy h1 span{display:none!important}
-.landing-hero-description{max-width:650px!important;margin-top:1.4rem!important}
+.landing-hero-description{max-width:625px!important;margin-top:1.25rem!important;font-size:1.05rem!important;line-height:1.7!important}
+.landing-hero-actions{margin-top:1.7rem!important}
+.landing-trust-line{margin-top:1rem!important}
 .landing-btn{background:linear-gradient(100deg,var(--brag-purple),var(--brag-blue),var(--brag-cyan))!important;color:white!important;box-shadow:0 14px 38px rgba(64,101,255,.28)!important}
 .landing-btn-secondary{background:rgba(6,15,35,.72)!important;border-color:rgba(73,175,255,.28)!important}
 
@@ -31,20 +33,30 @@
 .sidebar-add{background:linear-gradient(90deg,var(--brag-purple),var(--brag-blue),var(--brag-cyan))!important;color:#fff!important}
 
 /* Tablet/mobile */
+@media(max-width:1100px){
+  .landing-hero-copy h1::before,.landing-hero-copy h1::after{font-size:clamp(2.9rem,5.3vw,4.1rem)}
+}
+
 @media(max-width:980px){
   .mobile-app-bar{justify-content:flex-start!important;gap:10px!important}
   .mobile-app-bar>button{order:-1!important;flex:0 0 auto!important}
   .mobile-brand{margin-right:auto!important}
-  .landing-hero{grid-template-columns:1fr!important;padding-top:3.5rem!important;gap:1.5rem!important}
+  .landing-hero{grid-template-columns:1fr!important;padding-top:3rem!important;gap:1.5rem!important}
   .landing-proof-preview{min-height:410px!important}
+  .landing-hero-copy h1{max-width:760px!important}
+}
+
+@media(max-width:760px){
+  .landing-hero-copy h1::before,.landing-hero-copy h1::after{white-space:normal}
 }
 
 @media(max-width:700px){
-  .landing-hero-copy{padding-top:100px}
-  .landing-hero-copy::before{padding-left:64px;min-height:54px;font-size:2.45rem}
-  .landing-hero-copy::after{width:52px;height:52px}
-  .landing-eyebrow{top:62px;left:65px;letter-spacing:.16em!important}
-  .landing-eyebrow::before{font-size:.58rem}
-  .landing-hero-copy h1{margin-top:14px!important}
-  .landing-hero-copy h1::before,.landing-hero-copy h1::after{font-size:clamp(2.7rem,13vw,4rem);line-height:1.03}
+  .landing-hero-copy{padding-top:94px}
+  .landing-hero-copy::before{padding-left:62px;min-height:50px;font-size:2.25rem}
+  .landing-hero-copy::after{width:50px;height:50px}
+  .landing-eyebrow{top:58px;left:63px;letter-spacing:.15em!important}
+  .landing-eyebrow::before{font-size:.56rem}
+  .landing-hero-copy h1{margin-top:16px!important}
+  .landing-hero-copy h1::before,.landing-hero-copy h1::after{font-size:clamp(2.55rem,12vw,3.65rem);line-height:1.04}
+  .landing-hero-description{font-size:.98rem!important}
 }


### PR DESCRIPTION
Tightens the BragStack landing hero after the latest production screenshots:

- reduces the oversized hero headline
- keeps “Turn Your Work” and “Into Opportunities.” visually balanced
- scales down the BragStack hero lockup
- gives the tagline more separation from the wordmark
- improves left/right column balance
- tightens hero spacing and CTA rhythm
- preserves responsive wrapping on smaller screens

This is a visual-only follow-up to PR #62.