### PR TITLE
Harden API security headers and CORS

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -34,34 +34,74 @@ from app.public_slug_routes import router as public_slug_router
 from app.reports_routes import router as reports_router
 from app.resume_builder_routes import router as resume_builder_router
 from app.routes import public_router, router as entries_router
+from app.security import add_security_headers
 
 app = FastAPI(title="BragStack API", description="Evidence-backed career proof for accomplishments, impact, and reports.", version="1.0.0")
 frontend_url = os.getenv("FRONTEND_URL", "http://localhost:5173").rstrip("/")
 ENTRY_EDIT_WINDOW = timedelta(hours=1)
 mongo_admin = mongo_client.admin
-app.add_middleware(CORSMiddleware, allow_origins=[frontend_url, "http://localhost:5173", "http://127.0.0.1:5173"], allow_origin_regex=r"https://.*\.app\.github\.dev", allow_credentials=True, allow_methods=["*"], allow_headers=["*"])
+
+app.middleware("http")(add_security_headers)
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=[frontend_url, "http://localhost:5173", "http://127.0.0.1:5173"],
+    allow_origin_regex=r"https://.*\.app\.github\.dev",
+    allow_credentials=True,
+    allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "HEAD"],
+    allow_headers=["Authorization", "Content-Type", "Accept"],
+)
+
 
 def _as_utc(value: datetime) -> datetime:
-    if value.tzinfo is None: return value.replace(tzinfo=timezone.utc)
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
     return value.astimezone(timezone.utc)
 
+
 def enforce_entry_usage(request: Request, current_user: dict = Depends(get_current_user)):
-    path=request.url.path.rstrip("/"); user_id=str(current_user["_id"])
-    if request.method=="POST" and path=="/entries":
-        enforce_usage_limit(user=current_user,entitlement_name="max_entries",current_count=entries_collection.count_documents({"user_id":user_id}),resource_name="proof entries"); return
-    if request.method!="PUT" or not path.startswith("/entries/"): return
-    entry_id=path.removeprefix("/entries/")
-    if not ObjectId.is_valid(entry_id): return
-    existing_entry=entries_collection.find_one({"_id":ObjectId(entry_id),"user_id":user_id},{"created_at":1})
-    if not existing_entry: return
-    created_at=existing_entry.get("created_at")
-    if not isinstance(created_at,datetime): raise HTTPException(status_code=403,detail="This accomplishment can no longer be edited.")
-    if datetime.now(timezone.utc)-_as_utc(created_at)>=ENTRY_EDIT_WINDOW: raise HTTPException(status_code=403,detail="The 60-minute edit window for this accomplishment has ended.")
+    path = request.url.path.rstrip("/")
+    user_id = str(current_user["_id"])
+    if request.method == "POST" and path == "/entries":
+        enforce_usage_limit(
+            user=current_user,
+            entitlement_name="max_entries",
+            current_count=entries_collection.count_documents({"user_id": user_id}),
+            resource_name="proof entries",
+        )
+        return
+    if request.method != "PUT" or not path.startswith("/entries/"):
+        return
+    entry_id = path.removeprefix("/entries/")
+    if not ObjectId.is_valid(entry_id):
+        return
+    existing_entry = entries_collection.find_one(
+        {"_id": ObjectId(entry_id), "user_id": user_id},
+        {"created_at": 1},
+    )
+    if not existing_entry:
+        return
+    created_at = existing_entry.get("created_at")
+    if not isinstance(created_at, datetime):
+        raise HTTPException(status_code=403, detail="This accomplishment can no longer be edited.")
+    if datetime.now(timezone.utc) - _as_utc(created_at) >= ENTRY_EDIT_WINDOW:
+        raise HTTPException(status_code=403, detail="The 60-minute edit window for this accomplishment has ended.")
+
 
 def enforce_receipt_usage(request: Request, current_user: dict = Depends(get_current_user)):
-    path=request.url.path.rstrip("/"); is_create=request.method=="POST" and (path=="/impact-receipts" or path.startswith("/impact-receipts/from-entry/"))
-    if not is_create: return
-    user_id=str(current_user["_id"]); enforce_usage_limit(user=current_user,entitlement_name="max_impact_receipts",current_count=impact_receipts_collection.count_documents({"user_id":user_id}),resource_name="Impact Receipts")
+    path = request.url.path.rstrip("/")
+    is_create = request.method == "POST" and (
+        path == "/impact-receipts" or path.startswith("/impact-receipts/from-entry/")
+    )
+    if not is_create:
+        return
+    user_id = str(current_user["_id"])
+    enforce_usage_limit(
+        user=current_user,
+        entitlement_name="max_impact_receipts",
+        current_count=impact_receipts_collection.count_documents({"user_id": user_id}),
+        resource_name="Impact Receipts",
+    )
+
 
 app.include_router(auth_router)
 app.include_router(oauth_router)
