### PR TITLE
Fix Aisha with resilient CSS rendering across browsers

### DIFF
--- a/frontend/src/AnimatedInterviewerAvatar.css
+++ b/frontend/src/AnimatedInterviewerAvatar.css
@@ -1,28 +1,98 @@
 .animated-interviewer-host{
-  place-content:stretch!important;
-  align-items:stretch!important;
-  justify-items:stretch!important;
-  grid-template-columns:minmax(0,1fr)!important;
-  grid-template-rows:minmax(0,1fr)!important;
-  overflow:hidden!important;
-  background-color:#0a0d16!important;
-  background-image:url("./assets/aisha-jordan-interviewer.jpg")!important;
-  background-size:cover!important;
-  background-position:center center!important;
-  background-repeat:no-repeat!important;
-}
-
-.animated-interviewer-host>.aisha-interviewer-canvas{
   position:absolute!important;
   inset:0!important;
   width:100%!important;
   height:100%!important;
-  min-width:100%!important;
-  min-height:100%!important;
+  min-width:0!important;
+  min-height:0!important;
   display:block!important;
-  z-index:2!important;
-  pointer-events:none!important;
-  background:#0a0d16;
+  overflow:hidden!important;
+  isolation:isolate;
+  background-color:#0a0d16!important;
+  background-image:url("./assets/aisha-jordan-interviewer.jpg")!important;
+  background-size:cover!important;
+  background-position:center 42%!important;
+  background-repeat:no-repeat!important;
+}
+
+/*
+  The portrait is painted with CSS background layers rather than <canvas> or a
+  replaced <img> element. The stage itself remains the fallback layer, so even
+  if an animated layer is unavailable the interviewer never becomes a black box.
+*/
+.aisha-motion-frame{
+  position:absolute;
+  inset:0;
+  z-index:2;
+  overflow:hidden;
+  pointer-events:none;
+  transform:translateZ(0);
+  transform-origin:50% 45%;
+  backface-visibility:hidden;
+  -webkit-backface-visibility:hidden;
+  will-change:transform;
+}
+
+.aisha-photo-layer,
+.aisha-mouth-layer{
+  position:absolute;
+  inset:-1%;
+  background-color:transparent;
+  background-size:cover;
+  background-position:center 42%;
+  background-repeat:no-repeat;
+  transform:translateZ(0);
+  backface-visibility:hidden;
+  -webkit-backface-visibility:hidden;
+}
+
+.aisha-photo-layer{
+  z-index:1;
+}
+
+/*
+  Keep the clip window fixed on Aisha's mouth while only the duplicate image
+  inside it moves. This avoids the tearing/jumping that happens when the clip
+  region itself is transformed.
+*/
+.aisha-mouth-window{
+  position:absolute;
+  inset:0;
+  z-index:2;
+  overflow:hidden;
+  opacity:0;
+  pointer-events:none;
+  clip-path:ellipse(10.5% 5% at 52.5% 46%);
+  -webkit-clip-path:ellipse(10.5% 5% at 52.5% 46%);
+}
+
+.aisha-mouth-layer{
+  transform-origin:52.5% 46%;
+  will-change:transform,filter;
+}
+
+.aisha-motion-frame.state-speaking{
+  animation:aisha-speaking-body 4.8s ease-in-out infinite;
+}
+
+.aisha-motion-frame.state-speaking .aisha-mouth-window{
+  opacity:1;
+}
+
+.aisha-motion-frame.state-speaking .aisha-mouth-layer{
+  animation:aisha-mouth-talk .46s cubic-bezier(.4,0,.2,1) infinite;
+}
+
+.aisha-motion-frame.state-listening{
+  animation:aisha-listening-breathe 6s ease-in-out infinite;
+}
+
+.aisha-motion-frame.state-encouraging{
+  animation:aisha-encouraging-nod 1.7s ease-in-out 1;
+}
+
+.aisha-motion-frame.state-thinking{
+  filter:saturate(.97) brightness(.99);
 }
 
 .aisha-photo-vignette{
@@ -31,8 +101,8 @@
   z-index:3;
   pointer-events:none;
   background:
-    linear-gradient(180deg,rgba(4,7,15,.025) 0%,rgba(4,7,15,.015) 60%,rgba(4,7,15,.40) 100%),
-    radial-gradient(circle at 50% 42%,transparent 39%,rgba(0,0,0,.10) 100%);
+    linear-gradient(180deg,rgba(4,7,15,.02) 0%,rgba(4,7,15,.01) 60%,rgba(4,7,15,.34) 100%),
+    radial-gradient(circle at 50% 42%,transparent 42%,rgba(0,0,0,.09) 100%);
 }
 
 .aisha-speaking-glow{
@@ -80,7 +150,9 @@
   animation:avatar-pulse 1.1s ease-out infinite;
 }
 
