### PR TITLE
Add tested MongoDB restore validation harness

### DIFF
--- a/backend/app/restore_validation.py
+++ b/backend/app/restore_validation.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+REQUIRED_COLLECTIONS = {
+    "users",
+    "entries",
+    "impact_receipts",
+    "packet_export_audit",
+    "packet_shares",
+    "beta_feedback",
+}
+
+
+@dataclass
+class RestoreValidationResult:
+    passed: bool
+    checks: dict[str, bool] = field(default_factory=dict)
+    errors: list[str] = field(default_factory=list)
+    counts: dict[str, int] = field(default_factory=dict)
+
+
+def _fail(result: RestoreValidationResult, check: str, message: str) -> None:
+    result.checks[check] = False
+    result.errors.append(message)
+    result.passed = False
+
+
+def validate_restored_database(db: Any) -> RestoreValidationResult:
+    """Validate an isolated restored BragStack database.
+
+    This performs read-only structural, ownership, and privacy checks. It is
+    intentionally provider-agnostic so the same validator can be used for
+    Atlas or another managed MongoDB provider after a real snapshot restore.
+    """
+    result = RestoreValidationResult(passed=True)
+
+    available = set(db.list_collection_names())
+    missing = sorted(REQUIRED_COLLECTIONS - available)
+    result.checks["required_collections_present"] = not missing
+    if missing:
+        _fail(
+            result,
+            "required_collections_present",
+            f"Missing required collections: {', '.join(missing)}",
+        )
+        return result
+
+    for name in sorted(REQUIRED_COLLECTIONS):
+        result.counts[name] = db[name].count_documents({})
+
+    users = {str(doc["_id"]) for doc in db["users"].find({}, {"_id": 1})}
+    result.checks["users_readable"] = True
+
+    owner_collections = (
+        "entries",
+        "impact_receipts",
+        "packet_export_audit",
+        "packet_shares",
+        "beta_feedback",
+    )
+    ownership_ok = True
+    for collection_name in owner_collections:
+        for doc in db[collection_name].find({"user_id": {"$exists": True}}):
+            user_id = str(doc.get("user_id", ""))
+            if not user_id or user_id not in users:
+                ownership_ok = False
+                result.errors.append(
+                    f"{collection_name} contains an orphaned user_id"
+                )
+    result.checks["ownership_integrity"] = ownership_ok
+    if not ownership_ok:
+        result.passed = False
+
+    source_links_ok = True
+    for receipt in db["impact_receipts"].find(
+        {"source_entry_id": {"$exists": True, "$ne": None}},
+        {"source_entry_id": 1, "user_id": 1},
+    ):
+        entry_id = receipt.get("source_entry_id")
+        entry = None
+        try:
+            from bson import ObjectId
+
+            if ObjectId.is_valid(str(entry_id)):
+                entry = db["entries"].find_one({"_id": ObjectId(str(entry_id))})
+        except Exception:
+            entry = None
+        if entry is None:
+            entry = db["entries"].find_one({"_id": entry_id})
+        if entry and str(entry.get("user_id")) != str(receipt.get("user_id")):
+            source_links_ok = False
+            result.errors.append(
+                "impact_receipts contains a source entry owned by another user"
+            )
+    result.checks["receipt_source_ownership"] = source_links_ok
+    if not source_links_ok:
+        result.passed = False
+
+    privacy_ok = True
+    for collection_name in ("entries", "impact_receipts"):
+        for doc in db[collection_name].find({"is_public": {"$exists": True}}):
+            if not isinstance(doc.get("is_public"), bool):
+                privacy_ok = False
+                result.errors.append(
+                    f"{collection_name} contains a non-boolean is_public value"
+                )
+
+    for receipt in db["impact_receipts"].find({"evidence": {"$type": "array"}}):
+        for evidence in receipt.get("evidence", []):
+            if "is_public" in evidence and not isinstance(evidence.get("is_public"), bool):
+                privacy_ok = False
+                result.errors.append(
+                    "impact_receipts evidence contains a non-boolean is_public value"
+                )
+
+    result.checks["privacy_flags_valid"] = privacy_ok
+    if not privacy_ok:
+        result.passed = False
+
+    result.checks["collections_readable"] = True
+    return result

