### PR TITLE
Fix Aisha final visual rendering and speaking animation

### DIFF
--- a/frontend/.aisha-canvas-test-marker
+++ b/frontend/.aisha-canvas-test-marker
@@ -1,0 +1,1 @@
+Aisha final visual fix branch: canvas rendering + speaking motion.

--- a/frontend/.aisha-canvas-test-marker
+++ b/frontend/.aisha-canvas-test-marker
@@ -1,1 +1,0 @@
-Aisha final visual fix branch: canvas rendering + speaking motion.

--- a/frontend/src/AnimatedInterviewerAvatar.css
+++ b/frontend/src/AnimatedInterviewerAvatar.css
@@ -1,39 +1,118 @@
-.animated-interviewer-avatar{position:absolute;inset:0;width:100%;height:100%;min-width:100%;min-height:100%;overflow:hidden;border-radius:24px;background:#0a0d16;isolation:isolate;transform:translateZ(0)}
-.photo-interviewer{display:block}
-.aisha-interviewer-photo,.aisha-mouth-motion{position:absolute;inset:0;width:100%;height:100%;display:block;object-fit:cover;object-position:center 42%;transform:scale(1.015) translate3d(0,0,0);backface-visibility:hidden;-webkit-backface-visibility:hidden}
-.aisha-interviewer-photo{z-index:0;opacity:1;visibility:visible;transition:transform .7s ease,filter .45s ease}
-.aisha-mouth-motion{z-index:1;opacity:0;visibility:visible;pointer-events:none;clip-path:inset(45.5% 36.5% 31% 36.5% round 8%);-webkit-clip-path:inset(45.5% 36.5% 31% 36.5% round 8%);transform-origin:50% 57%;will-change:transform,opacity,filter;filter:saturate(1.01) contrast(1.01)}
-.aisha-photo-vignette{position:absolute;inset:0;background:linear-gradient(180deg,rgba(4,7,15,.04) 0%,rgba(4,7,15,.02) 58%,rgba(4,7,15,.5) 100%),radial-gradient(circle at 50% 42%,transparent 35%,rgba(0,0,0,.14) 100%);pointer-events:none;z-index:2}
-.aisha-speaking-glow{position:absolute;inset:0;opacity:0;box-shadow:inset 0 0 0 2px rgba(139,92,246,.55),inset 0 0 42px rgba(139,92,246,.12);transition:opacity .25s ease;pointer-events:none;z-index:2}
-.avatar-state-pill{position:absolute;left:50%;bottom:20px;transform:translateX(-50%);display:flex;align-items:center;gap:8px;padding:8px 12px;border:1px solid rgba(255,255,255,.14);border-radius:999px;background:rgba(7,12,25,.82);backdrop-filter:blur(12px);-webkit-backdrop-filter:blur(12px);font-size:.78rem;color:#e5e7eb;z-index:3;white-space:nowrap}
-.avatar-state-dot{width:8px;height:8px;border-radius:50%;background:#34d399;box-shadow:0 0 0 5px rgba(52,211,153,.1)}
-.state-speaking .aisha-interviewer-photo{animation:aisha-natural-speak 4.6s ease-in-out infinite}
-.state-speaking .aisha-mouth-motion{opacity:1;animation:aisha-mouth-natural .64s cubic-bezier(.37,0,.3,1) infinite}
-.state-speaking .aisha-speaking-glow{opacity:1}
-.state-speaking .avatar-state-dot{background:#a78bfa;box-shadow:0 0 0 5px rgba(167,139,250,.12);animation:avatar-pulse 1.1s ease-out infinite}
-.state-listening .aisha-interviewer-photo{animation:aisha-natural-listen 6s ease-in-out infinite}
-.state-listening .avatar-state-dot{animation:avatar-pulse 1.4s ease-out infinite}
-.state-thinking .aisha-interviewer-photo{filter:saturate(.96) brightness(.98);transform:scale(1.018)}
-.state-encouraging .aisha-interviewer-photo{animation:aisha-natural-nod 3.8s ease-in-out 1}
-.reduced-motion *{animation:none!important;transition:none!important}
-.reduced-motion .aisha-mouth-motion{opacity:0!important}
-.animated-avatar-caption{position:absolute;left:18px;top:18px;z-index:4;padding:9px 12px;border:1px solid rgba(255,255,255,.12);border-radius:10px;background:rgba(7,12,25,.76);backdrop-filter:blur(10px);-webkit-backdrop-filter:blur(10px);display:grid;gap:2px;box-shadow:0 10px 30px rgba(0,0,0,.18)}
+.animated-interviewer-host{
+  place-content:stretch!important;
+  align-items:stretch!important;
+  justify-items:stretch!important;
+  grid-template-columns:minmax(0,1fr)!important;
+  grid-template-rows:minmax(0,1fr)!important;
+  overflow:hidden!important;
+  background-color:#0a0d16!important;
+  background-image:url("./assets/aisha-jordan-interviewer.jpg")!important;
+  background-size:cover!important;
+  background-position:center center!important;
+  background-repeat:no-repeat!important;
+}
+
+.animated-interviewer-host>.aisha-interviewer-canvas{
+  position:absolute!important;
+  inset:0!important;
+  width:100%!important;
+  height:100%!important;
+  min-width:100%!important;
+  min-height:100%!important;
+  display:block!important;
+  z-index:2!important;
+  pointer-events:none!important;
+  background:#0a0d16;
+}
+
+.aisha-photo-vignette{
+  position:absolute;
+  inset:0;
+  z-index:3;
+  pointer-events:none;
+  background:
+    linear-gradient(180deg,rgba(4,7,15,.025) 0%,rgba(4,7,15,.015) 60%,rgba(4,7,15,.40) 100%),
+    radial-gradient(circle at 50% 42%,transparent 39%,rgba(0,0,0,.10) 100%);
+}
+
+.aisha-speaking-glow{
+  position:absolute;
+  inset:0;
+  z-index:4;
+  opacity:0;
+  pointer-events:none;
+  box-shadow:inset 0 0 0 2px rgba(139,92,246,.55),inset 0 0 42px rgba(139,92,246,.12);
+  transition:opacity .22s ease;
+}
+
+.aisha-speaking-glow.state-speaking{opacity:1}
+
+.avatar-state-pill{
+  position:absolute;
+  right:18px;
+  bottom:18px;
+  z-index:6;
+  display:flex;
+  align-items:center;
+  gap:8px;
+  padding:8px 12px;
+  border:1px solid rgba(255,255,255,.14);
+  border-radius:999px;
+  background:rgba(7,12,25,.84);
+  backdrop-filter:blur(12px);
+  -webkit-backdrop-filter:blur(12px);
+  font-size:.78rem;
+  color:#e5e7eb;
+  white-space:nowrap;
+}
+
+.avatar-state-dot{
+  width:8px;
+  height:8px;
+  border-radius:50%;
+  background:#34d399;
+  box-shadow:0 0 0 5px rgba(52,211,153,.1);
+}
+
+.avatar-state-pill.state-speaking .avatar-state-dot{
+  background:#a78bfa;
+  box-shadow:0 0 0 5px rgba(167,139,250,.12);
+  animation:avatar-pulse 1.1s ease-out infinite;
+}
+
+.avatar-state-pill.state-listening .avatar-state-dot{animation:avatar-pulse 1.4s ease-out infinite}
+
+.animated-avatar-caption{
+  position:absolute;
+  left:auto!important;
+  right:18px!important;
+  top:18px!important;
+  z-index:7;
+  padding:9px 12px;
+  border:1px solid rgba(255,255,255,.12);
+  border-radius:10px;
+  background:rgba(7,12,25,.76);
+  backdrop-filter:blur(10px);
+  -webkit-backdrop-filter:blur(10px);
+  display:grid;
+  gap:2px;
+  box-shadow:0 10px 30px rgba(0,0,0,.18);
+}
+
 .animated-avatar-caption strong{font-size:.8rem}
 .animated-avatar-caption span{font-size:.68rem;color:#aebbd0}
 
-/* Explicit host class avoids relying on :has(), so Firefox ESR and older Safari/Chromium builds still render Aisha correctly. */
-.animated-interviewer-host{position:relative!important;place-content:stretch!important;align-items:stretch!important;justify-items:stretch!important;grid-template-columns:minmax(0,1fr)!important;grid-template-rows:minmax(0,1fr)!important;overflow:hidden}
-.animated-interviewer-host>.animated-interviewer-avatar{position:absolute!important;inset:0!important;width:100%!important;height:100%!important;min-width:100%!important;min-height:100%!important;border-radius:0!important;display:block!important;z-index:1!important}
-.animated-interviewer-host .aisha-interviewer-photo{display:block!important;opacity:1!important;visibility:visible!important;z-index:0!important}
-.animated-interviewer-host .aisha-mouth-motion{visibility:visible!important}
+@keyframes avatar-pulse{
+  0%{box-shadow:0 0 0 0 rgba(167,139,250,.35)}
+  100%{box-shadow:0 0 0 12px rgba(167,139,250,0)}
+}
 
-@keyframes aisha-natural-speak{0%,100%{transform:scale(1.015) translate3d(0,0,0)}24%{transform:scale(1.017) translate3d(-.25px,-.45px,0)}49%{transform:scale(1.019) translate3d(.2px,-.9px,0)}73%{transform:scale(1.017) translate3d(.35px,-.3px,0)}}
-@keyframes aisha-mouth-natural{0%,100%{transform:scale(1.015) scaleX(1) scaleY(1) translate3d(0,0,0);filter:saturate(1.01) contrast(1.01)}12%{transform:scale(1.015) scaleX(.997) scaleY(1.018) translate3d(0,.35px,0)}27%{transform:scale(1.015) scaleX(1.002) scaleY(1.006) translate3d(0,.08px,0)}43%{transform:scale(1.015) scaleX(.996) scaleY(1.027) translate3d(0,.58px,0);filter:saturate(1.015) contrast(1.02)}58%{transform:scale(1.015) scaleX(1.001) scaleY(.998) translate3d(0,-.08px,0)}74%{transform:scale(1.015) scaleX(.998) scaleY(1.021) translate3d(0,.42px,0)}88%{transform:scale(1.015) scaleX(1.001) scaleY(1.008) translate3d(0,.14px,0)}}
-@keyframes aisha-natural-listen{0%,100%{transform:scale(1.015) translate3d(0,0,0)}50%{transform:scale(1.017) translate3d(0,1px,0)}}
-@keyframes aisha-natural-nod{0%,100%{transform:scale(1.015) translate3d(0,0,0)}45%{transform:scale(1.017) translate3d(0,2px,0)}70%{transform:scale(1.016) translate3d(0,0,0)}}
-@keyframes avatar-pulse{0%{box-shadow:0 0 0 0 rgba(52,211,153,.35)}100%{box-shadow:0 0 0 12px rgba(52,211,153,0)}}
+@media(max-width:620px){
+  .animated-avatar-caption{right:10px!important;top:10px!important;max-width:52%}
+  .avatar-state-pill{right:10px!important;bottom:66px!important;max-width:calc(100% - 20px)}
+}
 
-@media(max-width:950px){.animated-interviewer-avatar{min-height:430px}}
-@media(max-width:620px){.animated-interviewer-avatar{min-height:360px}.aisha-interviewer-photo,.aisha-mouth-motion{object-position:center 42%}.aisha-mouth-motion{clip-path:inset(44.5% 34.5% 31% 34.5% round 8%);-webkit-clip-path:inset(44.5% 34.5% 31% 34.5% round 8%)}}
-@supports not (clip-path:inset(1px)){.aisha-mouth-motion{display:none!important}}
-@media(prefers-reduced-motion:reduce){.animated-interviewer-avatar *{animation:none!important;transition:none!important}.aisha-mouth-motion{opacity:0!important}}
+@media(prefers-reduced-motion:reduce){
+  .avatar-state-dot{animation:none!important}
+  .aisha-speaking-glow{transition:none!important}
+}

--- a/frontend/src/AnimatedInterviewerAvatar.jsx
+++ b/frontend/src/AnimatedInterviewerAvatar.jsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from "react";
 import bundledAishaJordanInterviewer from "./assets/aisha-jordan-interviewer.jpg";
 
 const STATE_COPY = {
@@ -8,73 +9,175 @@ const STATE_COPY = {
   encouraging: "Follow-up coaching",
 };
 
-const FALLBACK_AISHA = "/assets/aisha-interviewer-concept.jpg";
+function coverGeometry(imageWidth, imageHeight, width, height, scaleBoost = 1, offsetX = 0, offsetY = 0) {
+  const scale = Math.max(width / imageWidth, height / imageHeight) * scaleBoost;
+  const drawWidth = imageWidth * scale;
+  const drawHeight = imageHeight * scale;
+  return {
+    x: (width - drawWidth) / 2 + offsetX,
+    y: (height - drawHeight) / 2 + offsetY,
+    width: drawWidth,
+    height: drawHeight,
+    scale,
+  };
+}
 
-const rootStyle = {
-  position: "absolute",
-  inset: 0,
-  width: "100%",
-  height: "100%",
-  minWidth: "100%",
-  minHeight: "100%",
-  display: "block",
-  overflow: "hidden",
-  backgroundImage: `url(${bundledAishaJordanInterviewer}), url(${FALLBACK_AISHA})`,
-  backgroundSize: "cover",
-  backgroundPosition: "center 42%",
-  backgroundRepeat: "no-repeat",
-};
+function drawMouthMotion(context, image, geometry, time) {
+  const sourceX = image.naturalWidth * 0.43;
+  const sourceY = image.naturalHeight * 0.415;
+  const sourceWidth = image.naturalWidth * 0.20;
+  const sourceHeight = image.naturalHeight * 0.11;
 
-const photoStyle = {
-  position: "absolute",
-  inset: 0,
-  width: "100%",
-  height: "100%",
-  display: "block",
-  opacity: 1,
-  visibility: "visible",
-  objectFit: "cover",
-  objectPosition: "center 42%",
-};
+  const destinationX = geometry.x + sourceX * geometry.scale;
+  const destinationY = geometry.y + sourceY * geometry.scale;
+  const destinationWidth = sourceWidth * geometry.scale;
+  const destinationHeight = sourceHeight * geometry.scale;
 
-function useFallbackImage(event) {
-  const image = event.currentTarget;
-  if (!image.src.endsWith(FALLBACK_AISHA)) image.src = FALLBACK_AISHA;
+  const speechWave = (Math.sin(time / 86) + Math.sin(time / 137 + 1.1) + 2) / 4;
+  const verticalScale = 1 + speechWave * 0.075;
+  const horizontalScale = 1 - speechWave * 0.018;
+  const animatedWidth = destinationWidth * horizontalScale;
+  const animatedHeight = destinationHeight * verticalScale;
+  const animatedX = destinationX + (destinationWidth - animatedWidth) / 2;
+  const animatedY = destinationY + (destinationHeight - animatedHeight) / 2 + speechWave * 0.7;
+
+  context.save();
+  context.beginPath();
+  context.ellipse(
+    destinationX + destinationWidth / 2,
+    destinationY + destinationHeight / 2,
+    destinationWidth * 0.48,
+    destinationHeight * 0.48,
+    0,
+    0,
+    Math.PI * 2,
+  );
+  context.clip();
+  context.drawImage(
+    image,
+    sourceX,
+    sourceY,
+    sourceWidth,
+    sourceHeight,
+    animatedX,
+    animatedY,
+    animatedWidth,
+    animatedHeight,
+  );
+  context.restore();
 }
 
 export default function AnimatedInterviewerAvatar({ state = "idle", name = "Aisha Jordan", reducedMotion = false }) {
   const safeState = STATE_COPY[state] ? state : "idle";
+  const canvasRef = useRef(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return undefined;
+
+    const image = new Image();
+    image.decoding = "async";
+    image.src = bundledAishaJordanInterviewer;
+
+    let frameId = 0;
+    let active = true;
+    let resizeObserver = null;
+    const prefersReducedMotion = reducedMotion || window.matchMedia?.("(prefers-reduced-motion: reduce)")?.matches;
+
+    const paint = (time = performance.now()) => {
+      if (!active || !image.naturalWidth || !image.naturalHeight) return;
+
+      const parent = canvas.parentElement;
+      const width = Math.max(1, canvas.clientWidth || parent?.clientWidth || 1);
+      const height = Math.max(1, canvas.clientHeight || parent?.clientHeight || 1);
+      const pixelRatio = Math.min(window.devicePixelRatio || 1, 2);
+      const targetWidth = Math.round(width * pixelRatio);
+      const targetHeight = Math.round(height * pixelRatio);
+
+      if (canvas.width !== targetWidth || canvas.height !== targetHeight) {
+        canvas.width = targetWidth;
+        canvas.height = targetHeight;
+      }
+
+      const context = canvas.getContext("2d", { alpha: false });
+      if (!context) return;
+      context.setTransform(pixelRatio, 0, 0, pixelRatio, 0, 0);
+      context.clearRect(0, 0, width, height);
+      context.imageSmoothingEnabled = true;
+      context.imageSmoothingQuality = "high";
+
+      let scaleBoost = 1.01;
+      let offsetX = 0;
+      let offsetY = 0;
+
+      if (!prefersReducedMotion) {
+        if (safeState === "speaking") {
+          scaleBoost = 1.012 + Math.sin(time / 760) * 0.0025;
+          offsetX = Math.sin(time / 1120) * 0.7;
+          offsetY = Math.sin(time / 690) * 0.55;
+        } else if (safeState === "listening") {
+          scaleBoost = 1.011 + Math.sin(time / 1600) * 0.0015;
+          offsetY = Math.sin(time / 1450) * 0.7;
+        } else if (safeState === "encouraging") {
+          offsetY = Math.sin(time / 240) * 1.1;
+        }
+      }
+
+      const geometry = coverGeometry(image.naturalWidth, image.naturalHeight, width, height, scaleBoost, offsetX, offsetY);
+      context.drawImage(image, geometry.x, geometry.y, geometry.width, geometry.height);
+
+      if (!prefersReducedMotion && safeState === "speaking") {
+        drawMouthMotion(context, image, geometry, time);
+      }
+    };
+
+    const animate = (time) => {
+      paint(time);
+      if (active && !prefersReducedMotion && ["speaking", "listening", "encouraging"].includes(safeState)) {
+        frameId = window.requestAnimationFrame(animate);
+      }
+    };
+
+    const start = () => {
+      window.cancelAnimationFrame(frameId);
+      paint();
+      if (!prefersReducedMotion && ["speaking", "listening", "encouraging"].includes(safeState)) {
+        frameId = window.requestAnimationFrame(animate);
+      }
+    };
+
+    image.onload = start;
+    if (image.complete && image.naturalWidth) start();
+
+    if (window.ResizeObserver) {
+      resizeObserver = new ResizeObserver(() => paint());
+      resizeObserver.observe(canvas.parentElement || canvas);
+    } else {
+      window.addEventListener("resize", paint);
+    }
+
+    return () => {
+      active = false;
+      window.cancelAnimationFrame(frameId);
+      resizeObserver?.disconnect();
+      if (!window.ResizeObserver) window.removeEventListener("resize", paint);
+    };
+  }, [safeState, reducedMotion]);
 
   return (
-    <div
-      className={`animated-interviewer-avatar photo-interviewer state-${safeState} ${reducedMotion ? "reduced-motion" : ""}`}
-      role="img"
-      aria-label={`${name}, virtual interviewer, ${STATE_COPY[safeState]}`}
-      style={rootStyle}
-    >
-      <img
-        className="aisha-interviewer-photo"
-        src={bundledAishaJordanInterviewer}
-        onError={useFallbackImage}
-        alt="Aisha Jordan, BragStack virtual interviewer"
-        draggable="false"
-        decoding="sync"
-        fetchPriority="high"
-        style={photoStyle}
+    <>
+      <canvas
+        ref={canvasRef}
+        className={`aisha-interviewer-canvas state-${safeState}`}
+        role="img"
+        aria-label={`${name}, virtual interviewer, ${STATE_COPY[safeState]}`}
       />
-      <img
-        className="aisha-mouth-motion"
-        src={bundledAishaJordanInterviewer}
-        onError={useFallbackImage}
-        alt=""
-        aria-hidden="true"
-        draggable="false"
-        decoding="sync"
-        style={{ ...photoStyle, opacity: safeState === "speaking" && !reducedMotion ? undefined : 0 }}
-      />
-      <div className="aisha-photo-vignette" />
-      <div className="aisha-speaking-glow" aria-hidden="true" />
-      <div className="avatar-state-pill"><span className="avatar-state-dot" /><strong>{STATE_COPY[safeState]}</strong></div>
-    </div>
+      <div className="aisha-photo-vignette" aria-hidden="true" />
+      <div className={`aisha-speaking-glow state-${safeState}`} aria-hidden="true" />
+      <div className={`avatar-state-pill state-${safeState}`}>
+        <span className="avatar-state-dot" />
+        <strong>{STATE_COPY[safeState]}</strong>
+      </div>
+    </>
   );
 }


### PR DESCRIPTION
Final visual-only fix for the Practice Interviewer.

Changes:
- replaces the nested img-based Aisha renderer with a direct canvas renderer that fills the interviewer stage across Safari, iPad/iPhone, Chrome, Edge and Firefox
- keeps the existing bundled Aisha artwork as the source and as a CSS fallback
- draws the image with object-cover geometry at device pixel ratio for sharp rendering
- adds subtle head/breathing motion while speaking/listening
- adds a clipped lip-region animation while Aisha is speaking
- keeps reduced-motion support
- preserves all interview sequencing, timer, recruiter-specialty, catalog, camera and evaluation behavior

Do not merge until the live preview confirms Aisha is visible and animated.