### PR TITLE
Move product issues into Docs and use security contact

### DIFF
--- a/frontend/public/docs/troubleshooting.html
+++ b/frontend/public/docs/troubleshooting.html
@@ -1,0 +1,87 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>BragStack Troubleshooting | Docs</title>
+  <meta name="description" content="BragStack troubleshooting for sign-in, billing, Interview Practice, Aisha, Resume Builder, Career Intelligence, saves, uploads, browser issues, and support escalation." />
+  <style>
+    :root{font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;color:#172033;background:#f7f9fc}*{box-sizing:border-box}body{margin:0}.top{position:sticky;top:0;z-index:2;display:flex;align-items:center;justify-content:space-between;gap:20px;padding:18px clamp(20px,5vw,60px);border-bottom:1px solid #e4e8ef;background:rgba(255,255,255,.96);backdrop-filter:blur(14px)}.brand{display:flex;align-items:center;gap:10px;text-decoration:none;color:#111827;font-weight:900}.brand img{width:36px;height:36px}.top nav{display:flex;gap:18px;flex-wrap:wrap}.top nav a{color:#556070;text-decoration:none;font-weight:700;font-size:.9rem}.hero,.shell{max-width:1120px;margin:auto;padding-left:clamp(20px,5vw,54px);padding-right:clamp(20px,5vw,54px)}.hero{padding-top:62px;padding-bottom:30px}.kicker{color:#5363e5;font-size:.78rem;font-weight:900;letter-spacing:.12em}.hero h1{font-size:clamp(2.5rem,6vw,4.9rem);line-height:1;letter-spacing:-.055em;margin:12px 0 18px}.hero p{max-width:820px;color:#5f6979;font-size:1.08rem;line-height:1.7}.quick{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:12px;margin:22px 0 38px}.quick a,.card{border:1px solid #e1e6ef;border-radius:16px;background:#fff;box-shadow:0 12px 28px rgba(32,47,80,.04)}.quick a{padding:16px;color:#3344c7;text-decoration:none;font-weight:800}.shell{padding-bottom:76px}.section{scroll-margin-top:100px;margin:0 0 30px}.section h2{font-size:1.65rem;margin:0 0 12px}.grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:14px}.card{padding:22px}.card h3{margin:0 0 8px;font-size:1.08rem}.card p,.card li{color:#5f6979;line-height:1.62}.card ol,.card ul{padding-left:21px}.fix{border-left:4px solid #5363e5}.warn{border:1px solid #f0d6a2;background:#fffaf0;border-radius:16px;padding:18px 20px;margin:26px 0;color:#654b1e}.support{border-radius:20px;background:#111827;color:#fff;padding:26px;margin-top:34px}.support p{color:#cbd5e1;line-height:1.6}.support a{color:#aab5ff;font-weight:900}.tag{display:inline-block;padding:5px 9px;border-radius:999px;background:#eef0ff;color:#4658d7;font-size:.75rem;font-weight:900;margin-bottom:10px}@media(max-width:820px){.quick{grid-template-columns:1fr 1fr}.grid{grid-template-columns:1fr}.top nav{display:none}}@media(max-width:520px){.quick{grid-template-columns:1fr}}
+  </style>
+</head>
+<body>
+  <header class="top">
+    <a class="brand" href="/docs"><img src="/brandmark.svg" alt="" />BragStack Docs</a>
+    <nav><a href="/docs">Help Center</a><a href="/security">Security</a><a href="/privacy">Privacy</a><a href="/nda-safety">NDA guidance</a><a href="/login">Sign in</a></nav>
+  </header>
+  <main>
+    <section class="hero">
+      <div class="kicker">BRAGSTACK DOCS · TROUBLESHOOTING</div>
+      <h1>Something went wrong? Start here.</h1>
+      <p>This is the dedicated product-issues page. Try the recommended fixes first. If the problem continues, contact <strong>support@usebragstack.com</strong>. Security vulnerabilities, suspected compromise, or data-exposure concerns should go to <strong>security@usebragstack.com</strong>.</p>
+      <div class="quick"><a href="#signin">Sign-in</a><a href="#billing">Billing</a><a href="#interview">Interview & Aisha</a><a href="#app">App problems</a></div>
+    </section>
+    <div class="shell">
+      <section class="section" id="first"><h2>Try these first</h2><div class="grid">
+        <article class="card"><span class="tag">FAST CHECK</span><h3>Four safe first steps</h3><ol><li>Refresh the page once.</li><li>Confirm your internet connection is stable.</li><li>Sign out and sign back in.</li><li>Try a private/incognito window with extensions temporarily disabled.</li></ol></article>
+        <article class="card"><span class="tag">DO NOT SEND</span><h3>Protect sensitive information</h3><p>Never email passwords, API keys, access tokens, card numbers, security codes, confidential workplace evidence, restricted source code, or customer data. Redact screenshots when necessary.</p></article>
+      </div></section>
+
+      <section class="section" id="signin"><h2>Sign-in & account access</h2><div class="grid">
+        <article class="card fix"><h3>Google or GitHub sign-in loops back</h3><ol><li>Return to the BragStack login page and start sign-in again.</li><li>Use the same provider and account you originally registered with.</li><li>Allow pop-ups and redirects for usebragstack.com.</li><li>Temporarily disable strict ad/privacy blockers.</li><li>Try a private window.</li></ol></article>
+        <article class="card fix"><h3>OAuth popup closes, hangs, or errors</h3><ol><li>Do not keep refreshing the provider callback page.</li><li>Close the failed tab or popup.</li><li>Return to BragStack and restart sign-in.</li><li>Confirm cookies are allowed for the session.</li><li>Try another modern browser.</li></ol></article>
+        <article class="card fix"><h3>Wrong account appears</h3><ol><li>Sign out of BragStack.</li><li>Check which Google or GitHub account is active in the browser.</li><li>Sign back in and deliberately choose the correct account.</li><li>Avoid creating duplicate accounts as a workaround.</li></ol></article>
+        <article class="card fix"><h3>Email/password sign-in fails</h3><ol><li>Verify the email address and Caps Lock.</li><li>Check password-manager autofill.</li><li>Use password recovery if available.</li><li>If you normally use Google or GitHub, use that same provider.</li></ol></article>
+      </div></section>
+
+      <section class="section" id="billing"><h2>Billing, Stripe, coupons & Pro</h2><div class="grid">
+        <article class="card fix"><h3>Payment succeeded but Pro is locked</h3><ol><li>Wait a few seconds.</li><li>Refresh once.</li><li>Sign out and back in.</li><li>Confirm checkout used the same BragStack account.</li><li>If still locked, send support the receipt time and account email.</li></ol></article>
+        <article class="card fix"><h3>Coupon does not apply</h3><ol><li>Enter the code exactly as provided.</li><li>Check expiration date and redemption limits.</li><li>Check whether it is new-customer or one-use only.</li><li>Start a fresh checkout instead of reopening an old Stripe tab.</li></ol></article>
+        <article class="card fix"><h3>Checkout will not open</h3><ol><li>Allow redirects/pop-ups.</li><li>Temporarily disable blocking extensions.</li><li>Restart checkout from BragStack.</li><li>Do not reuse a stale checkout session from browser history.</li></ol></article>
+        <article class="card fix"><h3>What support needs</h3><p>Send the BragStack account email, approximate checkout time, and exact error message. Do not send full card numbers, CVCs, bank credentials, or passwords.</p></article>
+      </div></section>
+
+      <section class="section" id="interview"><h2>Practice Interview, microphone & Aisha</h2><div class="grid">
+        <article class="card fix"><h3>Aisha does not appear</h3><ol><li>Refresh once.</li><li>Wait for the interview session to finish loading.</li><li>Start a new practice session if the current one is incomplete.</li><li>Try a private window if extensions may be blocking media or scripts.</li><li>Report whether the avatar area was blank, loading, or errored.</li></ol></article>
+        <article class="card fix"><h3>Aisha appears but does not speak</h3><ol><li>Confirm the tab is not muted.</li><li>Raise system/browser volume.</li><li>Allow audio playback for usebragstack.com.</li><li>Interact with the page once if the browser requires a user gesture.</li><li>Reload the session.</li></ol></article>
+        <article class="card fix"><h3>Microphone does not listen</h3><ol><li>Allow microphone permission for usebragstack.com.</li><li>Close Zoom, Teams, Discord, OBS, or other apps using the mic.</li><li>Choose the intended microphone device.</li><li>Reload after changing permissions.</li><li>Use text answers temporarily if voice capture is unavailable.</li></ol></article>
+        <article class="card fix"><h3>Timer or listening sequence is wrong</h3><ol><li>Start a fresh session.</li><li>Do not press start/next controls repeatedly.</li><li>Report the exact order: Aisha starts speaking → Aisha finishes → timer starts → microphone starts.</li><li>Include a screen recording if possible, with private data removed.</li></ol></article>
+        <article class="card fix"><h3>Mouth or avatar animation freezes</h3><ol><li>Reload the page.</li><li>Enable hardware acceleration where supported.</li><li>Close high-CPU/GPU tabs or apps.</li><li>Try another modern browser.</li><li>Report whether audio continued while animation stopped.</li></ol></article>
+        <article class="card fix"><h3>Speech recognition is inaccurate</h3><ol><li>Reduce background noise.</li><li>Move closer to the mic.</li><li>Select the correct input device.</li><li>Avoid speaking over Aisha.</li><li>Include browser and device details when reporting repeated errors.</li></ol></article>
+      </div></section>
+
+      <section class="section" id="resume"><h2>Resume Builder & Career Intelligence</h2><div class="grid">
+        <article class="card fix"><h3>Resume generation is stuck</h3><ol><li>Wait briefly before retrying.</li><li>Do not click Generate repeatedly.</li><li>Refresh once if no result or error appears.</li><li>Shorten extremely large pasted job descriptions.</li><li>Report the approximate time and whether a partial result appeared.</li></ol></article>
+        <article class="card fix"><h3>Generated content is missing or wrong</h3><ol><li>Confirm the relevant accomplishments/Impact Receipts are saved.</li><li>Check the target role and job description.</li><li>Regenerate once after correcting inputs.</li><li>Review final output before using it.</li><li>Do not invent experience to fill an evidence gap.</li></ol></article>
+        <article class="card fix"><h3>Career Intelligence feedback feels unrelated</h3><ol><li>Confirm the target role, competency, or interview type.</li><li>Add more specific evidence about what you personally did.</li><li>Remove irrelevant proof where possible.</li><li>Try again with a clearer job description or accomplishment.</li></ol></article>
+        <article class="card fix"><h3>Export or download fails</h3><ol><li>Allow downloads for usebragstack.com.</li><li>Check the browser download tray/folder.</li><li>Refresh and try once more.</li><li>Try another browser if the download never begins.</li></ol></article>
+      </div></section>
+
+      <section class="section" id="proof"><h2>Accomplishments, Impact Receipts & public proof</h2><div class="grid">
+        <article class="card fix"><h3>An accomplishment will not save</h3><ol><li>Wait for any current save to finish.</li><li>Copy unsaved text somewhere safe.</li><li>Refresh once and retry.</li><li>Reduce unusually large pasted text or attachments.</li><li>Report the exact error.</li></ol></article>
+        <article class="card fix"><h3>Public profile looks outdated</h3><ol><li>Confirm the item is intentionally public.</li><li>Refresh the public page in a new tab.</li><li>Check you are viewing the correct profile/slug.</li><li>Report the public page address and what should have changed.</li></ol></article>
+        <article class="card fix"><h3>Evidence upload fails</h3><ol><li>Check file size and type.</li><li>Rename files with unusual characters.</li><li>Retry on a stable connection.</li><li>Never upload restricted employer/client material just to test the feature.</li></ol></article>
+        <article class="card fix"><h3>Duplicate entries appear</h3><ol><li>Do not click Save repeatedly while a request is processing.</li><li>Refresh the list to confirm the duplicate.</li><li>Delete only the confirmed duplicate.</li><li>Report the exact action that created it.</li></ol></article>
+      </div></section>
+
+      <section class="section" id="app"><h2>Pages that will not load, save, or update</h2><div class="grid">
+        <article class="card fix"><h3>Blank page or endless loading</h3><ol><li>Refresh once.</li><li>Open a new tab and go directly to usebragstack.com.</li><li>Try private/incognito mode.</li><li>Disable extensions that modify scripts, cookies, or requests.</li><li>Try another modern browser.</li></ol></article>
+        <article class="card fix"><h3>Buttons do nothing</h3><ol><li>Wait for any loading indicator to finish.</li><li>Click once, not repeatedly.</li><li>Refresh if the action never begins.</li><li>Try the same action in a private window.</li><li>Report the button label and page.</li></ol></article>
+        <article class="card fix"><h3>Changes disappear after refresh</h3><ol><li>Confirm a save-success message appeared.</li><li>Copy important text before troubleshooting further.</li><li>Retry the save once.</li><li>Sign out and back in if the session may have expired.</li><li>Report which fields failed to persist.</li></ol></article>
+        <article class="card fix"><h3>Unexpected error message</h3><ol><li>Copy the exact message or take a screenshot.</li><li>Note the page and approximate time.</li><li>Record the action performed immediately before the error.</li><li>Refresh once, then retry only once.</li></ol></article>
+      </div></section>
+
+      <section class="section" id="browser"><h2>Browser, cache, cookies & permissions</h2><div class="grid">
+        <article class="card fix"><h3>Site behaves differently in another browser</h3><p>Try a current version of Chrome, Edge, Firefox, or Safari. If the issue only happens in one browser, report the browser name/version and whether extensions are enabled.</p></article>
+        <article class="card fix"><h3>Permissions were denied</h3><p>Open the browser's site settings for usebragstack.com, re-enable the required permission such as microphone or downloads, then reload the page.</p></article>
+        <article class="card fix"><h3>Clearing site data</h3><p>Use this only after simpler fixes. Clearing cookies/site data can sign you out. Save any unsaved work first, then clear site data for usebragstack.com only and sign back in.</p></article>
+        <article class="card fix"><h3>Extensions may be interfering</h3><p>Ad blockers, script blockers, privacy extensions, password managers, and security software can affect OAuth, audio, downloads, or requests. Test in a private window with extensions disabled.</p></article>
+      </div></section>
+
+      <div class="warn"><strong>Security issue?</strong> If you suspect account compromise, data exposure, or a vulnerability, do not use general support. Email <strong>security@usebragstack.com</strong>. Do not include passwords, access tokens, or confidential evidence.</div>
+
+      <section class="support" id="contact"><h2>Still not fixed?</h2><p>Email <a href="mailto:support@usebragstack.com?subject=BragStack%20support%20request">support@usebragstack.com</a> with: the page/feature, what you expected, what happened, exact error text, approximate time, browser/device, and the troubleshooting steps you already tried.</p><p>For security vulnerabilities, suspected compromise, or privacy/data-exposure incidents, email <a href="mailto:security@usebragstack.com?subject=BragStack%20security%20report">security@usebragstack.com</a>.</p></section>
+    </div>
+  </main>
+</body>
+</html>

--- a/frontend/src/SecurityPage.jsx
+++ b/frontend/src/SecurityPage.jsx
@@ -14,7 +14,7 @@ function SecurityPage() {
     <main className="security-page">
       <header className="security-topbar">
         <a className="security-brand" href="/"><img src="/brandmark.svg" alt="" /><strong>BragStack</strong></a>
-        <nav aria-label="Security page navigation"><a href="/docs">Docs</a><a href="/help/troubleshooting.html">Troubleshooting</a><a href="/privacy">Privacy</a><a href="/nda-safety">NDA guidance</a><a href="/login">Sign in</a></nav>
+        <nav aria-label="Security page navigation"><a href="/docs">Docs</a><a href="/privacy">Privacy</a><a href="/nda-safety">NDA guidance</a><a href="/login">Sign in</a></nav>
       </header>
 
       <section className="security-hero">
@@ -22,7 +22,7 @@ function SecurityPage() {
           <span className="security-kicker"><ShieldCheck size={16} /> BRAGSTACK SECURITY</span>
           <h1>Your career proof deserves careful protection.</h1>
           <p>BragStack is designed around a simple idea: your private career evidence should stay private unless you decide otherwise. This page explains our security approach in plain English.</p>
-          <div className="security-actions"><a className="security-primary" href="/docs#privacy">Read privacy & NDA guidance</a><a className="security-secondary" href="/help/troubleshooting.html">Technical troubleshooting</a><a className="security-secondary" href="mailto:support@usebragstack.com?subject=BragStack%20security%20report">Report a security concern</a></div>
+          <div className="security-actions"><a className="security-primary" href="/docs#privacy">Read privacy & NDA guidance</a><a className="security-secondary" href="mailto:security@usebragstack.com?subject=BragStack%20security%20report">Report a security concern</a></div>
         </div>
         <div className="security-lock-card"><ShieldCheck size={42} /><strong>Private by default</strong><span>You decide what becomes public.</span></div>
       </section>
@@ -41,14 +41,7 @@ function SecurityPage() {
 
       <section className="security-guidance">
         <article><h2>What you should never put into BragStack</h2><ul><li>Passwords, API keys, access tokens, or authentication secrets</li><li>Customer data or personal information you are not authorized to retain</li><li>Restricted source code, internal logs, confidential documents, or trade secrets</li><li>Anything your employer, client, contract, or NDA says cannot leave its systems</li></ul><a href="/nda-safety">See our confidential-work guide →</a></article>
-        <article><h2>If something looks wrong</h2><p>If you notice unexpected account activity, a suspicious sign-in, a privacy problem, or a possible vulnerability, contact us with enough detail to investigate. Do not email passwords, access tokens, or confidential evidence.</p><a href="mailto:support@usebragstack.com?subject=BragStack%20security%20report">support@usebragstack.com →</a></article>
-      </section>
-
-      <section className="security-guidance" aria-label="Technical troubleshooting">
-        <article><h2>Sign-in or account access problems</h2><p><strong>Recommended fixes:</strong> retry from the BragStack sign-in page, confirm you are using the same Google, GitHub, or email account you originally registered with, disable aggressive privacy extensions for the sign-in attempt, and try a private/incognito window. If an OAuth window closes or redirects unexpectedly, return to BragStack and sign in again instead of repeatedly refreshing the callback page.</p><a href="/help/troubleshooting.html#signin">Full sign-in guide →</a></article>
-        <article><h2>Payment succeeded but Pro is locked</h2><p><strong>Recommended fixes:</strong> wait a few seconds, refresh the app once, then sign out and back in so your account entitlement can reload. Confirm you completed checkout using the same BragStack account. Do not send card numbers or payment credentials by email; a receipt time and the email used for BragStack are enough for us to investigate.</p><a href="/help/troubleshooting.html#billing">Full billing guide →</a></article>
-        <article><h2>Interview voice, microphone, or Aisha is not working</h2><p><strong>Recommended fixes:</strong> allow microphone permission for usebragstack.com, close other apps that may be using the microphone, reload the interview page, and start a new practice session. If speech is unavailable, use text answering temporarily. Include your browser, device, and what happened immediately before the failure when reporting the issue.</p><a href="/help/troubleshooting.html#interview">Full interview guide →</a></article>
-        <article><h2>Page will not load, save, or update</h2><p><strong>Recommended fixes:</strong> confirm your internet connection, refresh once, then sign out and back in. Avoid submitting the same form repeatedly while a request is still processing. If the problem continues, capture the page name, approximate time, browser, and the exact error message or screenshot. Never include passwords, access tokens, or confidential workplace evidence.</p><a href="/help/troubleshooting.html#app">Full app troubleshooting guide →</a></article>
+        <article><h2>Report a security issue</h2><p>If you notice unexpected account activity, a suspicious sign-in that may indicate compromise, a privacy or data-exposure problem, or a possible vulnerability, contact the security address with enough detail to investigate. Do not email passwords, access tokens, card details, or confidential evidence.</p><a href="mailto:security@usebragstack.com?subject=BragStack%20security%20report">security@usebragstack.com →</a></article>
       </section>
 
       <section className="security-note"><TriangleAlert size={20} /><div><strong>No online service can promise absolute security.</strong><p>BragStack uses reasonable safeguards designed to protect your information, but good account hygiene still matters: use strong credentials, protect your Google or GitHub account, and be careful about what workplace material you retain.</p></div></section>


### PR DESCRIPTION
## What changed
- Removed general product troubleshooting from the Security page.
- Changed all Security-page reporting links to `security@usebragstack.com`.
- Kept the Security page focused on security posture, sensitive-data guidance, and reporting actual security/privacy/vulnerability concerns.
- Added a dedicated troubleshooting page under Docs at `/docs/troubleshooting.html`.
- The new Docs troubleshooting page covers sign-in/OAuth, billing/Stripe/coupons/Pro, Interview Practice and Aisha, microphone/audio/timer issues, Resume Builder, Career Intelligence, accomplishments/Impact Receipts, uploads/public proof, browser/cache/cookie/permission problems, and support escalation.
- General product issues use `support@usebragstack.com`; security issues use `security@usebragstack.com`.

## Intent
Security and product support are now separated cleanly: Security is for security concerns, while operational/product issues live under Docs.