### PR TITLE
Strengthen Google sitelink and search appearance signals

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Test structured resume helpers
         run: npm run test:resume
 
+      - name: Verify search appearance and sitelink signals
+        run: npm run test:seo
+
       - name: Lint
         run: npm run lint
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint .",
     "test:interview": "node --test src/interviewEngine*.test.js",
     "test:resume": "node --test src/resumeStructured.test.js",
+    "test:seo": "node scripts/verify-search-appearance.mjs",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -1,8 +1,6 @@
 User-agent: *
 Allow: /
 Disallow: /app/
-Disallow: /login
-Disallow: /register
 Disallow: /upgrade
 
 Sitemap: https://usebragstack.com/sitemap.xml

--- a/frontend/scripts/verify-search-appearance.mjs
+++ b/frontend/scripts/verify-search-appearance.mjs
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const read = (path) => readFileSync(new URL(`../${path}`, import.meta.url), "utf8");
+
+const robots = read("public/robots.txt");
+const sitemap = read("public/sitemap.xml");
+const searchMeta = read("src/useSearchAppearanceMeta.js");
+const sitelinksNav = read("src/SearchSitelinksNav.jsx");
+
+const publicSitelinks = [
+  "/resume-accomplishments",
+  "/interview-preparation",
+  "/impact-receipts",
+  "/pricing",
+  "/docs",
+  "/login",
+  "/register",
+];
+
+assert.match(robots, /Sitemap:\s+https:\/\/usebragstack\.com\/sitemap\.xml/);
+assert.match(robots, /Disallow:\s+\/app\//);
+assert.doesNotMatch(robots, /Disallow:\s+\/login/);
+assert.doesNotMatch(robots, /Disallow:\s+\/register/);
+
+for (const path of publicSitelinks) {
+  assert.ok(sitemap.includes(`<loc>https://usebragstack.com${path}</loc>`), `${path} must be present in sitemap.xml`);
+  assert.ok(searchMeta.includes(`"${path}"`), `${path} must be represented in search appearance metadata`);
+  assert.ok(sitelinksNav.includes(`"${path}"`), `${path} must be linked from the crawlable homepage sitelinks navigation`);
+}
+
+assert.match(searchMeta, /NOINDEX_PREFIXES\s*=\s*\["\/app"\]/);
+assert.match(searchMeta, /"\/upgrade"/);
+assert.match(searchMeta, /"\/verify-receipt"/);
+assert.match(searchMeta, /SiteNavigationElement/);
+assert.match(searchMeta, /max-image-preview:large/);
+
+console.log("Search appearance checks passed.");

--- a/frontend/src/SearchSitelinksNav.jsx
+++ b/frontend/src/SearchSitelinksNav.jsx
@@ -3,6 +3,7 @@ import "./SearchSitelinksNav.css";
 const LINKS = [
   ["Resume Builder", "/resume-accomplishments", "Build evidence-backed resume material"],
   ["Practice Interviewer", "/interview-preparation", "Practice role-specific interview stories"],
+  ["Impact Receipts", "/impact-receipts", "Turn accomplishments into reusable proof"],
   ["Pricing", "/pricing", "Compare Free and Pro"],
   ["Docs", "/docs", "Learn the BragStack workflow"],
   ["Log in", "/login", "Open your BragStack account"],

--- a/frontend/src/useSearchAppearanceMeta.js
+++ b/frontend/src/useSearchAppearanceMeta.js
@@ -22,12 +22,15 @@ const PUBLIC_META = {
 const SITELINKS = [
   ["Resume Builder", "/resume-accomplishments"],
   ["Practice Interviewer", "/interview-preparation"],
+  ["Impact Receipts", "/impact-receipts"],
   ["Pricing", "/pricing"],
   ["Docs", "/docs"],
   ["Log in", "/login"],
   ["Sign up", "/register"],
 ];
 
+const NOINDEX_PREFIXES = ["/app"];
+const NOINDEX_PATHS = new Set(["/upgrade", "/verify-receipt"]);
 const OFFICIAL_LOGO_URL = "https://usebragstack.com/bragstack-logo-192.png";
 
 function ensureMeta(selector, attributes) {
@@ -64,9 +67,19 @@ function installOfficialIcon() {
   appleTouch.href = "/bragstack-logo-192.png?v=1";
 }
 
+function isNoindexPath(path) {
+  return NOINDEX_PATHS.has(path) || NOINDEX_PREFIXES.some((prefix) => path === prefix || path.startsWith(`${prefix}/`));
+}
+
 export default function useSearchAppearanceMeta(path) {
   useEffect(() => {
     installOfficialIcon();
+
+    const robots = ensureMeta('meta[name="robots"]', { name: "robots" });
+    robots.setAttribute("content", isNoindexPath(path) ? "noindex, nofollow" : "index, follow, max-image-preview:large");
+
+    const googlebot = ensureMeta('meta[name="googlebot"]', { name: "googlebot" });
+    googlebot.setAttribute("content", isNoindexPath(path) ? "noindex, nofollow" : "index, follow, max-image-preview:large");
 
     const meta = PUBLIC_META[path];
     if (meta) {
@@ -125,6 +138,11 @@ export default function useSearchAppearanceMeta(path) {
             url: `https://usebragstack.com${href}`,
           })),
         },
+        ...SITELINKS.map(([name, href]) => ({
+          "@type": "SiteNavigationElement",
+          name,
+          url: `https://usebragstack.com${href}`,
+        })),
       ],
     };
 


### PR DESCRIPTION
## What changed
- allow Google to crawl the public `/login` and `/register` pages so they can qualify as sitelinks
- keep authenticated `/app/*`, upgrade, and receipt-verification surfaces out of search via route-aware robots metadata
- add explicit Googlebot/indexing directives with large image preview support
- expand homepage structured data with `SiteNavigationElement` entries for key BragStack destinations
- add a regression check that verifies robots.txt, sitemap coverage, homepage sitelink navigation, and metadata stay aligned
- run the SEO regression check in Frontend CI

## Why
Google chooses sitelinks automatically, so the best lever we control is a clean, crawlable site hierarchy with consistent metadata, structured navigation, sitemap coverage, and no crawler contradictions. This PR removes the biggest contradiction: `/login` and `/register` were in the sitemap and homepage sitelink signals while robots.txt blocked them.

## Expected search result shape
Primary BragStack result with strong eligibility for sitelinks such as Resume Builder, Practice Interviewer, Impact Receipts, Pricing, Docs, Log in, and Sign up.

Google still decides whether and when sitelinks appear after recrawling/indexing.