### PR TITLE
Fix marketing footer placement

### DIFF
--- a/frontend/src/MarketingFooterOrder.css
+++ b/frontend/src/MarketingFooterOrder.css
@@ -1,0 +1,25 @@
+/* Homepage composition hotfix: RootContent appends marketing showcase sections after
+   LandingPage, while LandingPage owns the mega footer. Flatten the LandingPage box
+   into the homepage flex flow so the footer can be visually ordered after every
+   appended marketing section. */
+#root:has(> .landing-page) {
+  display: flex;
+  min-height: 100vh;
+  flex-direction: column;
+  overflow: hidden;
+  color: var(--landing-text);
+  background:
+    radial-gradient(circle at 15% 5%, rgba(58, 171, 214, 0.17), transparent 28rem),
+    radial-gradient(circle at 90% 10%, rgba(157, 81, 255, 0.16), transparent 30rem),
+    var(--landing-bg);
+}
+
+#root:has(> .landing-page) > .landing-page {
+  display: contents;
+}
+
+#root:has(> .landing-page) > .landing-page > .mega-footer {
+  order: 999;
+  width: 100%;
+  margin-top: auto;
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -4,6 +4,7 @@ import { createRoot } from "react-dom/client";
 import "./index.css";
 import "./ProductPolish.css";
 import "./ReferencePolish.css";
+import "./MarketingFooterOrder.css";
 import RootContent from "./RootContent.jsx";
 import { initializeAnalytics } from "./analytics.js";
 


### PR DESCRIPTION
## Fix
Keep the marketing-page mega footer at the true bottom of the homepage, after the Interview showcase, Resume Builder showcase, and search sitelink section.

## Root cause
`LandingPage` owns the footer, while `RootContent` appends newer marketing sections after the whole `LandingPage`, so the footer appeared before those sections.

## Change
Use a homepage-scoped layout rule to flatten the LandingPage box into the homepage flow and explicitly order the mega footer last, preserving the existing marketing content and styles.

## Scope
- 1 small CSS file
- 1 CSS import
- no API/backend behavior changes