### PR TITLE
Handle Render HEAD probes cleanly

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -91,6 +91,10 @@ app.include_router(certification_packet_export_router)
 @app.get("/")
 def root(): return {"message":"BragStack API is running"}
 
+@app.head("/", include_in_schema=False)
+def root_head():
+    return None
+
 @app.get("/health")
 def health():
     return {"status": "ok"}

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -7,6 +7,13 @@ import app.main as main
 client = TestClient(main.app)
 
 
+def test_root_supports_head_probe():
+    response = client.head("/")
+
+    assert response.status_code == 200
+    assert response.text == ""
+
+
 def test_health_reports_process_alive():
     response = client.get("/health")
 


### PR DESCRIPTION
## Summary
Production logs show Render probing `HEAD /` and receiving `405 Method Not Allowed` even though the API is healthy.

This PR:
- adds an explicit `HEAD /` route returning 200
- keeps the existing `GET /` response unchanged
- adds regression coverage for the probe behavior

This removes noisy false-negative probe responses without changing application behavior.