### PR TITLE
Make Aisha visible and start the interview automatically on iPad/iOS

### DIFF
--- a/frontend/src/AnimatedInterviewerAvatar.jsx
+++ b/frontend/src/AnimatedInterviewerAvatar.jsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import bundledAishaJordanInterviewer from "./assets/aisha-jordan-interviewer.jpg";
 
 const STATE_COPY = {
@@ -9,31 +8,57 @@ const STATE_COPY = {
   encouraging: "Follow-up coaching",
 };
 
-export default function AnimatedInterviewerAvatar({ state = "idle", name = "Aisha Jordan", reducedMotion = false, onReady }) {
-  const safeState = STATE_COPY[state] ? state : "idle";
-  const [photoSrc, setPhotoSrc] = useState(bundledAishaJordanInterviewer);
+const rootStyle = {
+  position: "absolute",
+  inset: 0,
+  width: "100%",
+  height: "100%",
+  minWidth: "100%",
+  minHeight: "100%",
+  display: "block",
+  overflow: "hidden",
+  backgroundImage: `url(${bundledAishaJordanInterviewer})`,
+  backgroundSize: "cover",
+  backgroundPosition: "center 42%",
+  backgroundRepeat: "no-repeat",
+};
 
-  const handlePhotoError = () => {
-    if (photoSrc !== "/assets/aisha-interviewer-concept.jpg") {
-      setPhotoSrc("/assets/aisha-interviewer-concept.jpg");
-    }
-  };
+const photoStyle = {
+  position: "absolute",
+  inset: 0,
+  width: "100%",
+  height: "100%",
+  display: "block",
+  opacity: 1,
+  visibility: "visible",
+  objectFit: "cover",
+  objectPosition: "center 42%",
+};
+
+export default function AnimatedInterviewerAvatar({ state = "idle", name = "Aisha Jordan", reducedMotion = false }) {
+  const safeState = STATE_COPY[state] ? state : "idle";
 
   return (
-    <div className={`animated-interviewer-avatar photo-interviewer state-${safeState} ${reducedMotion ? "reduced-motion" : ""}`} role="img" aria-label={`${name}, virtual interviewer, ${STATE_COPY[safeState]}`}>
+    <div
+      className={`animated-interviewer-avatar photo-interviewer state-${safeState} ${reducedMotion ? "reduced-motion" : ""}`}
+      role="img"
+      aria-label={`${name}, virtual interviewer, ${STATE_COPY[safeState]}`}
+      style={rootStyle}
+    >
       <img
         className="aisha-interviewer-photo"
-        src={photoSrc}
-        onLoad={() => onReady?.()}
-        onError={handlePhotoError}
+        src={bundledAishaJordanInterviewer}
         alt="Aisha Jordan, BragStack virtual interviewer"
+        draggable="false"
+        style={photoStyle}
       />
       <img
         className="aisha-mouth-motion"
-        src={photoSrc}
-        onError={handlePhotoError}
+        src={bundledAishaJordanInterviewer}
         alt=""
         aria-hidden="true"
+        draggable="false"
+        style={{ ...photoStyle, opacity: safeState === "speaking" && !reducedMotion ? undefined : 0 }}
       />
       <div className="aisha-photo-vignette" />
       <div className="aisha-speaking-glow" aria-hidden="true" />

--- a/frontend/src/InterviewPracticePage.jsx
+++ b/frontend/src/InterviewPracticePage.jsx
@@ -1,6 +1,8 @@
 import { useEffect, useMemo, useRef, useState } from "react";
+import { flushSync } from "react-dom";
 import { AlertTriangle, Camera, CameraOff, CheckCircle2, ChevronRight, Clock3, Mic, RefreshCw, Sparkles, Star, Volume2 } from "lucide-react";
 import AnimatedInterviewerAvatar from "./AnimatedInterviewerAvatar.jsx";
+import aishaJordanPhoto from "./assets/aisha-jordan-interviewer.jpg";
 import { getImpactReceipts } from "./api.js";
 import { EXPERIENCE_LEVELS, INTERVIEW_TYPES } from "./interviewKnowledgeBase.js";
 import { analyzeAnswer, buildInterviewPlan, getBrowserInterviewCapabilities, summarizeInterview } from "./interviewEngine.js";
@@ -14,6 +16,9 @@ const INTRO_SEGMENTS = [
   "When your time ends, you’ll hear a soft chime and I’ll let you know. At the end, you’ll get your score, strengths, and specific ways to improve.",
   "Take your time and be yourself. Ready? Let’s begin.",
 ];
+const INTRO_PAUSE_MS = 2000;
+
+let cachedSoftVoice = null;
 
 function prettyDimension(value = "") {
   return value.replaceAll("_", " ").replace(/\b\w/g, (character) => character.toUpperCase());
@@ -24,59 +29,39 @@ function saveHistory(session) {
     const current = JSON.parse(localStorage.getItem(HISTORY_KEY) || "[]");
     localStorage.setItem(HISTORY_KEY, JSON.stringify([session, ...current].slice(0, 8)));
   } catch {
-    // Interview practice stays available if browser storage is unavailable.
+    // Storage should never block interview practice.
   }
-}
-
-function recentQuestionIds(roleTitle) {
-  try {
-    const normalized = roleTitle.trim().toLowerCase();
-    const current = JSON.parse(localStorage.getItem(HISTORY_KEY) || "[]");
-    return current.filter((session) => String(session?.roleTitle || "").trim().toLowerCase() === normalized).flatMap((session) => Array.isArray(session?.questionIds) ? session.questionIds : []).filter(Boolean);
-  } catch {
-    return [];
-  }
-}
-
-function slugifyRole(value = "") {
-  return String(value).toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
-}
-
-function interviewApiBase() {
-  if (window.location.hostname.endsWith(".app.github.dev")) return "/api";
-  return import.meta.env.VITE_API_BASE_URL || import.meta.env.VITE_API_URL || "http://localhost:8000";
-}
-
-async function getRotatedCatalogQuestions(roleTitle, count, excludeIds = []) {
-  const slug = slugifyRole(roleTitle);
-  if (!slug) throw new Error("Missing role slug");
-  const params = new URLSearchParams({ count: String(count), seed: `${Date.now()}` });
-  if (excludeIds.length) params.set("exclude", [...new Set(excludeIds)].join(","));
-  const token = localStorage.getItem("bragstack_token");
-  const response = await fetch(`${interviewApiBase()}/interview-catalog/careers/${encodeURIComponent(slug)}/questions?${params.toString()}`, { headers: token ? { Authorization: `Bearer ${token}` } : {} });
-  if (!response.ok) throw new Error(`Interview catalog returned ${response.status}`);
-  return response.json();
 }
 
 function formatTime(seconds) {
   const safe = Math.max(0, Number(seconds) || 0);
   const minutes = Math.floor(safe / 60);
-  const remainder = safe % 60;
-  return `${minutes}:${String(remainder).padStart(2, "0")}`;
+  return `${minutes}:${String(safe % 60).padStart(2, "0")}`;
 }
 
 function wait(ms) {
   return new Promise((resolve) => window.setTimeout(resolve, ms));
 }
 
-function pickSoftVoice() {
-  const voices = window.speechSynthesis?.getVoices?.() || [];
-  const preferred = ["Ava (Premium)", "Samantha (Enhanced)", "Ava", "Samantha", "Serena", "Tessa", "Moira", "Microsoft Aria Online", "Microsoft Aria", "Google US English"];
-  return preferred.map((name) => voices.find((voice) => voice.name.includes(name) && voice.lang?.startsWith("en"))).find(Boolean)
+function chooseSoftVoice(voices = []) {
+  const preferred = ["Samantha", "Ava", "Serena", "Tessa", "Moira", "Nicky", "Karen", "Microsoft Aria", "Google US English"];
+  return preferred.map((name) => voices.find((voice) => voice.lang?.startsWith("en") && voice.name.includes(name))).find(Boolean)
     || voices.find((voice) => voice.lang?.startsWith("en-US") && /premium|enhanced|natural|neural/i.test(voice.name))
     || voices.find((voice) => voice.lang?.startsWith("en-US"))
     || voices.find((voice) => voice.lang?.startsWith("en"))
     || null;
+}
+
+function warmSpeechVoices() {
+  const synth = window.speechSynthesis;
+  if (!synth?.getVoices) return () => {};
+  const refresh = () => {
+    const next = chooseSoftVoice(synth.getVoices());
+    if (next) cachedSoftVoice = next;
+  };
+  refresh();
+  synth.addEventListener?.("voiceschanged", refresh);
+  return () => synth.removeEventListener?.("voiceschanged", refresh);
 }
 
 function speakSoftText(text, { cancelFirst = false } = {}) {
@@ -88,11 +73,14 @@ function speakSoftText(text, { cancelFirst = false } = {}) {
     }
     if (cancelFirst) synth.cancel();
     const utterance = new SpeechSynthesisUtterance(text);
-    const voice = pickSoftVoice();
-    if (voice) utterance.voice = voice;
-    utterance.rate = 0.84;
-    utterance.pitch = 0.98;
-    utterance.volume = 0.9;
+    const voice = cachedSoftVoice || chooseSoftVoice(synth.getVoices?.() || []);
+    if (voice) {
+      cachedSoftVoice = voice;
+      utterance.voice = voice;
+    }
+    utterance.rate = 0.92;
+    utterance.pitch = 0.99;
+    utterance.volume = 0.86;
     let settled = false;
     const finish = (spoken) => {
       if (settled) return;
@@ -102,7 +90,8 @@ function speakSoftText(text, { cancelFirst = false } = {}) {
     utterance.onend = () => finish(true);
     utterance.onerror = () => finish(false);
     synth.speak(utterance);
-    window.setTimeout(() => finish(false), Math.max(14000, text.length * 150));
+    synth.resume?.();
+    window.setTimeout(() => finish(false), Math.max(12000, text.length * 125));
   });
 }
 
@@ -118,7 +107,7 @@ function playSoftChime() {
       oscillator.type = "sine";
       oscillator.frequency.value = frequency;
       gain.gain.setValueAtTime(0.0001, now + index * 0.12);
-      gain.gain.exponentialRampToValueAtTime(0.055, now + index * 0.12 + 0.018);
+      gain.gain.exponentialRampToValueAtTime(0.05, now + index * 0.12 + 0.018);
       gain.gain.exponentialRampToValueAtTime(0.0001, now + index * 0.12 + 0.28);
       oscillator.connect(gain);
       gain.connect(context.destination);
@@ -127,7 +116,7 @@ function playSoftChime() {
     });
     window.setTimeout(() => context.close?.(), 800);
   } catch {
-    // Audio polish must never block the interview.
+    // Chime polish must never block the interview.
   }
 }
 
@@ -139,8 +128,8 @@ export default function InterviewPracticePage() {
   const [questionIndex, setQuestionIndex] = useState(0);
   const [answer, setAnswer] = useState("");
   const [feedback, setFeedback] = useState(null);
-  const [fatalResponse, setFatalResponse] = useState(null);
   const [responses, setResponses] = useState([]);
+  const [fatalResponse, setFatalResponse] = useState(null);
   const [followUpActive, setFollowUpActive] = useState(false);
   const [followUpPrompt, setFollowUpPrompt] = useState("");
   const [followUpUsed, setFollowUpUsed] = useState(false);
@@ -152,16 +141,23 @@ export default function InterviewPracticePage() {
   const [cameraError, setCameraError] = useState("");
   const [listening, setListening] = useState(false);
   const [interviewPhase, setInterviewPhaseState] = useState("idle");
-  const [aishaReady, setAishaReady] = useState(false);
-  const [speechBlocked, setSpeechBlocked] = useState(false);
+  const [audioError, setAudioError] = useState("");
+
   const videoRef = useRef(null);
   const recognitionRef = useRef(null);
   const answerRef = useRef("");
-  const timeoutHandledRef = useRef(false);
   const phaseRef = useRef("idle");
+  const timerRunningRef = useRef(false);
   const sequenceBusyRef = useRef(false);
-  const greetingCompleteRef = useRef(false);
+  const timeoutHandledRef = useRef(false);
+  const autoListenRef = useRef(false);
+  const activeRef = useRef(true);
+
   const capabilities = useMemo(() => getBrowserInterviewCapabilities(window), []);
+  const currentQuestion = plan?.questions?.[questionIndex] || null;
+  const currentPrompt = followUpActive ? followUpPrompt : currentQuestion?.text || "";
+  const responseSeconds = Math.max(60, Number(setup.responseMinutes) * 60 || 180);
+  const avatarState = interviewPhase === "listening" ? "listening" : interviewPhase === "reviewing" ? "thinking" : interviewPhase === "transition" ? "encouraging" : interviewPhase === "speaking" ? "speaking" : "idle";
 
   function setInterviewPhase(value) {
     phaseRef.current = value;
@@ -169,8 +165,26 @@ export default function InterviewPracticePage() {
   }
 
   useEffect(() => {
+    activeRef.current = true;
+    const preload = new Image();
+    preload.src = aishaJordanPhoto;
+    const cleanupVoices = warmSpeechVoices();
+    return () => {
+      activeRef.current = false;
+      cleanupVoices();
+      recognitionRef.current?.stop?.();
+      cameraStream?.getTracks().forEach((track) => track.stop());
+      window.speechSynthesis?.cancel?.();
+    };
+  }, [cameraStream]);
+
+  useEffect(() => {
     answerRef.current = answer;
   }, [answer]);
+
+  useEffect(() => {
+    timerRunningRef.current = timerRunning;
+  }, [timerRunning]);
 
   useEffect(() => {
     let active = true;
@@ -182,138 +196,201 @@ export default function InterviewPracticePage() {
     if (videoRef.current && cameraStream) videoRef.current.srcObject = cameraStream;
   }, [cameraStream, stage]);
 
-  useEffect(() => () => {
-    cameraStream?.getTracks().forEach((track) => track.stop());
-    recognitionRef.current?.stop?.();
-    window.speechSynthesis?.cancel?.();
-  }, [cameraStream]);
-
-  const currentQuestion = plan?.questions?.[questionIndex] || null;
-  const currentPrompt = followUpActive ? followUpPrompt : currentQuestion?.text || "";
-  const responseSeconds = Math.max(60, Number(setup.responseMinutes) * 60 || 180);
-  const avatarState = interviewPhase === "listening" ? "listening" : interviewPhase === "reviewing" ? "thinking" : interviewPhase === "transition" ? "encouraging" : interviewPhase === "speaking" ? "speaking" : "idle";
-
-  function updateSetup(event) {
-    const { name, value, type, checked } = event.target;
-    setSetup((current) => ({ ...current, [name]: type === "checkbox" ? checked : value }));
-  }
-
-  function beginResponseClock() {
-    timeoutHandledRef.current = false;
-    setSecondsLeft(responseSeconds);
-    setQuestionStartedAt(Date.now());
-    setTimerRunning(true);
-  }
-
-  async function askPrompt(prompt, { restartClock = true } = {}) {
-    if (!prompt) return false;
-    const shouldResume = !restartClock && timerRunning;
-    stopDictation();
-    setTimerRunning(false);
-    setSpeechBlocked(false);
-    setInterviewPhase("speaking");
-    const spoken = await speakSoftText(prompt, { cancelFirst: true });
-    if (!spoken) {
-      setInterviewPhase("idle");
-      setSpeechBlocked(true);
-      return false;
-    }
-    if (restartClock) {
-      beginResponseClock();
-      setInterviewPhase("listening");
-      window.setTimeout(() => {
-        if (phaseRef.current === "listening") dictateAnswer();
-      }, 350);
-    } else if (shouldResume) {
-      setTimerRunning(true);
-      setInterviewPhase("listening");
-      window.setTimeout(() => {
-        if (phaseRef.current === "listening") dictateAnswer();
-      }, 350);
-    } else {
-      setInterviewPhase("idle");
-    }
-    return true;
-  }
-
-  function speakPrompt({ restartClock = true } = {}) {
-    if (!currentPrompt || sequenceBusyRef.current) return;
-    sequenceBusyRef.current = true;
-    void askPrompt(currentPrompt, { restartClock }).finally(() => { sequenceBusyRef.current = false; });
-  }
-
-  async function runGreetingAndFirstQuestion() {
-    if (sequenceBusyRef.current || greetingCompleteRef.current || !aishaReady || !currentPrompt) return;
-    sequenceBusyRef.current = true;
-    setSpeechBlocked(false);
-    stopDictation();
-    setTimerRunning(false);
-    setInterviewPhase("speaking");
-    window.speechSynthesis?.cancel?.();
-    await wait(700);
-    for (let index = 0; index < INTRO_SEGMENTS.length; index += 1) {
-      const spoken = await speakSoftText(INTRO_SEGMENTS[index]);
-      if (!spoken) {
-        setInterviewPhase("idle");
-        setSpeechBlocked(true);
-        sequenceBusyRef.current = false;
-        return;
-      }
-      if (index < INTRO_SEGMENTS.length - 1) await wait(5000);
-    }
-    greetingCompleteRef.current = true;
-    await wait(5000);
-    const spoken = await askPrompt(currentPrompt, { restartClock: true });
-    if (!spoken) setSpeechBlocked(true);
-    sequenceBusyRef.current = false;
-  }
-
-  async function retryAishaSpeech() {
-    if (sequenceBusyRef.current) return;
-    if (!greetingCompleteRef.current) {
-      await runGreetingAndFirstQuestion();
-      return;
-    }
-    sequenceBusyRef.current = true;
-    await askPrompt(currentPrompt, { restartClock: true });
-    sequenceBusyRef.current = false;
-  }
-
-  useEffect(() => {
-    if (stage !== "interview" || !aishaReady || !currentPrompt || greetingCompleteRef.current || sequenceBusyRef.current) return undefined;
-    const id = window.setTimeout(() => { void runGreetingAndFirstQuestion(); }, 350);
-    return () => window.clearTimeout(id);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [stage, aishaReady, currentPrompt]);
-
-  useEffect(() => {
-    if (stage !== "interview" || feedback || !currentPrompt || interviewPhase !== "transition" || sequenceBusyRef.current) return undefined;
-    const id = window.setTimeout(() => {
-      sequenceBusyRef.current = true;
-      void askPrompt(currentPrompt, { restartClock: true }).finally(() => { sequenceBusyRef.current = false; });
-    }, 900);
-    return () => window.clearTimeout(id);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [stage, currentPrompt, questionIndex, followUpActive, feedback, interviewPhase]);
-
   useEffect(() => {
     if (!timerRunning || stage !== "interview" || feedback) return undefined;
     const id = window.setInterval(() => setSecondsLeft((current) => Math.max(0, current - 1)), 1000);
     return () => window.clearInterval(id);
   }, [timerRunning, stage, feedback]);
 
-  function stopDictation() {
-    recognitionRef.current?.stop?.();
+  useEffect(() => {
+    if (stage !== "interview" || secondsLeft > 0 || feedback || timeoutHandledRef.current) return;
+    const id = window.setTimeout(() => { void handleTimeout(); }, 0);
+    return () => window.clearTimeout(id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [secondsLeft, stage, feedback]);
+
+  useEffect(() => {
+    if (stage !== "interview" || !feedback) return undefined;
+    const hasFollowUp = Boolean(feedback.followUp && !followUpUsed);
+    const id = window.setTimeout(() => {
+      if (hasFollowUp) beginFollowUp();
+      else nextQuestion();
+    }, hasFollowUp ? 8000 : 9000);
+    return () => window.clearTimeout(id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [feedback, followUpUsed, stage]);
+
+  function updateSetup(event) {
+    const { name, value, type, checked } = event.target;
+    setSetup((current) => ({ ...current, [name]: type === "checkbox" ? checked : value }));
+  }
+
+  function stopDictation({ disableAuto = true } = {}) {
+    if (disableAuto) autoListenRef.current = false;
+    try { recognitionRef.current?.stop?.(); } catch { /* ignore */ }
     recognitionRef.current = null;
     setListening(false);
+  }
+
+  function startDictation() {
+    if (!capabilities.speechRecognition || phaseRef.current !== "listening" || !timerRunningRef.current) return;
+    const Recognition = window.SpeechRecognition || window.webkitSpeechRecognition;
+    if (!Recognition || recognitionRef.current) return;
+    const recognition = new Recognition();
+    recognition.lang = "en-US";
+    recognition.interimResults = false;
+    recognition.continuous = true;
+    recognition.onresult = (event) => {
+      const transcript = Array.from(event.results).slice(event.resultIndex).map((result) => result[0]?.transcript || "").join(" ").trim();
+      if (transcript) setAnswer((current) => `${current} ${transcript}`.trim());
+    };
+    recognition.onerror = () => {
+      recognitionRef.current = null;
+      setListening(false);
+      autoListenRef.current = false;
+    };
+    recognition.onend = () => {
+      recognitionRef.current = null;
+      setListening(false);
+      if (autoListenRef.current && phaseRef.current === "listening" && timerRunningRef.current) {
+        window.setTimeout(() => startDictation(), 250);
+      }
+    };
+    recognitionRef.current = recognition;
+    try {
+      setListening(true);
+      recognition.start();
+    } catch {
+      recognitionRef.current = null;
+      setListening(false);
+    }
+  }
+
+  function beginResponseClock() {
+    timeoutHandledRef.current = false;
+    setSecondsLeft(responseSeconds);
+    setQuestionStartedAt(Date.now());
+    timerRunningRef.current = true;
+    setTimerRunning(true);
+    autoListenRef.current = true;
+    setInterviewPhase("listening");
+    window.setTimeout(() => {
+      if (phaseRef.current === "listening" && timerRunningRef.current) startDictation();
+    }, 250);
+  }
+
+  async function speakQuestion(prompt) {
+    if (!prompt) return false;
+    stopDictation();
+    timerRunningRef.current = false;
+    setTimerRunning(false);
+    setAudioError("");
+    setInterviewPhase("speaking");
+    let spoken = await speakSoftText(prompt);
+    if (!spoken) {
+      await wait(250);
+      spoken = await speakSoftText(prompt, { cancelFirst: true });
+    }
+    if (!spoken) {
+      setAudioError("Aisha’s voice could not start automatically on this browser. Tap Replay question once to continue.");
+      setInterviewPhase("idle");
+      return false;
+    }
+    beginResponseClock();
+    return true;
+  }
+
+  async function continueGreeting(firstSegmentPromise, firstQuestionPrompt) {
+    sequenceBusyRef.current = true;
+    setInterviewPhase("speaking");
+    let spoken = await firstSegmentPromise;
+    if (!spoken) {
+      await wait(200);
+      spoken = await speakSoftText(INTRO_SEGMENTS[0], { cancelFirst: true });
+    }
+    if (!spoken) {
+      setAudioError("Aisha’s voice could not start automatically on this browser. Tap Replay question once to continue.");
+      setInterviewPhase("idle");
+      sequenceBusyRef.current = false;
+      return;
+    }
+
+    for (let index = 1; index < INTRO_SEGMENTS.length; index += 1) {
+      await wait(INTRO_PAUSE_MS);
+      const ok = await speakSoftText(INTRO_SEGMENTS[index]);
+      if (!ok) {
+        setAudioError("Aisha’s intro was interrupted. Tap Replay question to continue with the interview question.");
+        break;
+      }
+    }
+
+    await wait(INTRO_PAUSE_MS);
+    await speakQuestion(firstQuestionPrompt);
+    sequenceBusyRef.current = false;
+  }
+
+  function startInterview(event) {
+    event.preventDefault();
+    if (!setup.roleTitle.trim()) return;
+    const nextPlan = buildInterviewPlan({ ...setup, receipts: setup.useReceipts ? receipts : [] });
+    const firstQuestionPrompt = nextPlan.questions?.[0]?.text || `Tell me about your background and what interests you in this ${setup.roleTitle} opportunity.`;
+
+    window.speechSynthesis?.cancel?.();
+    stopDictation();
+    sequenceBusyRef.current = true;
+    setAudioError("");
+
+    flushSync(() => {
+      setPlan(nextPlan);
+      setQuestionIndex(0);
+      setResponses([]);
+      setAnswer("");
+      setFeedback(null);
+      setFatalResponse(null);
+      setFollowUpActive(false);
+      setFollowUpPrompt("");
+      setFollowUpUsed(false);
+      setBaseAnswer("");
+      setSecondsLeft(responseSeconds);
+      setTimerRunning(false);
+      setListening(false);
+      setInterviewPhase("speaking");
+      setStage("interview");
+    });
+
+    // This first real sentence is intentionally started inside the user’s Start Interview gesture.
+    // That is the reliable iOS/Safari path; no separate “Start Aisha” button is needed.
+    const firstSegmentPromise = speakSoftText(INTRO_SEGMENTS[0], { cancelFirst: true });
+    void continueGreeting(firstSegmentPromise, firstQuestionPrompt);
+  }
+
+  async function replayQuestion() {
+    if (!currentPrompt || sequenceBusyRef.current) return;
+    sequenceBusyRef.current = true;
+    window.speechSynthesis?.cancel?.();
+    await speakQuestion(currentPrompt);
+    sequenceBusyRef.current = false;
+  }
+
+  async function handleTimeout() {
+    if (timeoutHandledRef.current) return;
+    timeoutHandledRef.current = true;
+    stopDictation();
+    timerRunningRef.current = false;
+    setTimerRunning(false);
+    setInterviewPhase("speaking");
+    playSoftChime();
+    await wait(450);
+    await speakSoftText("Okay, that’s time. Thank you.");
+    evaluateAnswer(answerRef.current, { timedOut: true });
   }
 
   function evaluateAnswer(rawAnswer, { timedOut = false } = {}) {
     if (!currentQuestion) return;
     stopDictation();
+    timerRunningRef.current = false;
     setTimerRunning(false);
     setInterviewPhase("reviewing");
-    const durationSeconds = Math.max(1, Math.round((Date.now() - questionStartedAt) / 1000));
     const responseText = String(rawAnswer || "").trim();
     const combinedAnswer = followUpActive ? `${baseAnswer} ${responseText}`.trim() : responseText;
     const nextFeedback = analyzeAnswer(combinedAnswer, {
@@ -321,13 +398,17 @@ export default function InterviewPracticePage() {
       competency: currentQuestion.competency,
       roleTitle: plan?.roleTitle || setup.roleTitle,
       jobDescription: plan?.jobDescription || setup.jobDescription,
-      durationSeconds,
+      durationSeconds: Math.max(1, Math.round((Date.now() - questionStartedAt) / 1000)),
     });
     if (timedOut) nextFeedback.timedOut = true;
     const response = { question: currentQuestion, answer: combinedAnswer, analysis: nextFeedback };
     setAnswer(combinedAnswer);
     setFeedback(nextFeedback);
-    if (followUpActive) { setFollowUpActive(false); setBaseAnswer(""); setFollowUpUsed(true); }
+    if (followUpActive) {
+      setFollowUpActive(false);
+      setBaseAnswer("");
+      setFollowUpUsed(true);
+    }
     if (nextFeedback.instantFail) {
       setFatalResponse(response);
       setResponses((current) => [...current, response]);
@@ -335,79 +416,63 @@ export default function InterviewPracticePage() {
     }
   }
 
-  async function handleTimeout() {
-    if (timeoutHandledRef.current) return;
-    timeoutHandledRef.current = true;
-    stopDictation();
-    setTimerRunning(false);
-    setInterviewPhase("speaking");
-    playSoftChime();
-    await wait(450);
-    await speakSoftText("Okay, that’s time. Thank you.", { cancelFirst: true });
-    evaluateAnswer(answerRef.current, { timedOut: true });
+  function submitAnswer(event) {
+    event.preventDefault();
+    if (!answer.trim() || !currentQuestion) return;
+    evaluateAnswer(answer);
   }
 
-  useEffect(() => {
-    if (stage !== "interview" || secondsLeft > 0 || feedback || timeoutHandledRef.current) return;
-    void handleTimeout();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [secondsLeft, stage, feedback]);
+  function beginFollowUp() {
+    if (!feedback?.followUp) return;
+    const prompt = feedback.followUp;
+    setBaseAnswer(answer);
+    setAnswer("");
+    setFollowUpPrompt(prompt);
+    setFeedback(null);
+    setFollowUpActive(true);
+    setFollowUpUsed(true);
+    setSecondsLeft(responseSeconds);
+    setInterviewPhase("transition");
+    window.setTimeout(() => { void speakQuestion(prompt); }, 350);
+  }
 
-  useEffect(() => {
-    if (stage !== "interview" || !feedback) return undefined;
-    // Feedback is created synchronously by evaluateAnswer; this keeps the visual avatar in review mode while the auto-advance timer runs.
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    setInterviewPhase("reviewing");
-    const hasFollowUp = Boolean(feedback.followUp && !followUpUsed);
-    const id = window.setTimeout(() => {
-      if (hasFollowUp) answerFollowUp();
-      else nextQuestion();
-    }, hasFollowUp ? 8000 : 9000);
-    return () => window.clearTimeout(id);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [feedback, followUpUsed, stage]);
-
-  async function startInterview(event) {
-    event.preventDefault();
-    if (!setup.roleTitle.trim()) return;
-    const fallbackPlan = buildInterviewPlan({ ...setup, receipts: setup.useReceipts ? receipts : [] });
-    let nextPlan = fallbackPlan;
-    try {
-      const desiredCount = Math.max(3, Math.min(15, Number(setup.questionCount) || 8));
-      const catalog = await getRotatedCatalogQuestions(setup.roleTitle, desiredCount, recentQuestionIds(setup.roleTitle));
-      const catalogQuestions = (catalog.questions || []).map((question) => ({ ...question, id: question.question_id, competency: String(question.competency || question.competencies?.[0] || question.category || "role_alignment").replaceAll("-", "_"), source: "mongo-catalog" }));
-      const personalized = fallbackPlan.questions.filter((question) => question.source === "impact-receipt" || question.source === "job-description");
-      const seen = new Set();
-      const questions = [...personalized, ...catalogQuestions].filter((question) => {
-        const key = question.id || question.question_id || question.text;
-        if (seen.has(key)) return false;
-        seen.add(key);
-        return true;
-      }).slice(0, desiredCount);
-      if (questions.length) nextPlan = { ...fallbackPlan, family: catalog.family || fallbackPlan.family, catalogVersion: catalog.catalog_version, questionCount: questions.length, questions };
-    } catch {
-      // Local interview plan remains available if the catalog is temporarily unavailable.
-    }
-    window.speechSynthesis?.cancel?.();
-    recognitionRef.current?.stop?.();
-    sequenceBusyRef.current = false;
-    greetingCompleteRef.current = false;
-    phaseRef.current = "idle";
-    setPlan(nextPlan);
-    setQuestionIndex(0);
-    setResponses([]);
+  function retryAnswer() {
     setAnswer("");
     setFeedback(null);
-    setFatalResponse(null);
+    setBaseAnswer("");
     setFollowUpActive(false);
+    setFollowUpPrompt("");
     setFollowUpUsed(false);
     setSecondsLeft(responseSeconds);
-    setTimerRunning(false);
-    setListening(false);
-    setAishaReady(false);
-    setSpeechBlocked(false);
-    setInterviewPhase("idle");
-    setStage("interview");
+    const prompt = currentQuestion?.text || "";
+    setInterviewPhase("transition");
+    window.setTimeout(() => { void speakQuestion(prompt); }, 350);
+  }
+
+  function nextQuestion() {
+    if (!feedback || !currentQuestion) return;
+    const nextResponses = [...responses, { question: currentQuestion, answer, analysis: feedback }];
+    setResponses(nextResponses);
+    setAnswer("");
+    setFeedback(null);
+    setBaseAnswer("");
+    setFollowUpActive(false);
+    setFollowUpPrompt("");
+    setFollowUpUsed(false);
+
+    if (questionIndex + 1 >= plan.questions.length) {
+      const summary = summarizeInterview(nextResponses);
+      saveHistory({ id: Date.now(), completedAt: new Date().toISOString(), roleTitle: plan.roleTitle, family: plan.family, interviewType: plan.interviewType, summary });
+      setStage("results");
+      return;
+    }
+
+    const nextIndex = questionIndex + 1;
+    const prompt = plan.questions[nextIndex]?.text || "";
+    setQuestionIndex(nextIndex);
+    setSecondsLeft(responseSeconds);
+    setInterviewPhase("transition");
+    window.setTimeout(() => { void speakQuestion(prompt); }, 350);
   }
 
   async function enableCamera() {
@@ -426,85 +491,11 @@ export default function InterviewPracticePage() {
     setCameraStream(null);
   }
 
-  function dictateAnswer() {
-    if (!capabilities.speechRecognition || listening || phaseRef.current !== "listening") return;
-    const Recognition = window.SpeechRecognition || window.webkitSpeechRecognition;
-    if (!Recognition) return;
-    const recognition = new Recognition();
-    recognition.lang = "en-US";
-    recognition.interimResults = false;
-    recognition.continuous = true;
-    recognition.onresult = (event) => {
-      const transcript = Array.from(event.results).slice(event.resultIndex).map((result) => result[0]?.transcript || "").join(" ").trim();
-      if (transcript) setAnswer((current) => `${current} ${transcript}`.trim());
-    };
-    recognition.onerror = () => setListening(false);
-    recognition.onend = () => setListening(false);
-    recognitionRef.current = recognition;
-    try {
-      setListening(true);
-      recognition.start();
-    } catch {
-      setListening(false);
-    }
-  }
-
-  function submitAnswer(event) {
-    event.preventDefault();
-    if (!answer.trim() || !currentQuestion) return;
-    evaluateAnswer(answer);
-  }
-
-  function answerFollowUp() {
-    if (!feedback?.followUp) return;
-    setBaseAnswer(answer);
-    setAnswer("");
-    setFollowUpPrompt(feedback.followUp);
-    setFeedback(null);
-    setFollowUpActive(true);
-    setFollowUpUsed(true);
-    setSecondsLeft(responseSeconds);
-    setInterviewPhase("transition");
-  }
-
-  function retryAnswer() {
-    setAnswer("");
-    setFeedback(null);
-    setBaseAnswer("");
-    setFollowUpActive(false);
-    setFollowUpPrompt("");
-    setFollowUpUsed(false);
-    setSecondsLeft(responseSeconds);
-    setInterviewPhase("transition");
-  }
-
-  function nextQuestion() {
-    if (!feedback || !currentQuestion) return;
-    const nextResponses = [...responses, { question: currentQuestion, answer, analysis: feedback }];
-    setResponses(nextResponses);
-    setAnswer("");
-    setFeedback(null);
-    setBaseAnswer("");
-    setFollowUpActive(false);
-    setFollowUpPrompt("");
-    setFollowUpUsed(false);
-    if (questionIndex + 1 >= plan.questions.length) {
-      const summary = summarizeInterview(nextResponses);
-      saveHistory({ id: Date.now(), completedAt: new Date().toISOString(), roleTitle: plan.roleTitle, family: plan.family, interviewType: plan.interviewType, questionIds: plan.questions.filter((question) => question.source === "mongo-catalog").map((question) => question.id), summary });
-      setStage("results");
-      return;
-    }
-    setQuestionIndex((index) => index + 1);
-    setSecondsLeft(responseSeconds);
-    setInterviewPhase("transition");
-  }
-
   function resetInterview() {
     disableCamera();
+    stopDictation();
     window.speechSynthesis?.cancel?.();
-    recognitionRef.current?.stop?.();
     sequenceBusyRef.current = false;
-    greetingCompleteRef.current = false;
     setStage("setup");
     setPlan(null);
     setResponses([]);
@@ -514,14 +505,14 @@ export default function InterviewPracticePage() {
     setFatalResponse(null);
     setTimerRunning(false);
     setListening(false);
-    setAishaReady(false);
-    setSpeechBlocked(false);
+    setAudioError("");
     setInterviewPhase("idle");
   }
 
   if (stage === "setup") return (
     <main className="interview-practice-page">
-      <header className="interview-page-header"><div><span className="interview-pro-badge"><Sparkles size={14} /> BRAGSTACK CAREER INTELLIGENCE™</span><h1>Practice Interview</h1><p>Aisha asks the questions out loud, times your response, evaluates the evidence in your answer, and tells you exactly what to improve.</p></div><div className="zero-cost-card"><strong>BragStack Intelligence</strong><span>Evidence-aware coaching personalized to your target role</span></div></header>
+      <img src={aishaJordanPhoto} alt="" aria-hidden="true" style={{ position: "absolute", width: 1, height: 1, opacity: 0, pointerEvents: "none" }} />
+      <header className="interview-page-header"><div><span className="interview-pro-badge"><Sparkles size={14} /> BRAGSTACK CAREER INTELLIGENCE™</span><h1>Practice Interview</h1><p>Aisha greets you, asks each question out loud, starts your timer only after she finishes, listens to your response, and gives specific coaching.</p></div><div className="zero-cost-card"><strong>BragStack Intelligence</strong><span>Evidence-aware coaching personalized to your target role</span></div></header>
       <section className="interview-setup-grid">
         <form className="interview-setup-card" onSubmit={startInterview}>
           <div className="section-kicker">BUILD YOUR INTERVIEW</div>
@@ -539,21 +530,34 @@ export default function InterviewPracticePage() {
           <label className="receipt-personalization"><input type="checkbox" name="useReceipts" checked={setup.useReceipts} onChange={updateSetup} /><span><strong>Personalize with my career proof</strong><small>{receipts.length ? `${receipts.length} Impact Receipt${receipts.length === 1 ? "" : "s"} available` : "No Impact Receipts loaded yet — the interview still works normally."}</small></span></label>
           <button className="start-interview-button" type="submit">Start practice interview <ChevronRight size={18} /></button>
         </form>
-        <aside className="interview-preview-card"><div className="preview-interviewer-window"><div className="interviewer-avatar">AJ</div><div><span>Aisha Jordan</span><strong>Senior Technical Recruiter</strong></div></div><div className="preview-question-card"><span>REAL INTERVIEW COACHING</span><p>Follow-ups target the missing part of your answer instead of simply asking the original question again.</p></div><div className="preview-capabilities"><div><CheckCircle2 size={17} /><span>Questions spoken automatically</span></div><div><CheckCircle2 size={17} /><span>1, 3, or 5 minute response timer</span></div><div><CheckCircle2 size={17} /><span>Specific strengths + improvements</span></div><div><CheckCircle2 size={17} /><span>Professional-language red flag warnings</span></div><div><CheckCircle2 size={17} /><span>1–5 star final interview rating</span></div><div><CheckCircle2 size={17} /><span>Actionable end-of-session coaching</span></div></div></aside>
+        <aside className="interview-preview-card"><div className="preview-interviewer-window"><div className="interviewer-avatar">AJ</div><div><span>Aisha Jordan</span><strong>Senior Technical Recruiter</strong></div></div><div className="preview-question-card"><span>REAL INTERVIEW COACHING</span><p>Follow-ups target the missing part of your answer instead of simply repeating the original question.</p></div><div className="preview-capabilities"><div><CheckCircle2 size={17} /><span>Automatic greeting + spoken questions</span></div><div><CheckCircle2 size={17} /><span>1, 3, or 5 minute response timer</span></div><div><CheckCircle2 size={17} /><span>Specific strengths + improvements</span></div><div><CheckCircle2 size={17} /><span>Professional-language red flag warnings</span></div><div><CheckCircle2 size={17} /><span>1–5 star final interview rating</span></div></div></aside>
       </section>
     </main>
   );
 
   if (stage === "failed") {
     const summary = summarizeInterview(responses);
-    return <main className="interview-practice-page"><section className="interview-fail-screen" role="alert"><AlertTriangle size={48} /><span>‼️ CRITICAL INTERVIEW WARNING</span><h1>Interview failed</h1><p>{fatalResponse?.analysis?.warning?.message || "A critical professional-language red flag was detected."}</p><div className="interview-fail-term">Flagged: {fatalResponse?.analysis?.warning?.terms?.join(", ")}</div><div className="interview-fail-coaching"><strong>How to fix it</strong><p>{fatalResponse?.analysis?.warning?.coaching}</p></div><div className="final-stars" aria-label={`${summary.stars} out of 5 stars`}>{[1,2,3,4,5].map((star) => <Star key={star} size={28} fill={star <= summary.stars ? "currentColor" : "none"} />)}</div><p className="fail-note">Practice score: {summary.overallScore}/100 · {summary.verdict}</p><button className="start-interview-button" type="button" onClick={resetInterview}><RefreshCw size={17} /> Restart interview</button></section></main>;
+    return <main className="interview-practice-page"><section className="interview-fail-screen" role="alert"><AlertTriangle size={48} /><span>‼️ CRITICAL INTERVIEW WARNING</span><h1>Interview failed</h1><p>{fatalResponse?.analysis?.warning?.message || "A critical professional-language red flag was detected."}</p><div className="interview-fail-term">Flagged: {fatalResponse?.analysis?.warning?.terms?.join(", ")}</div><div className="interview-fail-coaching"><strong>How to fix it</strong><p>{fatalResponse?.analysis?.warning?.coaching}</p></div><div className="final-stars" aria-label={`${summary.stars} out of 5 stars`}>{[1,2,3,4,5].map((star) => <Star key={star} size={28} fill={star <= summary.stars ? "currentColor" : "none"} />)}</div><button className="start-interview-button" type="button" onClick={resetInterview}><RefreshCw size={17} /> Restart interview</button></section></main>;
   }
 
   if (stage === "results") {
     const summary = summarizeInterview(responses);
-    const best = summary.bestAnswerIndex == null ? null : responses[summary.bestAnswerIndex];
-    return <main className="interview-practice-page"><header className="interview-results-hero"><span className="interview-pro-badge"><Sparkles size={14} /> INTERVIEW COMPLETE</span><h1>Your interview feedback</h1><div className="final-score-row"><div className="final-stars" aria-label={`${summary.stars} out of 5 stars`}>{[1,2,3,4,5].map((star) => <Star key={star} size={27} fill={star <= summary.stars ? "currentColor" : "none"} />)}</div><strong>{summary.overallScore}/100</strong></div><p>{plan.roleTitle} · {summary.overallLabel}</p><h2 className="final-verdict">{summary.verdict}</h2></header><section className="results-grid"><article className="result-card"><span>STRONGEST AREAS</span>{summary.strongestAreas.map((area) => <div className="result-line strong" key={area.name}><strong>{prettyDimension(area.name)}</strong><em>{area.score}/100 · {area.label}</em></div>)}</article><article className="result-card"><span>FOCUS NEXT</span>{summary.improvementAreas.map((area) => <div className="result-line" key={area.name}><strong>{prettyDimension(area.name)}</strong><em>{area.score}/100 · {area.label}</em></div>)}</article><article className="result-card compact-stats"><span>SESSION SIGNALS</span><div><strong>{summary.averageWords}</strong><small>avg. words / answer</small></div><div><strong>{summary.totalFillers}</strong><small>filler phrases detected</small></div></article></section><section className="pattern-card"><span>WHAT BRAGSTACK NOTICED</span>{summary.patterns.map((pattern) => <p key={pattern}>{pattern}</p>)}</section><section className="pattern-card recommendations-card"><span>EXACTLY WHAT TO IMPROVE NEXT</span>{summary.recommendations.map((recommendation) => <p key={recommendation}>→ {recommendation}</p>)}</section>{best && <section className="best-answer-card"><span>YOUR STRONGEST ANSWER</span><h2>{best.question.text}</h2><p>{best.answer}</p><div className="feedback-pill-row">{Object.entries(best.analysis.dimensions).map(([name, value]) => <span key={name}>{prettyDimension(name)} · {value.score}/100</span>)}</div></section>}<div className="results-actions"><button className="start-interview-button" type="button" onClick={resetInterview}><RefreshCw size={17} /> Practice another interview</button><a className="secondary-interview-button" href="/app/reports?packet=interview#packet-builder">Build my interview packet</a></div></main>;
+    return <main className="interview-practice-page"><header className="interview-results-hero"><span className="interview-pro-badge"><Sparkles size={14} /> INTERVIEW COMPLETE</span><h1>Your interview feedback</h1><div className="final-score-row"><div className="final-stars" aria-label={`${summary.stars} out of 5 stars`}>{[1,2,3,4,5].map((star) => <Star key={star} size={27} fill={star <= summary.stars ? "currentColor" : "none"} />)}</div><strong>{summary.overallScore}/100</strong></div><h2 className="final-verdict">{summary.verdict}</h2></header><section className="results-grid"><article className="result-card"><span>STRONGEST AREAS</span>{summary.strongestAreas.map((area) => <div className="result-line strong" key={area.name}><strong>{prettyDimension(area.name)}</strong><em>{area.score}/100 · {area.label}</em></div>)}</article><article className="result-card"><span>FOCUS NEXT</span>{summary.improvementAreas.map((area) => <div className="result-line" key={area.name}><strong>{prettyDimension(area.name)}</strong><em>{area.score}/100 · {area.label}</em></div>)}</article><article className="result-card compact-stats"><span>SESSION SIGNALS</span><div><strong>{summary.averageWords}</strong><small>avg. words / answer</small></div><div><strong>{summary.totalFillers}</strong><small>filler phrases detected</small></div></article></section><section className="pattern-card recommendations-card"><span>EXACTLY WHAT TO IMPROVE NEXT</span>{summary.recommendations.map((recommendation) => <p key={recommendation}>→ {recommendation}</p>)}</section><div className="results-actions"><button className="start-interview-button" type="button" onClick={resetInterview}><RefreshCw size={17} /> Practice another interview</button></div></main>;
   }
 
-  return <main className="interview-practice-page interview-room-page"><header className="interview-room-header"><div><span>{plan.roleTitle}</span><strong>Practice Interview with Aisha</strong></div><div className="question-progress"><span>Question {questionIndex + 1} of {plan.questions.length}</span><div><i style={{ width: `${((questionIndex + 1) / plan.questions.length) * 100}%` }} /></div></div></header><section className="interview-room-grid"><div className="interview-video-stage"><div className="virtual-interviewer"><AnimatedInterviewerAvatar state={avatarState} onReady={() => setAishaReady(true)} /><div className="animated-avatar-caption" aria-hidden="true"><strong>Aisha Jordan</strong><span>Senior Technical Recruiter</span></div></div><div className="candidate-video-tile">{cameraStream ? <video ref={videoRef} autoPlay muted playsInline /> : <div className="camera-placeholder"><CameraOff size={28} /><span>Your camera is off</span></div>}<div className="candidate-video-label">You</div></div><div className="video-controls">{cameraStream ? <button type="button" onClick={disableCamera}><CameraOff size={17} /> Camera off</button> : <button type="button" onClick={enableCamera} disabled={!capabilities.camera}><Camera size={17} /> Enable camera</button>}<button type="button" onClick={() => speakPrompt({ restartClock: false })} disabled={!capabilities.speechSynthesis || sequenceBusyRef.current}><Volume2 size={17} /> Replay question</button>{speechBlocked && <button type="button" onClick={() => { void retryAishaSpeech(); }}><Volume2 size={17} /> Start Aisha</button>}</div>{cameraError && <p className="camera-error">{cameraError}</p>}</div><div className="interview-answer-panel"><div className="question-box"><div className="question-meta-row"><span>{followUpActive ? "TARGETED FOLLOW-UP" : `QUESTION ${questionIndex + 1}`}</span><strong className={`response-timer ${secondsLeft <= 20 ? "urgent" : ""}`}><Clock3 size={16} /> {formatTime(secondsLeft)}</strong></div><h1>{currentPrompt}</h1>{followUpActive && <small>This follow-up targets the missing part of your previous answer. You do not need to repeat the whole story.</small>}{speechBlocked && <small>Aisha’s voice was blocked by the browser. Tap “Start Aisha” in the interview window to continue. The timer will not start until she finishes speaking.</small>}</div>{!feedback ? <form onSubmit={submitAnswer} className="answer-form"><label htmlFor="practice-answer">Your answer</label><textarea id="practice-answer" value={answer} onChange={(event) => setAnswer(event.target.value)} rows="9" placeholder="Answer naturally. Focus on the exact question, what YOU did, and what changed as a result." autoFocus /><div className="answer-tools">{capabilities.speechRecognition && (listening ? <button className="dictation-button active" type="button" onClick={stopDictation}><Mic size={17} /> Stop dictation</button> : <button className="dictation-button" type="button" onClick={dictateAnswer} disabled={interviewPhase !== "listening"}><Mic size={17} /> Speak answer</button>)}<span>{answer.trim() ? answer.trim().split(/\s+/).length : 0} words</span></div><button className="start-interview-button" type="submit" disabled={!answer.trim()}>Review my answer</button></form> : <section className="answer-feedback-panel">{feedback.timedOut && <div className="timeout-warning"><Clock3 size={18} /><span>Time expired. This answer was scored as submitted.</span></div>}<div className="feedback-heading"><div><span>ANSWER FEEDBACK</span><h2>{feedback.overallLabel}</h2></div><strong>{feedback.overallScore}/100</strong></div><div className="answer-coaching-grid"><article className="answer-strengths"><span>WHAT WORKED</span>{feedback.strengths.map((item) => <p key={item}>✓ {item}</p>)}</article><article className="answer-improvements"><span>HOW TO IMPROVE</span>{feedback.improvements.map((item) => <p key={item}>→ {item}</p>)}</article></div><div className="feedback-dimensions">{Object.entries(feedback.dimensions).map(([name, value]) => <article key={name}><div><strong>{prettyDimension(name)}</strong><span className={value.label === "Excellent" || value.label === "Strong" ? "strong" : value.label === "Developing" ? "developing" : "needs-detail"}>{value.score}/100 · {value.label}</span></div><p>{value.note}</p><small><b>Improve:</b> {value.improve}</small></article>)}</div>{feedback.followUp && !followUpUsed && <div className="follow-up-card"><span>TARGETED INTERVIEWER FOLLOW-UP</span><p>{feedback.followUp}</p><button type="button" onClick={answerFollowUp}>Answer targeted follow-up</button></div>}<div className="feedback-actions"><button className="secondary-interview-button" type="button" onClick={retryAnswer}>Try this answer again</button><button className="start-interview-button" type="button" onClick={nextQuestion}>{questionIndex + 1 >= plan.questions.length ? "Finish interview" : "Next question"} <ChevronRight size={17} /></button></div></section>}</div></section></main>;
+  return <main className="interview-practice-page interview-room-page">
+    <header className="interview-room-header"><div><span>{plan.roleTitle}</span><strong>Practice Interview with Aisha</strong></div><div className="question-progress"><span>Question {questionIndex + 1} of {plan.questions.length}</span><div><i style={{ width: `${((questionIndex + 1) / plan.questions.length) * 100}%` }} /></div></div></header>
+    <section className="interview-room-grid">
+      <div className="interview-video-stage">
+        <div className="virtual-interviewer"><AnimatedInterviewerAvatar state={avatarState} /><div className="animated-avatar-caption" aria-hidden="true"><strong>Aisha Jordan</strong><span>Senior Technical Recruiter</span></div></div>
+        <div className="candidate-video-tile">{cameraStream ? <video ref={videoRef} autoPlay muted playsInline /> : <div className="camera-placeholder"><CameraOff size={28} /><span>Your camera is off</span></div>}<div className="candidate-video-label">You</div></div>
+        <div className="video-controls">{cameraStream ? <button type="button" onClick={disableCamera}><CameraOff size={17} /> Camera off</button> : <button type="button" onClick={enableCamera} disabled={!capabilities.camera}><Camera size={17} /> Enable camera</button>}<button type="button" onClick={() => { void replayQuestion(); }} disabled={!capabilities.speechSynthesis || sequenceBusyRef.current}><Volume2 size={17} /> Replay question</button></div>
+        {cameraError && <p className="camera-error">{cameraError}</p>}
+      </div>
+      <div className="interview-answer-panel">
+        <div className="question-box"><div className="question-meta-row"><span>{followUpActive ? "TARGETED FOLLOW-UP" : `QUESTION ${questionIndex + 1}`}</span><strong className={`response-timer ${secondsLeft <= 20 && timerRunning ? "urgent" : ""}`}><Clock3 size={16} /> {formatTime(secondsLeft)}</strong></div><h1>{currentPrompt}</h1>{followUpActive && <small>This follow-up targets the missing part of your previous answer. You do not need to repeat the whole story.</small>}{audioError && <small>{audioError}</small>}</div>
+        {!feedback ? <form onSubmit={submitAnswer} className="answer-form"><label htmlFor="practice-answer">Your answer</label><textarea id="practice-answer" value={answer} onChange={(event) => setAnswer(event.target.value)} rows="9" placeholder="Answer naturally. Focus on the exact question, what YOU did, and what changed as a result." /><div className="answer-tools">{capabilities.speechRecognition && (listening ? <button className="dictation-button active" type="button" onClick={() => stopDictation()}><Mic size={17} /> Stop dictation</button> : <button className="dictation-button" type="button" onClick={() => { autoListenRef.current = true; startDictation(); }} disabled={interviewPhase !== "listening"}><Mic size={17} /> Speak answer</button>)}<span>{answer.trim() ? answer.trim().split(/\s+/).length : 0} words</span></div><button className="start-interview-button" type="submit" disabled={!answer.trim()}>Review my answer</button></form> : <section className="answer-feedback-panel">{feedback.timedOut && <div className="timeout-warning"><Clock3 size={18} /><span>Time expired. This answer was scored as submitted.</span></div>}<div className="feedback-heading"><div><span>ANSWER FEEDBACK</span><h2>{feedback.overallLabel}</h2></div><strong>{feedback.overallScore}/100</strong></div><div className="answer-coaching-grid"><article className="answer-strengths"><span>WHAT WORKED</span>{feedback.strengths.map((item) => <p key={item}>✓ {item}</p>)}</article><article className="answer-improvements"><span>HOW TO IMPROVE</span>{feedback.improvements.map((item) => <p key={item}>→ {item}</p>)}</article></div><div className="feedback-dimensions">{Object.entries(feedback.dimensions).map(([name, value]) => <article key={name}><div><strong>{prettyDimension(name)}</strong><span className={value.label === "Excellent" || value.label === "Strong" ? "strong" : value.label === "Developing" ? "developing" : "needs-detail"}>{value.score}/100 · {value.label}</span></div><p>{value.note}</p><small><b>Improve:</b> {value.improve}</small></article>)}</div>{feedback.followUp && !followUpUsed && <div className="follow-up-card"><span>TARGETED INTERVIEWER FOLLOW-UP</span><p>{feedback.followUp}</p><button type="button" onClick={beginFollowUp}>Answer targeted follow-up</button></div>}<div className="feedback-actions"><button className="secondary-interview-button" type="button" onClick={retryAnswer}>Try this answer again</button><button className="start-interview-button" type="button" onClick={nextQuestion}>{questionIndex + 1 >= plan.questions.length ? "Finish interview" : "Next question"} <ChevronRight size={17} /></button></div></section>}
+      </div>
+    </section>
+  </main>;
 }


### PR DESCRIPTION
Replaces the delayed interview startup with a direct production flow in InterviewPracticePage. The first real Aisha greeting sentence starts inside the user’s Start practice interview gesture (using flushSync so Aisha is rendered first), intro pauses are exactly ~2 seconds, the timer and mic start only after the spoken question ends, and later follow-ups/questions repeat the same sequence. Also hardens Aisha rendering with absolute inline sizing plus a background-image fallback so Safari/iPad cannot collapse the avatar out of view. Voice selection now preloads and prefers softer English voices, with a more natural rate/pitch. No OAuth, marketing, billing, or Resume Builder changes.