### PR TITLE
Add tested core MongoDB indexes

### DIFF
--- a/backend/app/indexes.py
+++ b/backend/app/indexes.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from pymongo import ASCENDING, DESCENDING
+
+
+def ensure_core_indexes(db) -> dict[str, list[str]]:
+    """Create BragStack's core MongoDB indexes idempotently.
+
+    This function is intentionally not executed at import time. Operators run
+    the companion script during deployment/maintenance so tests and local app
+    imports never mutate a production database implicitly.
+    """
+    created: dict[str, list[str]] = {}
+
+    users = db["users"]
+    created["users"] = [
+        users.create_index(
+            [("email", ASCENDING)],
+            name="uniq_users_email",
+            unique=True,
+        ),
+        users.create_index(
+            [("public_slug", ASCENDING)],
+            name="uniq_users_public_slug",
+            unique=True,
+            sparse=True,
+        ),
+    ]
+
+    entries = db["entries"]
+    created["entries"] = [
+        entries.create_index(
+            [("user_id", ASCENDING), ("created_at", DESCENDING)],
+            name="entries_user_created",
+        ),
+        entries.create_index(
+            [("user_id", ASCENDING), ("is_public", ASCENDING), ("created_at", DESCENDING)],
+            name="entries_user_public_created",
+        ),
+    ]
+
+    receipts = db["impact_receipts"]
+    created["impact_receipts"] = [
+        receipts.create_index(
+            [("user_id", ASCENDING), ("created_at", DESCENDING)],
+            name="receipts_user_created",
+        ),
+        receipts.create_index(
+            [("user_id", ASCENDING), ("is_public", ASCENDING), ("created_at", DESCENDING)],
+            name="receipts_user_public_created",
+        ),
+        receipts.create_index(
+            [("source_entry_id", ASCENDING)],
+            name="receipts_source_entry",
+        ),
+    ]
+
+    return created

--- a/backend/scripts/ensure_core_indexes.py
+++ b/backend/scripts/ensure_core_indexes.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import os
+import sys
+
+from pymongo import MongoClient
+
+from app.indexes import ensure_core_indexes
+
+
+def main() -> int:
+    mongo_url = os.getenv("MONGO_URL", "").strip()
+    db_name = os.getenv("MONGO_DB_NAME", "bragstack").strip() or "bragstack"
+    if not mongo_url:
+        print("MONGO_URL is required.", file=sys.stderr)
+        return 2
+
+    client = MongoClient(mongo_url, serverSelectionTimeoutMS=5000)
+    try:
+        client.admin.command("ping")
+        created = ensure_core_indexes(client[db_name])
+    finally:
+        client.close()
+
+    # Index names are safe operational metadata; never print MONGO_URL.
+    for collection, names in created.items():
+        print(f"{collection}: {', '.join(names)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/test_core_indexes.py
+++ b/backend/tests/test_core_indexes.py
@@ -1,0 +1,59 @@
+import mongomock
+import pytest
+from pymongo.errors import DuplicateKeyError
+
+from app.indexes import ensure_core_indexes
+
+
+def test_core_indexes_are_created_with_expected_shapes():
+    db = mongomock.MongoClient()["bragstack_test"]
+
+    created = ensure_core_indexes(db)
+
+    assert set(created) == {"users", "entries", "impact_receipts"}
+
+    user_indexes = db.users.index_information()
+    assert user_indexes["uniq_users_email"]["key"] == [("email", 1)]
+    assert user_indexes["uniq_users_email"]["unique"] is True
+    assert user_indexes["uniq_users_public_slug"]["key"] == [("public_slug", 1)]
+    assert user_indexes["uniq_users_public_slug"]["unique"] is True
+
+    entry_indexes = db.entries.index_information()
+    assert entry_indexes["entries_user_created"]["key"] == [("user_id", 1), ("created_at", -1)]
+    assert entry_indexes["entries_user_public_created"]["key"] == [
+        ("user_id", 1),
+        ("is_public", 1),
+        ("created_at", -1),
+    ]
+
+    receipt_indexes = db.impact_receipts.index_information()
+    assert receipt_indexes["receipts_user_created"]["key"] == [("user_id", 1), ("created_at", -1)]
+    assert receipt_indexes["receipts_source_entry"]["key"] == [("source_entry_id", 1)]
+
+
+def test_unique_email_index_rejects_duplicate_accounts():
+    db = mongomock.MongoClient()["bragstack_test"]
+    ensure_core_indexes(db)
+    db.users.insert_one({"email": "person@example.com", "public_slug": "person-a"})
+
+    with pytest.raises(DuplicateKeyError):
+        db.users.insert_one({"email": "person@example.com", "public_slug": "person-b"})
+
+
+def test_sparse_public_slug_allows_missing_values_but_rejects_duplicate_slug():
+    db = mongomock.MongoClient()["bragstack_test"]
+    ensure_core_indexes(db)
+    db.users.insert_many([{"email": "one@example.com"}, {"email": "two@example.com"}])
+    db.users.insert_one({"email": "three@example.com", "public_slug": "same-slug"})
+
+    with pytest.raises(DuplicateKeyError):
+        db.users.insert_one({"email": "four@example.com", "public_slug": "same-slug"})
+
+
+def test_index_creation_is_idempotent():
+    db = mongomock.MongoClient()["bragstack_test"]
+
+    first = ensure_core_indexes(db)
+    second = ensure_core_indexes(db)
+
+    assert first == second


### PR DESCRIPTION
## Summary
Production sweep found that `users`, `entries`, and `impact_receipts` only had MongoDB's default `_id` index. That makes common production queries degrade to collection scans as BragStack grows and leaves email/public-slug uniqueness enforced only in application code.

### Changes
- add idempotent core index definitions
- add an explicit operator migration script (never runs implicitly at import/startup)
- add unique `users.email`
- add sparse unique `users.public_slug`
- add user/time and user/public/time indexes for entries and Impact Receipts
- add `impact_receipts.source_entry_id` index
- add tests for index shapes, uniqueness guarantees, sparse slug behavior, and idempotency

### Production safety checks already completed
- no duplicate exact email groups found
- no case-insensitive duplicate email groups found
- no duplicate non-empty public slugs found

## Important
Merging this PR does **not** automatically mutate production. The migration script must be run explicitly after CI is green and the deploy is healthy.