### PR TITLE
Harden production OAuth callback URLs

### DIFF
--- a/backend/app/oauth_routes.py
+++ b/backend/app/oauth_routes.py
@@ -14,6 +14,7 @@ from app.database import users_collection
 router = APIRouter(prefix="/auth", tags=["auth"])
 
 FRONTEND_URL = os.getenv("FRONTEND_URL", "http://localhost:5173").rstrip("/")
+OAUTH_CALLBACK_BASE_URL = os.getenv("OAUTH_CALLBACK_BASE_URL", "").rstrip("/")
 GOOGLE_CLIENT_ID = os.getenv("GOOGLE_CLIENT_ID", "")
 GOOGLE_CLIENT_SECRET = os.getenv("GOOGLE_CLIENT_SECRET", "")
 GITHUB_CLIENT_ID = os.getenv("GITHUB_CLIENT_ID", "")
@@ -54,6 +55,8 @@ def _require_credentials(provider: str) -> None:
 
 
 def _redirect_uri(request: Request, provider: str) -> str:
+    if OAUTH_CALLBACK_BASE_URL:
+        return f"{OAUTH_CALLBACK_BASE_URL}/auth/{provider}/callback"
     return str(request.url_for(f"{provider}_callback"))
 
 

--- a/backend/tests/test_oauth_routes.py
+++ b/backend/tests/test_oauth_routes.py
@@ -1,0 +1,47 @@
+from fastapi import Request
+
+import app.oauth_routes as oauth_routes
+
+
+def _request(url: str = "http://internal-service/auth/google/login") -> Request:
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "scheme": "http",
+        "path": "/auth/google/login",
+        "raw_path": b"/auth/google/login",
+        "query_string": b"",
+        "headers": [(b"host", b"internal-service")],
+        "client": ("127.0.0.1", 12345),
+        "server": ("internal-service", 80),
+    }
+    return Request(scope)
+
+
+def test_redirect_uri_uses_explicit_callback_base(monkeypatch):
+    monkeypatch.setattr(
+        oauth_routes,
+        "OAUTH_CALLBACK_BASE_URL",
+        "https://bragstack-api-bxf3.onrender.com",
+    )
+    request = _request()
+
+    assert oauth_routes._redirect_uri(request, "google") == (
+        "https://bragstack-api-bxf3.onrender.com/auth/google/callback"
+    )
+    assert oauth_routes._redirect_uri(request, "github") == (
+        "https://bragstack-api-bxf3.onrender.com/auth/github/callback"
+    )
+
+
+def test_redirect_uri_falls_back_to_request_url_for_local_dev(monkeypatch):
+    monkeypatch.setattr(oauth_routes, "OAUTH_CALLBACK_BASE_URL", "")
+
+    class FakeRequest:
+        def url_for(self, name):
+            return f"http://localhost:8000/{name}"
+
+    request = FakeRequest()
+
+    assert oauth_routes._redirect_uri(request, "google") == "http://localhost:8000/google_callback"
+    assert oauth_routes._redirect_uri(request, "github") == "http://localhost:8000/github_callback"


### PR DESCRIPTION
## Summary
- add an explicit `OAUTH_CALLBACK_BASE_URL` for production OAuth callbacks
- use the same stable callback URI for both authorization and token exchange
- preserve request-derived callbacks for local development
- add regression tests for Google and GitHub callback URI construction

## Production
Render is configured with `OAUTH_CALLBACK_BASE_URL=https://bragstack-api-bxf3.onrender.com` and trusted forwarded headers.

This addresses the Google 400 malformed-request flow observed behind the Render proxy.