-.avatar-state-pill.state-listening .avatar-state-dot{animation:avatar-pulse 1.4s ease-out infinite}
+.avatar-state-pill.state-listening .avatar-state-dot{
+  animation:avatar-pulse 1.4s ease-out infinite;
+}
 
 .animated-avatar-caption{
   position:absolute;
@@ -102,17 +174,78 @@
 .animated-avatar-caption strong{font-size:.8rem}
 .animated-avatar-caption span{font-size:.68rem;color:#aebbd0}
 
+@keyframes aisha-speaking-body{
+  0%,100%{transform:translate3d(0,0,0) scale(1.002)}
+  25%{transform:translate3d(-.4px,-.35px,0) scale(1.004)}
+  50%{transform:translate3d(.35px,-.65px,0) scale(1.005)}
+  75%{transform:translate3d(.45px,-.2px,0) scale(1.003)}
+}
+
+@keyframes aisha-mouth-talk{
+  0%,100%{transform:translate3d(0,0,0) scaleX(1) scaleY(1);filter:brightness(1)}
+  16%{transform:translate3d(0,.25px,0) scaleX(.996) scaleY(1.025);filter:brightness(1.006)}
+  34%{transform:translate3d(0,.48px,0) scaleX(.993) scaleY(1.055);filter:brightness(1.012)}
+  50%{transform:translate3d(0,.05px,0) scaleX(1.002) scaleY(.995);filter:brightness(1)}
+  68%{transform:translate3d(0,.38px,0) scaleX(.996) scaleY(1.042);filter:brightness(1.009)}
+  84%{transform:translate3d(0,.18px,0) scaleX(.999) scaleY(1.018);filter:brightness(1.004)}
+}
+
+@keyframes aisha-listening-breathe{
+  0%,100%{transform:translate3d(0,0,0) scale(1.002)}
+  50%{transform:translate3d(0,.7px,0) scale(1.004)}
+}
+
+@keyframes aisha-encouraging-nod{
+  0%,100%{transform:translate3d(0,0,0) scale(1.002)}
+  42%{transform:translate3d(0,1.7px,0) scale(1.004)}
+  72%{transform:translate3d(0,.2px,0) scale(1.003)}
+}
+
 @keyframes avatar-pulse{
   0%{box-shadow:0 0 0 0 rgba(167,139,250,.35)}
   100%{box-shadow:0 0 0 12px rgba(167,139,250,0)}
 }
 
 @media(max-width:620px){
+  .animated-interviewer-host,
+  .aisha-photo-layer,
+  .aisha-mouth-layer{
+    background-position:center 38%!important;
+  }
+
+  .aisha-mouth-window{
+    clip-path:ellipse(12% 4.8% at 52.5% 45%);
+    -webkit-clip-path:ellipse(12% 4.8% at 52.5% 45%);
+  }
+
+  .aisha-mouth-layer{
+    transform-origin:52.5% 45%;
+  }
+
   .animated-avatar-caption{right:10px!important;top:10px!important;max-width:52%}
   .avatar-state-pill{right:10px!important;bottom:66px!important;max-width:calc(100% - 20px)}
 }
 
+@supports not (clip-path:ellipse(10% 5% at 50% 50%)){
+  .aisha-mouth-window{display:none!important}
+}
+
+.aisha-motion-frame.reduced-motion,
+.aisha-motion-frame.reduced-motion .aisha-mouth-layer{
+  animation:none!important;
+}
+
+.aisha-motion-frame.reduced-motion .aisha-mouth-window{
+  display:none!important;
+}
+
 @media(prefers-reduced-motion:reduce){
-  .avatar-state-dot{animation:none!important}
+  .aisha-motion-frame,
+  .aisha-mouth-layer,
+  .avatar-state-dot{
+    animation:none!important;
+    transition:none!important;
+  }
+  .aisha-mouth-window{display:none!important}
   .aisha-speaking-glow{transition:none!important}
 }

--- a/frontend/src/AnimatedInterviewerAvatar.jsx
+++ b/frontend/src/AnimatedInterviewerAvatar.jsx
@@ -1,4 +1,3 @@
-import { useEffect, useRef } from "react";
 import bundledAishaJordanInterviewer from "./assets/aisha-jordan-interviewer.jpg";
 
 const STATE_COPY = {
@@ -9,169 +8,29 @@ const STATE_COPY = {
   encouraging: "Follow-up coaching",
 };
 
-function coverGeometry(imageWidth, imageHeight, width, height, scaleBoost = 1, offsetX = 0, offsetY = 0) {
-  const scale = Math.max(width / imageWidth, height / imageHeight) * scaleBoost;
-  const drawWidth = imageWidth * scale;
-  const drawHeight = imageHeight * scale;
-  return {
-    x: (width - drawWidth) / 2 + offsetX,
-    y: (height - drawHeight) / 2 + offsetY,
-    width: drawWidth,
-    height: drawHeight,
-    scale,
-  };
-}
-
-function drawMouthMotion(context, image, geometry, time) {
-  const sourceX = image.naturalWidth * 0.43;
-  const sourceY = image.naturalHeight * 0.415;
-  const sourceWidth = image.naturalWidth * 0.20;
-  const sourceHeight = image.naturalHeight * 0.11;
-
-  const destinationX = geometry.x + sourceX * geometry.scale;
-  const destinationY = geometry.y + sourceY * geometry.scale;
-  const destinationWidth = sourceWidth * geometry.scale;
-  const destinationHeight = sourceHeight * geometry.scale;
-
-  const speechWave = (Math.sin(time / 86) + Math.sin(time / 137 + 1.1) + 2) / 4;
-  const verticalScale = 1 + speechWave * 0.075;
-  const horizontalScale = 1 - speechWave * 0.018;
-  const animatedWidth = destinationWidth * horizontalScale;
-  const animatedHeight = destinationHeight * verticalScale;
-  const animatedX = destinationX + (destinationWidth - animatedWidth) / 2;
-  const animatedY = destinationY + (destinationHeight - animatedHeight) / 2 + speechWave * 0.7;
-
-  context.save();
-  context.beginPath();
-  context.ellipse(
-    destinationX + destinationWidth / 2,
-    destinationY + destinationHeight / 2,
-    destinationWidth * 0.48,
-    destinationHeight * 0.48,
-    0,
-    0,
-    Math.PI * 2,
-  );
-  context.clip();
-  context.drawImage(
-    image,
-    sourceX,
-    sourceY,
-    sourceWidth,
-    sourceHeight,
-    animatedX,
-    animatedY,
-    animatedWidth,
-    animatedHeight,
-  );
-  context.restore();
-}
+// Keep the actual portrait as a normal CSS background layer. This is deliberately
+// not a canvas: browsers can paint the imported asset directly even if animation
+// APIs, image decoding timing, or canvas sizing behave differently.
+const AISHA_BACKGROUND = {
+  backgroundImage: `url("${bundledAishaJordanInterviewer}"), url("/assets/aisha-interviewer-concept.jpg")`,
+};
 
 export default function AnimatedInterviewerAvatar({ state = "idle", name = "Aisha Jordan", reducedMotion = false }) {
   const safeState = STATE_COPY[state] ? state : "idle";
-  const canvasRef = useRef(null);
-
-  useEffect(() => {
-    const canvas = canvasRef.current;
-    if (!canvas) return undefined;
-
-    const image = new Image();
-    image.decoding = "async";
-    image.src = bundledAishaJordanInterviewer;
-
-    let frameId = 0;
-    let active = true;
-    let resizeObserver = null;
-    const prefersReducedMotion = reducedMotion || window.matchMedia?.("(prefers-reduced-motion: reduce)")?.matches;
-
-    const paint = (time = performance.now()) => {
-      if (!active || !image.naturalWidth || !image.naturalHeight) return;
-
-      const parent = canvas.parentElement;
-      const width = Math.max(1, canvas.clientWidth || parent?.clientWidth || 1);
-      const height = Math.max(1, canvas.clientHeight || parent?.clientHeight || 1);
-      const pixelRatio = Math.min(window.devicePixelRatio || 1, 2);
-      const targetWidth = Math.round(width * pixelRatio);
-      const targetHeight = Math.round(height * pixelRatio);
-
-      if (canvas.width !== targetWidth || canvas.height !== targetHeight) {
-        canvas.width = targetWidth;
-        canvas.height = targetHeight;
-      }
-
-      const context = canvas.getContext("2d", { alpha: false });
-      if (!context) return;
-      context.setTransform(pixelRatio, 0, 0, pixelRatio, 0, 0);
-      context.clearRect(0, 0, width, height);
-      context.imageSmoothingEnabled = true;
-      context.imageSmoothingQuality = "high";
-
-      let scaleBoost = 1.01;
-      let offsetX = 0;
-      let offsetY = 0;
-
-      if (!prefersReducedMotion) {
-        if (safeState === "speaking") {
-          scaleBoost = 1.012 + Math.sin(time / 760) * 0.0025;
-          offsetX = Math.sin(time / 1120) * 0.7;
-          offsetY = Math.sin(time / 690) * 0.55;
-        } else if (safeState === "listening") {
-          scaleBoost = 1.011 + Math.sin(time / 1600) * 0.0015;
-          offsetY = Math.sin(time / 1450) * 0.7;
-        } else if (safeState === "encouraging") {
-          offsetY = Math.sin(time / 240) * 1.1;
-        }
-      }
-
-      const geometry = coverGeometry(image.naturalWidth, image.naturalHeight, width, height, scaleBoost, offsetX, offsetY);
-      context.drawImage(image, geometry.x, geometry.y, geometry.width, geometry.height);
-
-      if (!prefersReducedMotion && safeState === "speaking") {
-        drawMouthMotion(context, image, geometry, time);
-      }
-    };
-
-    const animate = (time) => {
-      paint(time);
-      if (active && !prefersReducedMotion && ["speaking", "listening", "encouraging"].includes(safeState)) {
-        frameId = window.requestAnimationFrame(animate);
-      }
-    };
-
-    const start = () => {
-      window.cancelAnimationFrame(frameId);
-      paint();
-      if (!prefersReducedMotion && ["speaking", "listening", "encouraging"].includes(safeState)) {
-        frameId = window.requestAnimationFrame(animate);
-      }
-    };
-
-    image.onload = start;
-    if (image.complete && image.naturalWidth) start();
-
-    if (window.ResizeObserver) {
-      resizeObserver = new ResizeObserver(() => paint());
-      resizeObserver.observe(canvas.parentElement || canvas);
-    } else {
-      window.addEventListener("resize", paint);
-    }
-
-    return () => {
-      active = false;
-      window.cancelAnimationFrame(frameId);
-      resizeObserver?.disconnect();
-      if (!window.ResizeObserver) window.removeEventListener("resize", paint);
-    };
-  }, [safeState, reducedMotion]);
 
   return (
     <>
-      <canvas
-        ref={canvasRef}
-        className={`aisha-interviewer-canvas state-${safeState}`}
+      <div
+        className={`aisha-motion-frame state-${safeState} ${reducedMotion ? "reduced-motion" : ""}`}
         role="img"
         aria-label={`${name}, virtual interviewer, ${STATE_COPY[safeState]}`}
-      />
+      >
+        <div className="aisha-photo-layer" style={AISHA_BACKGROUND} />
+        <div className="aisha-mouth-window" aria-hidden="true">
+          <div className="aisha-mouth-layer" style={AISHA_BACKGROUND} />
+        </div>
+      </div>
+
       <div className="aisha-photo-vignette" aria-hidden="true" />
       <div className={`aisha-speaking-glow state-${safeState}`} aria-hidden="true" />
       <div className={`avatar-state-pill state-${safeState}`}>


### PR DESCRIPTION
Replaces the black/partial Aisha canvas renderer with normal CSS background layers so the interviewer portrait is always painted by the browser's layout engine.

What changed:
- removes the canvas renderer that could stay opaque/black when image paint timing failed
- renders Aisha with standard absolute-positioned CSS background layers
- keeps the stage itself as a visual fallback so a failed animation layer cannot hide Aisha
- uses background-size: cover, explicit positioning, overflow clipping, and stacking contexts
- adds subtle whole-body speaking/listening motion
- adds a clipped duplicate-image mouth animation while Aisha is speaking, with -webkit-clip-path fallback support
- keeps prefers-reduced-motion support
- preserves interview timing, speech, camera, recruiter specialty, questions, evaluation, and session progress

Implementation follows standard CSS layout/stacking/animation patterns suitable for Safari, iPad/iPhone, Chrome, Edge, Firefox, Android, tablet, and desktop browsers.