### PR TITLE
Reconstruct uploaded resumes into faithful ATS-safe formatting

### DIFF
--- a/backend/app/resume_builder_routes.py
+++ b/backend/app/resume_builder_routes.py
@@ -12,23 +12,17 @@ from pypdf import PdfReader
 from app.auth import get_current_user
 from app.database import impact_receipts_collection, resume_documents_collection
 from app.plans import require_feature
-from app.resume_builder import analyze_resume, parse_existing_resume_text
+from app.resume_builder import analyze_resume
+from app.resume_import_parser import parse_existing_resume_text
 
 router = APIRouter(prefix="/resume-builder", tags=["resume-builder"])
 MAX_RESUME_BYTES = 5 * 1024 * 1024
-ALLOWED_RESUME_TYPES = {
-    "application/pdf": ".pdf",
-    "application/vnd.openxmlformats-officedocument.wordprocessingml.document": ".docx",
-    "text/plain": ".txt",
-}
-
 
 class ResumeBuildRequest(BaseModel):
     target_role: str = Field(min_length=2, max_length=120)
     job_description: str = Field(min_length=20, max_length=20000)
     selected_receipt_ids: list[str] = Field(default_factory=list, max_length=100)
     existing_resume_text: str = Field(default="", max_length=50000)
-
 
 class ResumeBulletPayload(BaseModel):
     text: str = Field(min_length=1, max_length=500)
@@ -40,7 +34,6 @@ class ResumeBulletPayload(BaseModel):
     has_metrics: bool = False
     edited: bool = False
 
-
 class ResumeSaveRequest(BaseModel):
     title: str = Field(min_length=2, max_length=160)
     target_role: str = Field(min_length=2, max_length=120)
@@ -48,7 +41,6 @@ class ResumeSaveRequest(BaseModel):
     summary: str = Field(default="", max_length=1200)
     bullets: list[ResumeBulletPayload] = Field(default_factory=list, max_length=20)
     skills: list[str] = Field(default_factory=list, max_length=40)
-
 
 def _owned_receipts(user_id: str, selected_ids: list[str]) -> list[dict]:
     query: dict = {"user_id": user_id}
@@ -59,7 +51,6 @@ def _owned_receipts(user_id: str, selected_ids: list[str]) -> list[dict]:
         query["_id"] = {"$in": valid_ids}
     return list(impact_receipts_collection.find(query).sort("created_at", -1).limit(100))
 
-
 def _validate_saved_bullet_sources(user_id: str, bullets: list[ResumeBulletPayload]) -> None:
     receipt_bullets = [bullet for bullet in bullets if bullet.source_kind == "impact-receipt"]
     raw_ids = {bullet.source_receipt_id for bullet in receipt_bullets}