--- a/backend/scripts/validate_restore.py
+++ b/backend/scripts/validate_restore.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+from pymongo import MongoClient
+
+from app.restore_validation import validate_restored_database
+
+
+def main() -> int:
+    if os.getenv("RESTORE_DRILL_CONFIRM_ISOLATED", "").lower() != "true":
+        print(
+            "Refusing to run: set RESTORE_DRILL_CONFIRM_ISOLATED=true only for an isolated non-production restore target.",
+            file=sys.stderr,
+        )
+        return 2
+
+    restore_url = os.getenv("RESTORE_MONGO_URL", "").strip()
+    db_name = os.getenv("RESTORE_DB_NAME", "bragstack").strip() or "bragstack"
+    production_url = os.getenv("MONGO_URL", "").strip()
+
+    if not restore_url:
+        print("RESTORE_MONGO_URL is required.", file=sys.stderr)
+        return 2
+
+    if production_url and restore_url == production_url:
+        print(
+            "Refusing to validate: restore target matches MONGO_URL. Never run a restore drill against production.",
+            file=sys.stderr,
+        )
+        return 2
+
+    client = MongoClient(restore_url, serverSelectionTimeoutMS=5000)
+    try:
+        client.admin.command("ping")
+        result = validate_restored_database(client[db_name])
+    finally:
+        client.close()
+
+    # Deliberately output only non-sensitive validation metadata.
+    print(
+        json.dumps(
+            {
+                "passed": result.passed,
+                "checks": result.checks,
+                "counts": result.counts,
+                "errors": result.errors,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0 if result.passed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/test_restore_validation.py
+++ b/backend/tests/test_restore_validation.py
@@ -1,0 +1,130 @@
+import mongomock
+from bson import ObjectId
+
+from app.restore_validation import REQUIRED_COLLECTIONS, validate_restored_database
+
+
+def _restored_db():
+    client = mongomock.MongoClient()
+    db = client["bragstack_restore_test"]
+    for name in REQUIRED_COLLECTIONS:
+        db.create_collection(name)
+    return db
+
+
+def test_restore_validator_passes_valid_restored_database():
+    db = _restored_db()
+    user_id = ObjectId()
+    entry_id = ObjectId()
+
+    db.users.insert_one({"_id": user_id, "email": "restore@example.com"})
+    db.entries.insert_one(
+        {
+            "_id": entry_id,
+            "user_id": str(user_id),
+            "title": "Restored accomplishment",
+            "is_public": False,
+        }
+    )
+    db.impact_receipts.insert_one(
+        {
+            "_id": ObjectId(),
+            "user_id": str(user_id),
+            "source_entry_id": str(entry_id),
+            "is_public": True,
+            "evidence": [{"title": "Private proof", "is_public": False}],
+        }
+    )
+
+    result = validate_restored_database(db)
+
+    assert result.passed is True
+    assert all(result.checks.values())
+    assert result.counts["users"] == 1
+    assert result.counts["entries"] == 1
+    assert result.counts["impact_receipts"] == 1
+    assert result.errors == []
+
+
+def test_restore_validator_fails_when_required_collection_is_missing():
+    db = _restored_db()
+    db.drop_collection("packet_shares")
+
+    result = validate_restored_database(db)
+
+    assert result.passed is False
+    assert result.checks["required_collections_present"] is False
+    assert any("packet_shares" in error for error in result.errors)
+
+
+def test_restore_validator_fails_for_orphaned_user_owned_record():
+    db = _restored_db()
+    db.entries.insert_one(
+        {
+            "_id": ObjectId(),
+            "user_id": str(ObjectId()),
+            "title": "Orphan",
+            "is_public": False,
+        }
+    )
+
+    result = validate_restored_database(db)
+
+    assert result.passed is False
+    assert result.checks["ownership_integrity"] is False
+    assert any("orphaned user_id" in error for error in result.errors)
+
+
+def test_restore_validator_fails_cross_user_receipt_source_link():
+    db = _restored_db()
+    owner_a = ObjectId()
+    owner_b = ObjectId()
+    entry_id = ObjectId()
+
+    db.users.insert_many([{"_id": owner_a}, {"_id": owner_b}])
+    db.entries.insert_one(
+        {"_id": entry_id, "user_id": str(owner_a), "is_public": False}
+    )
+    db.impact_receipts.insert_one(
+        {
+            "_id": ObjectId(),
+            "user_id": str(owner_b),
+            "source_entry_id": str(entry_id),
+            "is_public": False,
+            "evidence": [],
+        }
+    )
+
+    result = validate_restored_database(db)
+
+    assert result.passed is False
+    assert result.checks["receipt_source_ownership"] is False
+    assert any("another user" in error for error in result.errors)
+
+
+def test_restore_validator_fails_invalid_privacy_flags():
+    db = _restored_db()
+    user_id = ObjectId()
+
+    db.users.insert_one({"_id": user_id})
+    db.entries.insert_one(
+        {
+            "_id": ObjectId(),
+            "user_id": str(user_id),
+            "is_public": "false",
+        }
+    )
+    db.impact_receipts.insert_one(
+        {
+            "_id": ObjectId(),
+            "user_id": str(user_id),
+            "is_public": False,
+            "evidence": [{"is_public": "false"}],
+        }
+    )
+
+    result = validate_restored_database(db)
+
+    assert result.passed is False
+    assert result.checks["privacy_flags_valid"] is False
+    assert sum("non-boolean is_public" in error for error in result.errors) == 2


### PR DESCRIPTION
## Summary
Starts the implementation side of #81 by adding a provider-agnostic, read-only post-restore validation harness and automated tests.

### What this adds
- Validates all required BragStack MongoDB collections exist after a restore.
- Records non-sensitive document counts for restore evidence.
- Detects orphaned user-linked records.
- Detects Impact Receipts linked to entries owned by another user.
- Validates public/private flags remain boolean and structurally intact.
- Adds a CLI that runs only against an explicitly confirmed isolated restore target.
- Refuses to run if `RESTORE_MONGO_URL` matches production `MONGO_URL`.
- Never prints connection strings or credentials.
- Adds automated pass/fail tests for the validator.

### Tests added
- valid restored database passes
- missing required collection fails
- orphaned user-owned record fails
- cross-user receipt/source-entry linkage fails
- invalid privacy flags fail

## Important
This PR does **not** claim the production restore drill has been completed. #81 must remain open until a real provider backup/snapshot is restored into an isolated non-production target and this validator plus application smoke tests pass against it, with measured RPO/RTO evidence recorded internally.

Part of #81.