### PR TITLE
Restore interview and resume marketing showcases

### DIFF
--- a/frontend/src/RootContent.jsx
+++ b/frontend/src/RootContent.jsx
@@ -7,9 +7,12 @@ import DashboardPage from "./DashboardPage.jsx";
 import DocsPage from "./DocsPage.jsx";
 import ImpactReceiptsPage from "./ImpactReceiptsPage.jsx";
 import InterviewPracticeExperience from "./InterviewPracticeExperience.jsx";
+import LandingInterviewShowcase from "./LandingInterviewShowcase.jsx";
+import LandingResumeShowcase from "./LandingResumeShowcase.jsx";
 import ReceiptVerificationCenter from "./ReceiptVerificationCenter.jsx";
 import ReceiptVerificationPage from "./ReceiptVerificationPage.jsx";
 import ResumeBuilderPage from "./ResumeBuilderPage.jsx";
+import SearchSitelinksNav from "./SearchSitelinksNav.jsx";
 import { PrivacyPolicyPage, PublicFooter, TermsPage } from "./LegalPages.jsx";
 import NDAGuidancePage from "./NDAGuidancePage.jsx";
 import ProductTour from "./ProductTour.jsx";
@@ -99,7 +102,7 @@ function RootContent() {
   if (isDocsPage) return <><DocsPage /><PublicFooter /></>;
   if (isNdaPage) return <><NDAGuidancePage /><PublicFooter /></>;
   if (seoLandingContent) return <SeoLandingPage content={seoLandingContent} />;
-  if (path === "/") return <App />;
+  if (path === "/") return <><App /><LandingInterviewShowcase /><LandingResumeShowcase /><SearchSitelinksNav /></>;
 
   let Content = App;
   let contentProps = {};


### PR DESCRIPTION
Restores the existing Practice Interviewer and Resume Builder showcases to the marketing homepage after the rollback removed their RootContent mounting. Keeps the current interview implementation and other main changes intact.