@@ -90,16 +130,21 @@ app.include_router(certification_packet_router)
 app.include_router(certification_packet_export_router)
 app.include_router(resume_builder_router)
 
+
 @app.get("/")
-def root(): return {"message":"BragStack API is running"}
+def root():
+    return {"message": "BragStack API is running"}
+
 
 @app.head("/", include_in_schema=False)
 def root_head():
     return None
 
+
 @app.get("/health")
 def health():
     return {"status": "ok"}
+
 
 @app.get("/ready")
 def ready():

--- a/backend/app/security.py
+++ b/backend/app/security.py
@@ -1,0 +1,27 @@
+from fastapi import Request
+
+
+SECURITY_HEADERS = {
+    "X-Content-Type-Options": "nosniff",
+    "X-Frame-Options": "DENY",
+    "Referrer-Policy": "strict-origin-when-cross-origin",
+    "Permissions-Policy": "camera=(), geolocation=(), microphone=(self)",
+    "Cross-Origin-Opener-Policy": "same-origin",
+    "Cross-Origin-Resource-Policy": "same-site",
+}
+
+
+async def add_security_headers(request: Request, call_next):
+    response = await call_next(request)
+
+    for name, value in SECURITY_HEADERS.items():
+        response.headers.setdefault(name, value)
+
+    if request.url.scheme == "https":
+        response.headers.setdefault(
+            "Strict-Transport-Security",
+            "max-age=31536000; includeSubDomains",
+        )
+
+    response.headers.setdefault("Cache-Control", "no-store")
+    return response

--- a/backend/tests/test_security_headers.py
+++ b/backend/tests/test_security_headers.py
@@ -1,0 +1,60 @@
+from fastapi.testclient import TestClient
+
+import app.main as main
+
+
+client = TestClient(main.app)
+
+
+def test_security_headers_are_applied_to_api_responses():
+    response = client.get("/health")
+
+    assert response.status_code == 200
+    assert response.headers["x-content-type-options"] == "nosniff"
+    assert response.headers["x-frame-options"] == "DENY"
+    assert response.headers["referrer-policy"] == "strict-origin-when-cross-origin"
+    assert response.headers["permissions-policy"] == "camera=(), geolocation=(), microphone=(self)"
+    assert response.headers["cross-origin-opener-policy"] == "same-origin"
+    assert response.headers["cross-origin-resource-policy"] == "same-site"
+    assert response.headers["cache-control"] == "no-store"
+
+
+def test_cors_allows_known_frontend_origin_and_expected_method():
+    response = client.options(
+        "/health",
+        headers={
+            "Origin": "http://localhost:5173",
+            "Access-Control-Request-Method": "GET",
+            "Access-Control-Request-Headers": "authorization,content-type",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.headers["access-control-allow-origin"] == "http://localhost:5173"
+    assert "GET" in response.headers["access-control-allow-methods"]
+
+
+def test_cors_rejects_unknown_origin():
+    response = client.options(
+        "/health",
+        headers={
+            "Origin": "https://evil.example",
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+
+    assert response.status_code == 400
+    assert "access-control-allow-origin" not in response.headers
+
+
+def test_cors_rejects_unapproved_request_header():
+    response = client.options(
+        "/health",
+        headers={
+            "Origin": "http://localhost:5173",
+            "Access-Control-Request-Method": "GET",
+            "Access-Control-Request-Headers": "x-not-allowed",
+        },
+    )
+
+    assert response.status_code == 400


### PR DESCRIPTION
Phase 1 security hardening for BragStack.

Changes:
- Adds global API security headers: nosniff, frame denial, referrer policy, permissions policy, COOP, CORP, no-store, and HSTS on HTTPS
- Replaces wildcard CORS methods/headers with the exact HTTP verbs and request headers BragStack uses
- Adds backend tests for security headers, allowed frontend origins, rejected unknown origins, and rejected unapproved request headers

Audit notes:
- OAuth state handling is already strong (random state + HttpOnly/Secure/SameSite cookie + constant-time comparison)
- Stripe webhook verification already validates HMAC signatures and timestamp freshness
- Packet shares already use random hashed tokens, bcrypt-hashed access codes, owner-scoped revoke queries, and no-store/no-referrer responses

Follow-up security work should focus on auth endpoint rate limiting and revocable/shorter-lived sessions.