@@ -68,26 +59,15 @@ def _validate_saved_bullet_sources(user_id: str, bullets: list[ResumeBulletPaylo
         raise HTTPException(status_code=400, detail="Every source-linked bullet must reference a valid Impact Receipt")
     if not source_ids:
         return
-    owned_count = impact_receipts_collection.count_documents({
-        "_id": {"$in": [ObjectId(value) for value in source_ids]},
-        "user_id": user_id,
-    })
+    owned_count = impact_receipts_collection.count_documents({"_id": {"$in": [ObjectId(value) for value in source_ids]}, "user_id": user_id})
     if owned_count != len(source_ids):
         raise HTTPException(status_code=400, detail="Resume bullet source does not belong to this account")
-
 
 def _server_readiness(bullets: list[ResumeBulletPayload]) -> dict:
     edited_count = sum(1 for bullet in bullets if bullet.edited)
     imported_count = sum(1 for bullet in bullets if bullet.source_kind == "imported")
     source_linked_count = sum(1 for bullet in bullets if bullet.source_kind == "impact-receipt")
-    return {
-        "source_linked_draft": edited_count == 0 and imported_count == 0,
-        "edited_bullets_needing_review": edited_count,
-        "imported_bullets": imported_count,
-        "source_linked_bullets": source_linked_count,
-        "verification_status": "source-linked" if edited_count == 0 and imported_count == 0 else "mixed-sources",
-    }
-
+    return {"source_linked_draft": edited_count == 0 and imported_count == 0, "edited_bullets_needing_review": edited_count, "imported_bullets": imported_count, "source_linked_bullets": source_linked_count, "verification_status": "source-linked" if edited_count == 0 and imported_count == 0 else "mixed-sources"}
 
 def _extract_uploaded_text(filename: str, content_type: str, data: bytes) -> str:
     suffix = "." + filename.rsplit(".", 1)[-1].lower() if "." in filename else ""
@@ -102,7 +82,6 @@ def _extract_uploaded_text(filename: str, content_type: str, data: bytes) -> str
     if content_type == "text/plain" or suffix == ".txt":
         return data.decode("utf-8", errors="replace")
     raise HTTPException(status_code=415, detail="Upload a PDF, DOCX, or TXT resume")
-
 
 @router.post("/import")
 async def import_resume(file: UploadFile = File(...), current_user: dict = Depends(get_current_user)):
@@ -122,33 +101,15 @@ async def import_resume(file: UploadFile = File(...), current_user: dict = Depen
     if len(text) < 20:
         raise HTTPException(status_code=400, detail="We could not find enough readable text in that resume")
     parsed = parse_existing_resume_text(text)
-    return {
-        "filename": filename,
-        "text": parsed["text"],
-        "summary": parsed["summary"],
-        "bullets": parsed["bullets"],
-        "skills": parsed["skills"],
-        "sections_found": parsed["sections_found"],
-        "sections": parsed.get("sections", {}),
-        "header_lines": parsed.get("header_lines", []),
-        "line_count": parsed["line_count"],
-    }
-
+    return {"filename": filename, "text": parsed["text"], "summary": parsed["summary"], "bullets": parsed["bullets"], "skills": parsed["skills"], "sections_found": parsed["sections_found"], "sections": parsed.get("sections", {}), "header_lines": parsed.get("header_lines", []), "line_count": parsed["line_count"]}
 
 @router.post("/build")
 def build_resume(payload: ResumeBuildRequest, current_user: dict = Depends(get_current_user)):
     require_feature(current_user, "resume_builder")
-    user_id = str(current_user["_id"])
-    receipts = _owned_receipts(user_id, payload.selected_receipt_ids)
-    result = analyze_resume(
-        target_role=payload.target_role,
-        job_description=payload.job_description,
-        receipts=receipts,
-        existing_resume_text=payload.existing_resume_text,
-    )
+    receipts = _owned_receipts(str(current_user["_id"]), payload.selected_receipt_ids)
+    result = analyze_resume(target_role=payload.target_role, job_description=payload.job_description, receipts=receipts, existing_resume_text=payload.existing_resume_text)
     result["source_receipt_count"] = len(receipts)
     return result
-
 
 @router.post("/resumes", status_code=status.HTTP_201_CREATED)
 def save_resume(payload: ResumeSaveRequest, current_user: dict = Depends(get_current_user)):
@@ -157,39 +118,15 @@ def save_resume(payload: ResumeSaveRequest, current_user: dict = Depends(get_cur
     _validate_saved_bullet_sources(user_id, payload.bullets)
     now = datetime.now(timezone.utc)
     bullets = [bullet.model_dump() for bullet in payload.bullets]
-    document = {
-        "user_id": user_id,
-        "title": payload.title.strip(),
-        "target_role": payload.target_role.strip(),
-        "job_description": payload.job_description,
-        "summary": payload.summary,
-        "bullets": bullets,
-        "skills": [skill.strip()[:120] for skill in payload.skills if skill.strip()],
-        "readiness": _server_readiness(payload.bullets),
-        "schema_version": 3,
-        "created_at": now,
-        "updated_at": now,
-    }
+    document = {"user_id": user_id, "title": payload.title.strip(), "target_role": payload.target_role.strip(), "job_description": payload.job_description, "summary": payload.summary, "bullets": bullets, "skills": [skill.strip()[:120] for skill in payload.skills if skill.strip()], "readiness": _server_readiness(payload.bullets), "schema_version": 3, "created_at": now, "updated_at": now}
     result = resume_documents_collection.insert_one(document)
     return {"id": str(result.inserted_id), **{k: v for k, v in document.items() if k != "user_id"}}
-
 
 @router.get("/resumes")
 def list_resumes(current_user: dict = Depends(get_current_user)):
     require_feature(current_user, "resume_builder")
     cursor = resume_documents_collection.find({"user_id": str(current_user["_id"])}).sort("updated_at", -1).limit(50)
-    return {"resumes": [{
-        "id": str(item["_id"]),
-        "title": item.get("title", "Untitled resume"),
-        "target_role": item.get("target_role", ""),
-        "summary": item.get("summary", ""),
-        "bullets": item.get("bullets", []),
-        "skills": item.get("skills", []),
-        "readiness": item.get("readiness", {}),
-        "created_at": item.get("created_at"),
-        "updated_at": item.get("updated_at"),
-    } for item in cursor]}
-
+    return {"resumes": [{"id": str(item["_id"]), "title": item.get("title", "Untitled resume"), "target_role": item.get("target_role", ""), "summary": item.get("summary", ""), "bullets": item.get("bullets", []), "skills": item.get("skills", []), "readiness": item.get("readiness", {}), "created_at": item.get("created_at"), "updated_at": item.get("updated_at")} for item in cursor]}
 
 @router.delete("/resumes/{resume_id}", status_code=status.HTTP_204_NO_CONTENT)
 def delete_resume(resume_id: str, current_user: dict = Depends(get_current_user)):

--- a/backend/app/resume_import_parser.py
+++ b/backend/app/resume_import_parser.py
@@ -56,7 +56,6 @@ def _join_fragments(lines: list[str], start: int) -> tuple[str, int]:
         nxt = _clean(lines[i])
         if not nxt or _heading(nxt) or BULLET_RE.match(nxt) or _date_atom(nxt) or _looks_role(nxt):
             break
-        # PDF column extraction often emits comma-terminated skill/tech fragments.
         if len(parts) >= 1 and _looks_short_label(parts[0]) and _looks_short_label(nxt) and not parts[-1].endswith((",", ";", ":")):
             break
         parts.append(nxt.strip("|"))
@@ -77,12 +76,17 @@ def _repair(raw_text: str) -> list[str]:
             i += 1
             continue
         if _heading(line):
-            out.append(line); i += 1; continue
+            out.append(line)
+            i += 1
+            continue
         if _date_atom(line):
-            parts = [line]; i += 1
+            parts = [line]
+            i += 1
             while i < len(source) and (_date_atom(source[i]) or _clean(source[i]) in {"-", "–", "—"}) and len(parts) < 6:
-                parts.append(source[i]); i += 1
-            out.append(_date_range(parts)); continue
+                parts.append(source[i])
+                i += 1
+            out.append(_date_range(parts))
+            continue
         if BULLET_RE.match(line):
             text = BULLET_RE.sub("", line).strip()
             i += 1
@@ -94,7 +98,8 @@ def _repair(raw_text: str) -> list[str]:
                 i += 1
                 if re.search(r"[.!?]$", text):
                     break
-            out.append("• " + _clean(text)); continue
+            out.append("• " + _clean(text))
+            continue
         out.append(line.strip("| "))
         i += 1
     return [x for x in out if x]
@@ -110,13 +115,16 @@ def parse_existing_resume_text(raw_text: str) -> dict:
         line = lines[i]
         heading = _heading(line)
         if heading:
-            current = heading; i += 1; continue
+            current = heading
+            i += 1
+            continue
         if current is None:
-            header.append(line); i += 1; continue
+            header.append(line)
+            i += 1
+            continue
         sections[current].append(line)
         i += 1
 
-    # Rebuild skills into compact category rows instead of one token per line.
     skill_lines = sections["skills"]
     compact_skills: list[str] = []
     pending_label = ""
@@ -130,7 +138,9 @@ def parse_existing_resume_text(raw_text: str) -> dict:
             compact_skills.append(f"{pending_label} | {line.strip('| ')}")
             pending_label = ""
         elif compact_skills and (line.startswith("|") or len(line.split()) <= 2):
-            compact_skills[-1] = _clean(compact_skills[-1] + ", " + line.strip("| ,"))
+            base = compact_skills[-1].rstrip(" ,;")
+            addition = line.strip("| ,;")
+            compact_skills[-1] = _clean(f"{base}, {addition}")
         else:
             compact_skills.append(line)
     sections["skills"] = compact_skills

--- a/backend/app/resume_import_parser.py
+++ b/backend/app/resume_import_parser.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import re
+
+SECTION_KEYS = ("summary", "skills", "projects", "experience", "education")
+SECTION_NAMES = {
+    "summary": {"summary", "professional summary", "profile", "professional profile"},
+    "skills": {"skills", "technical skills", "core skills", "technical proficiencies"},
+    "projects": {"projects", "technical projects", "selected projects", "project experience"},
+    "experience": {"experience", "work experience", "professional experience", "professional work experience", "employment history"},
+    "education": {"education", "education & training", "training"},
+}
+BULLET_RE = re.compile(r"^[•▪◦*-]\s*")
+MONTH_RE = re.compile(r"^(?:jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:t(?:ember)?)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?|present|current)$", re.I)
+YEAR_RE = re.compile(r"^(?:19|20)\d{2}$")
+ROLE_RE = re.compile(r"\b(?:engineer|analyst|manager|developer|specialist|consultant|administrator|designer|director|lead|coordinator|recruiter|intern)\b", re.I)
+CONTACT_RE = re.compile(r"(?:@|\b\d{3}[-.)\s]\d{3}[-.\s]\d{4}\b|linkedin|github\.com|https?://)", re.I)
+
+
+def _clean(value: str) -> str:
+    return re.sub(r"\s+", " ", value or "").strip()
+
+
+def _heading(line: str) -> str | None:
+    normalized = re.sub(r"[^a-z& ]", "", line.lower()).strip()
+    for key, names in SECTION_NAMES.items():
+        if normalized in names:
+            return key
+    return None
+
+
+def _date_atom(line: str) -> bool:
+    value = _clean(line).strip("|,.-–— ")
+    return bool(MONTH_RE.fullmatch(value) or YEAR_RE.fullmatch(value) or value in {"-", "–", "—"})
+
+
+def _date_range(parts: list[str]) -> str:
+    text = " ".join(_clean(p).strip("|") for p in parts)
+    text = re.sub(r"\s+[-–—]\s+", " – ", text)
+    return _clean(text)
+
+
+def _looks_role(line: str) -> bool:
+    return bool(ROLE_RE.search(line)) and len(line.split()) <= 18
+
+
+def _looks_short_label(line: str) -> bool:
+    words = line.split()
+    return 0 < len(words) <= 8 and not re.search(r"[.!?]$", line)
+
+
+def _join_fragments(lines: list[str], start: int) -> tuple[str, int]:
+    parts = [_clean(lines[start]).strip("|")]
+    i = start + 1
+    while i < len(lines):
+        nxt = _clean(lines[i])
+        if not nxt or _heading(nxt) or BULLET_RE.match(nxt) or _date_atom(nxt) or _looks_role(nxt):
+            break
+        # PDF column extraction often emits comma-terminated skill/tech fragments.
+        if len(parts) >= 1 and _looks_short_label(parts[0]) and _looks_short_label(nxt) and not parts[-1].endswith((",", ";", ":")):
+            break
+        parts.append(nxt.strip("|"))
+        i += 1
+        if re.search(r"[.!?]$", parts[-1]):
+            break
+    return _clean(" ".join(parts)), i
+
+
+def _repair(raw_text: str) -> list[str]:
+    raw_text = re.sub(r"(?<=\S)\s+([•▪◦])\s*", r"\n\1 ", raw_text or "")
+    source = [_clean(x) for x in raw_text.splitlines() if _clean(x)]
+    out: list[str] = []
+    i = 0
+    while i < len(source):
+        line = source[i]
+        if line == "|":
+            i += 1
+            continue
+        if _heading(line):
+            out.append(line); i += 1; continue
+        if _date_atom(line):
+            parts = [line]; i += 1
+            while i < len(source) and (_date_atom(source[i]) or _clean(source[i]) in {"-", "–", "—"}) and len(parts) < 6:
+                parts.append(source[i]); i += 1
+            out.append(_date_range(parts)); continue
+        if BULLET_RE.match(line):
+            text = BULLET_RE.sub("", line).strip()
+            i += 1
+            while i < len(source):
+                nxt = source[i]
+                if _heading(nxt) or BULLET_RE.match(nxt) or _date_atom(nxt) or _looks_role(nxt):
+                    break
+                text += " " + nxt.strip("|")
+                i += 1
+                if re.search(r"[.!?]$", text):
+                    break
+            out.append("• " + _clean(text)); continue
+        out.append(line.strip("| "))
+        i += 1
+    return [x for x in out if x]
+
+
+def parse_existing_resume_text(raw_text: str) -> dict:
+    lines = _repair(raw_text)
+    sections = {key: [] for key in SECTION_KEYS}
+    header: list[str] = []
+    current: str | None = None
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        heading = _heading(line)
+        if heading:
+            current = heading; i += 1; continue
+        if current is None:
+            header.append(line); i += 1; continue
+        sections[current].append(line)
+        i += 1
+
+    # Rebuild skills into compact category rows instead of one token per line.
+    skill_lines = sections["skills"]
+    compact_skills: list[str] = []
+    pending_label = ""
+    for line in skill_lines:
+        if line == "|":
+            continue
+        if _looks_short_label(line) and not any(ch in line for ch in ",;|") and line.lower() in {"languages", "frameworks", "libraries", "tools", "platforms", "databases", "cloud", "operating systems"}:
+            pending_label = line
+            continue
+        if pending_label:
+            compact_skills.append(f"{pending_label} | {line.strip('| ')}")
+            pending_label = ""
+        elif compact_skills and (line.startswith("|") or len(line.split()) <= 2):
+            compact_skills[-1] = _clean(compact_skills[-1] + ", " + line.strip("| ,"))
+        else:
+            compact_skills.append(line)
+    sections["skills"] = compact_skills
+
+    bullets = [BULLET_RE.sub("", x).strip() for x in sections["experience"] if BULLET_RE.match(x) and len(BULLET_RE.sub("", x).strip()) >= 18]
+    if not bullets:
+        bullets = [BULLET_RE.sub("", x).strip() for x in lines if BULLET_RE.match(x) and len(BULLET_RE.sub("", x).strip()) >= 18]
+    skills: list[str] = []
+    for line in sections["skills"]:
+        value = line.split("|", 1)[-1]
+        for skill in re.split(r"[,;•·/]", value):
+            skill = _clean(skill)
+            if 1 < len(skill) <= 80 and skill.lower() not in {x.lower() for x in skills}:
+                skills.append(skill)
+    summary = " ".join(sections["summary"][:3])[:1200]
+    return {
+        "summary": summary,
+        "bullets": bullets[:20],
+        "skills": skills[:40],
+        "sections_found": [k for k, v in sections.items() if v],
+        "sections": {k: v[:100] for k, v in sections.items() if v},
+        "header_lines": header[:12],
+        "line_count": len(lines),
+        "text": "\n".join(lines)[:50000],
+    }

--- a/backend/tests/test_resume_import_parser.py
+++ b/backend/tests/test_resume_import_parser.py
@@ -47,7 +47,8 @@ Georgia State University | Computer Science
     assert "June 2024 – July 2025" in experience
     assert "August 2021 – August 2022" in experience
     assert any(line.startswith("• Delivered technical support") for line in experience)
-    assert "Languages | Python," in parsed["sections"]["skills"]
+    assert "Languages | Python, JavaScript, React" in parsed["sections"]["skills"]
+    assert all(",," not in line for line in parsed["sections"]["skills"])
 
 
 def test_contact_header_does_not_become_resume_section_content():

--- a/backend/tests/test_resume_import_parser.py
+++ b/backend/tests/test_resume_import_parser.py
@@ -1,0 +1,68 @@
+from app.resume_import_parser import parse_existing_resume_text
+
+
+def test_fragmented_resume_keeps_sections_and_dates_together():
+    raw = """Tobias Scott
+Software Engineer / Technical Support Engineer
+Atlanta, GA | person@example.com | 470-000-0000
+SKILLS
+Languages
+|
+Python,
+JavaScript,
+React
+TECHNICAL PROJECTS
+Personal Website
+|
+React, Twitter API, Google Analytics, Github pages
+|
+PORTFOLIO • Crafted a portfolio website with integrated GitHub and Twitter feeds. Enhanced visitor engagement through SEO and Google Analytics tracking, significantly boosting daily traffic.
+PROFESSIONAL WORK EXPERIENCE
+Robin Powered | Senior Support Specialist
+|
+June
+2024
+-
+July
+2025
+• Delivered technical support and documented recurring issues for engineering.
+Zingtree | Technical Support Engineer
+|
+August
+2021
+-
+August
+2022
+• Delivered support for Salesforce, Zendesk, Zapier, and CRM systems.
+EDUCATION
+Georgia State University | Computer Science
+"""
+    parsed = parse_existing_resume_text(raw)
+    assert "skills" in parsed["sections_found"]
+    assert "projects" in parsed["sections_found"]
+    assert "experience" in parsed["sections_found"]
+    assert "education" in parsed["sections_found"]
+    assert all(line != "|" for values in parsed["sections"].values() for line in values)
+    experience = parsed["sections"]["experience"]
+    assert "June 2024 – July 2025" in experience
+    assert "August 2021 – August 2022" in experience
+    assert any(line.startswith("• Delivered technical support") for line in experience)
+    assert "Languages | Python," in parsed["sections"]["skills"]
+
+
+def test_contact_header_does_not_become_resume_section_content():
+    raw = """Tobias Scott
+Software Engineer / Technical Support Engineer
+Atlanta, GA | person@example.com | 470-000-0000
+PROJECTS
+Personal Website
+• Built a portfolio website.
+EXPERIENCE
+Zingtree | Technical Support Engineer
+August 2021 - August 2022
+• Supported customer integrations.
+"""
+    parsed = parse_existing_resume_text(raw)
+    assert parsed["header_lines"][0] == "Tobias Scott"
+    assert any("person@example.com" in line for line in parsed["header_lines"])
+    assert "Personal Website" in parsed["sections"]["projects"]


### PR DESCRIPTION
Fixes the uploaded-resume preview corruption shown in production. Adds a dedicated structured import parser that removes stray PDF column separators, rebuilds split date ranges, preserves section hierarchy, compacts skills, keeps project/experience bullets together, and prevents raw PDF fragments from becoming presentation rows. Adds regression tests modeled on the observed Personal Website / Zingtree / Robin Powered fragmentation. ATS Coach UI is intentionally unchanged.