### PR TITLE
Add production health and readiness endpoints

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta, timezone
 from bson import ObjectId
 from fastapi import Depends, FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
+from pymongo.errors import PyMongoError
 
 from app.auth import get_current_user
 from app.auth_routes import router as auth_router
@@ -13,7 +14,7 @@ from app.beta_metrics_routes import router as beta_metrics_router
 from app.certification_packet_export_routes import router as certification_packet_export_router
 from app.certification_packet_routes import router as certification_packet_router
 from app.core_output_routes import router as core_output_router
-from app.database import entries_collection, impact_receipts_collection
+from app.database import client as mongo_client, entries_collection, impact_receipts_collection
 from app.impact_receipt_routes import router as impact_receipts_router
 from app.receipt_verification_routes import router as receipt_verification_router
 from app.interview_packet_export_routes import router as interview_packet_export_router
@@ -86,3 +87,15 @@ app.include_router(certification_packet_export_router)
 
 @app.get("/")
 def root(): return {"message":"BragStack API is running"}
+
+@app.get("/health")
+def health():
+    return {"status": "ok"}
+
+@app.get("/ready")
+def ready():
+    try:
+        mongo_client.admin.command("ping")
+    except PyMongoError as exc:
+        raise HTTPException(status_code=503, detail="Service is not ready") from exc
+    return {"status": "ready"}

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -1,0 +1,36 @@
+from fastapi.testclient import TestClient
+from pymongo.errors import ServerSelectionTimeoutError
+
+import app.main as main
+
+
+client = TestClient(main.app)
+
+
+def test_health_reports_process_alive():
+    response = client.get("/health")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+def test_ready_reports_ready_when_mongo_responds(monkeypatch):
+    monkeypatch.setattr(main.mongo_client.admin, "command", lambda command: {"ok": 1.0})
+
+    response = client.get("/ready")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ready"}
+
+
+def test_ready_fails_safely_when_mongo_is_unavailable(monkeypatch):
+    def fail_ping(command):
+        raise ServerSelectionTimeoutError("mongodb unavailable")
+
+    monkeypatch.setattr(main.mongo_client.admin, "command", fail_ping)
+
+    response = client.get("/ready")
+
+    assert response.status_code == 503
+    assert response.json() == {"detail": "Service is not ready"}
+    assert "mongodb" not in response.text.lower()


### PR DESCRIPTION
## Summary
Starts #83 by adding explicit production health/readiness probes.

- Adds `GET /health` as a lightweight liveness check.
- Adds `GET /ready` with a MongoDB `ping` dependency check.
- Returns a generic 503 response when MongoDB is unavailable so infrastructure details are not exposed.
- Adds tests for healthy, ready, and dependency-failure behavior.

## Follow-up after merge
Render still needs `healthCheckPath` configured and external uptime/error alerting added before #83 is fully complete.

Closes part of #83.