### PR TITLE
Harden auth recovery against account enumeration

### DIFF
--- a/backend/app/auth_routes.py
+++ b/backend/app/auth_routes.py
@@ -85,9 +85,15 @@ async def register_user(payload: RegisterRequest):
     return {"verification_required":True,"email_sent":sent,"message":"Account created. Check your email to verify your account."}
 @router.post("/email-verification/resend")
 async def resend_email_verification(payload: EmailVerificationRequest):
+    message = {"message":"If that account needs verification, a new email has been sent."}
     email=payload.email.lower().strip(); user=users_collection.find_one({"email":email})
-    if not user or user.get("email_verified_at") or not user.get("email_verification_required",False): return {"message":"If that account needs verification, a new email has been sent."}
-    raw,_=_issue_verification_token(user); await _send_verification_email(email,f"{FRONTEND_URL}/login#verify_token={raw}"); return {"message":"If that account needs verification, a new email has been sent."}
+    if not user or user.get("email_verified_at") or not user.get("email_verification_required",False): return message
+    raw,_=_issue_verification_token(user)
+    try:
+        await _send_verification_email(email,f"{FRONTEND_URL}/login#verify_token={raw}")
+    except HTTPException:
+        pass
+    return message
 @router.post("/email-verification/confirm")
 def confirm_email_verification(payload: EmailVerificationConfirm):
     user=users_collection.find_one({"email_verification_token_hash":_hash_token(payload.token)})
@@ -105,10 +111,15 @@ def login_user(form_data: OAuth2PasswordRequestForm=Depends()):
     return {"access_token":create_access_token({"sub":str(user["_id"])}),"token_type":"bearer","user":serialize_user(user)}
 @router.post("/password-reset/request")
 async def request_password_reset(payload: PasswordResetRequest):
+    message = {"message":"If that email belongs to an account, a reset link has been sent."}
     email=payload.email.lower().strip(); user=users_collection.find_one({"email":email})
-    if not user: return {"message":"If that email belongs to an account, a reset link has been sent."}
+    if not user: return message
     raw=secrets.token_urlsafe(48); expires=datetime.now(timezone.utc)+timedelta(minutes=30); users_collection.update_one({"_id":user["_id"]},{"$set":{"password_reset_token_hash":_hash_token(raw),"password_reset_expires_at":expires.isoformat()}})
-    await _send_password_reset_email(email,f"{FRONTEND_URL}/login#reset_token={raw}"); return {"message":"If that email belongs to an account, a reset link has been sent."}
+    try:
+        await _send_password_reset_email(email,f"{FRONTEND_URL}/login#reset_token={raw}")
+    except HTTPException:
+        pass
+    return message
 @router.post("/password-reset/confirm")
 def confirm_password_reset(payload: PasswordResetConfirm):
     user=users_collection.find_one({"password_reset_token_hash":_hash_token(payload.token)})

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,0 +1,55 @@
+import mongomock
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+import app.auth_routes as auth_routes
+from app.main import app
+
+
+client = TestClient(app)
+
+
+def _mock_users(monkeypatch):
+    mock_client = mongomock.MongoClient()
+    collection = mock_client["bragstack_test"]["users"]
+    monkeypatch.setattr(auth_routes, "users_collection", collection)
+    return collection
+
+
+def test_password_reset_request_hides_existing_account_when_email_delivery_fails(monkeypatch):
+    users = _mock_users(monkeypatch)
+    users.insert_one({"email": "person@example.com"})
+
+    async def fail_send(email, url):
+        raise HTTPException(status_code=502, detail="Email could not be sent.")
+
+    monkeypatch.setattr(auth_routes, "_send_password_reset_email", fail_send)
+
+    existing = client.post("/auth/password-reset/request", json={"email": "person@example.com"})
+    missing = client.post("/auth/password-reset/request", json={"email": "missing@example.com"})
+
+    assert existing.status_code == 200
+    assert missing.status_code == 200
+    assert existing.json() == missing.json()
+
+
+def test_verification_resend_hides_existing_account_when_email_delivery_fails(monkeypatch):
+    users = _mock_users(monkeypatch)
+    users.insert_one(
+        {
+            "email": "person@example.com",
+            "email_verification_required": True,
+        }
+    )
+
+    async def fail_send(email, url):
+        raise HTTPException(status_code=502, detail="Email could not be sent.")
+
+    monkeypatch.setattr(auth_routes, "_send_verification_email", fail_send)
+
+    existing = client.post("/auth/email-verification/resend", json={"email": "person@example.com"})
+    missing = client.post("/auth/email-verification/resend", json={"email": "missing@example.com"})
+
+    assert existing.status_code == 200
+    assert missing.status_code == 200
+    assert existing.json() == missing.json()


### PR DESCRIPTION
## Summary
Production sweep found an account-enumeration side channel in email recovery flows: when Resend failed, a real account could receive a 5xx response while a nonexistent account received the generic 200 response.

This PR:
- keeps password-reset request responses identical whether an account exists or email delivery fails
- keeps verification-resend responses identical whether an account exists or email delivery fails
- adds regression tests covering both cases
- fills the previously empty `backend/tests/test_auth.py` with meaningful auth privacy coverage

## Why
Public recovery endpoints should not reveal account existence through provider failure behavior.

## Validation
- existing/missing password-reset requests now return the same 200 response when email delivery fails
- existing/missing verification-resend requests now return the same 200 response when email delivery fails

Part of production reliability/security sweep.