### PR TITLE
Show internal BragStack accounts as Pro

### DIFF
--- a/backend/app/plans.py
+++ b/backend/app/plans.py
@@ -37,12 +37,16 @@ def is_internal_user(user: dict) -> bool:
 
 
 def get_plan_for_user(user: dict) -> str:
+    """Internal users present as Pro so existing UI plan checks behave correctly."""
     if is_internal_user(user):
-        return "enterprise"
+        return "pro"
     return normalize_plan(user.get("plan"))
 
 
 def get_entitlements_for_user(user: dict) -> dict[str, Any]:
+    """Internal users receive the complete feature set, including future staff testing gates."""
+    if is_internal_user(user):
+        return dict(PLAN_FEATURES["enterprise"])
     return dict(PLAN_FEATURES[get_plan_for_user(user)])
 
 


### PR DESCRIPTION
Fixes the UI mismatch for verified @usebragstack.com accounts. Internal accounts now report plan=pro so existing frontend checks show PRO and hide Upgrade to Pro, while retaining the complete internal entitlement set server-side.