### PR TITLE
SEO/UI: modernize BragStack product landing pages

### DIFF
--- a/frontend/src/SeoLandingPages.css
+++ b/frontend/src/SeoLandingPages.css
@@ -1,0 +1,108 @@
+.seo-product-page { padding-bottom: 3rem; }
+
+.seo-product-hero,
+.seo-value-section,
+.seo-explore-section,
+.seo-final-cta {
+  width: min(1180px, calc(100% - 2rem));
+  margin-inline: auto;
+}
+
+.seo-product-hero {
+  padding: clamp(4.5rem, 9vw, 8rem) 0 5rem;
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(320px, .85fr);
+  align-items: center;
+  gap: clamp(2rem, 6vw, 5rem);
+}
+
+.seo-product-hero .landing-hero-copy h1 {
+  font-size: clamp(3.25rem, 7vw, 6.4rem);
+}
+
+.seo-trust-row {
+  margin-top: 1.5rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: .7rem 1.1rem;
+  color: var(--landing-muted);
+  font-size: .78rem;
+  font-weight: 750;
+}
+
+.seo-trust-row span,
+.seo-summary-list span {
+  display: inline-flex;
+  align-items: center;
+  gap: .4rem;
+}
+
+.seo-product-summary {
+  padding: clamp(1.5rem, 4vw, 2.2rem);
+  border: 1px solid var(--landing-border);
+  border-radius: 28px;
+  background: linear-gradient(145deg, rgba(20,32,54,.94), rgba(9,16,29,.94));
+  box-shadow: 0 34px 80px rgba(0,0,0,.3);
+}
+
+.seo-summary-label,
+.seo-card-number {
+  color: var(--landing-blue);
+  font-size: .7rem;
+  font-weight: 950;
+  letter-spacing: .14em;
+}
+
+.seo-summary-icon {
+  width: 58px;
+  height: 58px;
+  margin: 1.4rem 0 2.5rem;
+  display: grid;
+  place-items: center;
+  border: 1px solid rgba(166,220,255,.22);
+  border-radius: 18px;
+  background: rgba(166,220,255,.08);
+  color: var(--landing-blue);
+}
+
+.seo-product-summary h2 { margin: 0; font-size: clamp(1.7rem, 3vw, 2.35rem); letter-spacing: -.04em; }
+.seo-product-summary > p { color: var(--landing-muted); line-height: 1.7; }
+.seo-summary-list { display: grid; gap: .8rem; margin-top: 1.4rem; color: #d8e2ef; font-size: .88rem; }
+
+.seo-value-section { padding: 5.5rem 0; border-top: 1px solid var(--landing-border); }
+.seo-section-copy { display: block; margin-top: 1rem; color: var(--landing-muted); line-height: 1.7; }
+.seo-value-grid { display: grid; grid-template-columns: repeat(3, minmax(0,1fr)); gap: 1rem; }
+.seo-value-card { min-height: 245px; padding: 1.5rem; border: 1px solid var(--landing-border); border-radius: 22px; background: rgba(13,21,38,.62); }
+.seo-value-card h3 { margin: 4rem 0 .7rem; font-size: 1.18rem; }
+.seo-value-card p { margin: 0; color: var(--landing-muted); line-height: 1.65; }
+
+.seo-explore-section { padding: 5rem 0; }
+.seo-explore-heading { margin-bottom: 2rem; display: flex; justify-content: space-between; align-items: end; gap: 2rem; }
+.seo-explore-heading h2 { margin: 0; font-size: clamp(2rem, 4vw, 3.6rem); letter-spacing: -.05em; }
+.seo-explore-heading > p { max-width: 420px; margin: 0; color: var(--landing-muted); line-height: 1.65; }
+.seo-related-grid { display: grid; grid-template-columns: repeat(2,minmax(0,1fr)); gap: .8rem; }
+.seo-related-card { min-height: 82px; padding: 1rem 1.2rem; display: flex; align-items: center; justify-content: space-between; border: 1px solid var(--landing-border); border-radius: 18px; background: rgba(13,21,38,.62); font-weight: 850; transition: transform 160ms ease, border-color 160ms ease, background 160ms ease; }
+.seo-related-card:hover { transform: translateY(-2px); border-color: rgba(166,220,255,.38); background: rgba(20,32,54,.85); }
+
+.seo-final-cta { margin-top: 3rem; padding: clamp(2rem,5vw,3.5rem); display: flex; align-items: center; justify-content: space-between; gap: 2rem; border: 1px solid rgba(166,220,255,.2); border-radius: 28px; background: linear-gradient(120deg,rgba(41,83,119,.22),rgba(91,63,154,.18)); }
+.seo-final-cta h2 { margin: 0; font-size: clamp(2rem,4vw,3.5rem); letter-spacing: -.05em; }
+.seo-final-cta p:last-child { max-width: 620px; margin-bottom: 0; color: var(--landing-muted); line-height: 1.65; }
+.seo-final-cta .landing-btn { flex: 0 0 auto; }
+
+@media (max-width: 900px) {
+  .seo-product-hero { grid-template-columns: 1fr; padding-top: 4rem; }
+  .seo-value-grid { grid-template-columns: 1fr; }
+  .seo-value-card { min-height: 190px; }
+  .seo-value-card h3 { margin-top: 2.5rem; }
+  .seo-explore-heading, .seo-final-cta { align-items: flex-start; flex-direction: column; }
+}
+
+@media (max-width: 700px) {
+  .seo-product-hero, .seo-value-section, .seo-explore-section, .seo-final-cta { width: min(100% - 1.25rem, 1180px); }
+  .seo-product-hero { padding-top: 3.25rem; }
+  .seo-product-hero .landing-hero-copy h1 { font-size: clamp(2.8rem, 14vw, 4.5rem); }
+  .seo-related-grid { grid-template-columns: 1fr; }
+  .seo-trust-row { display: grid; }
+  .seo-final-cta { border-radius: 22px; }
+  .seo-final-cta .landing-btn { width: 100%; }
+}

--- a/frontend/src/SeoLandingPages.jsx
+++ b/frontend/src/SeoLandingPages.jsx
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import {
   ArrowRight,
   Briefcase,
+  Check,
   FileText,
   ReceiptText,
   Search,
@@ -10,6 +11,7 @@ import {
   UserRound,
 } from "lucide-react";
 import { getSeoSitelinkTitle } from "./seoSitelinkMeta.js";
+import { PRIMARY_SITELINKS } from "./seoSitelinks.js";
 
 const ICONS = {
   briefcase: Briefcase,
@@ -21,15 +23,6 @@ const ICONS = {
   user: UserRound,
 };
 
-const SITELINKS = [
-  ["Resume Builder", "/resume-accomplishments"],
-  ["Practice Interviewer", "/interview-preparation"],
-  ["Impact Receipts", "/impact-receipts"],
-  ["Pricing", "/pricing"],
-  ["Docs", "/docs"],
-  ["How BragStack Works", "/how-it-works"],
-];
-
 function setMetaContent(selector, value) {
   const element = document.querySelector(selector);
   if (element) element.setAttribute("content", value);
@@ -38,6 +31,7 @@ function setMetaContent(selector, value) {
 function SeoLandingPage({ content }) {
   const Icon = ICONS[content.icon] || FileText;
   const path = window.location.pathname.replace(/\/$/, "") || "/";
+  const relatedLinks = PRIMARY_SITELINKS.filter(({ href }) => href !== path && href !== "/login").slice(0, 4);
 
   useEffect(() => {
     const title = getSeoSitelinkTitle(path, `${content.eyebrow} | BragStack`);
@@ -56,63 +50,90 @@ function SeoLandingPage({ content }) {
   }, [content, path]);
 
   return (
-    <main className="landing-page">
+    <main className="landing-page seo-product-page">
       <header className="landing-nav">
-        <a className="landing-logo" href="/">BragStack</a>
-        <nav className="landing-nav-links" aria-label="BragStack">
+        <a className="landing-logo" href="/" aria-label="BragStack home">BragStack</a>
+        <nav className="landing-nav-links" aria-label="BragStack products">
           <a href="/resume-accomplishments">Resume Builder</a>
-          <a href="/interview-preparation">Practice Interviewer</a>
+          <a href="/interview-preparation">Interview Prep</a>
+          <a href="/impact-receipts">Impact Receipts</a>
           <a href="/pricing">Pricing</a>
-          <a href="/docs">Docs</a>
         </nav>
         <div className="landing-nav-actions">
-          <a className="landing-login-link" href="/login">Log in</a>
+          <a className="landing-login-link" href="/login">Sign in</a>
           <a className="landing-btn landing-btn-small" href="/register">Start free</a>
         </div>
       </header>
 
-      <section className="landing-hero" style={{ minHeight: "auto", paddingBottom: 48 }}>
+      <section className="seo-product-hero">
         <div className="landing-hero-copy">
           <div className="landing-eyebrow"><Icon size={16} />{content.eyebrow}</div>
           <h1>{content.title}</h1>
           <p className="landing-hero-description">{content.description}</p>
           <div className="landing-hero-actions">
-            <a className="landing-btn" href="/register">Start building career proof <ArrowRight size={18} /></a>
-            <a className="landing-btn landing-btn-secondary" href="/how-it-works">How BragStack works</a>
+            <a className="landing-btn" href="/register">Start free <ArrowRight size={18} /></a>
+            <a className="landing-btn landing-btn-secondary" href="/how-it-works">See how it works</a>
+          </div>
+          <div className="seo-trust-row" aria-label="BragStack benefits">
+            <span><Check size={15} /> No credit card</span>
+            <span><Check size={15} /> Your proof stays connected</span>
+            <span><Check size={15} /> Built for real career moments</span>
           </div>
         </div>
+
+        <aside className="seo-product-summary" aria-label={`${content.eyebrow} overview`}>
+          <span className="seo-summary-label">WHAT YOU GET</span>
+          <div className="seo-summary-icon"><Icon size={28} /></div>
+          <h2>Turn your work into career-ready proof.</h2>
+          <p>Capture the context behind what you did, then reuse that evidence when a resume, interview, or opportunity needs it.</p>
+          <div className="seo-summary-list">
+            {content.points.slice(0, 3).map((point) => <span key={point}><Check size={16} /> {point}</span>)}
+          </div>
+        </aside>
       </section>
 
-      <section className="landing-problem-section">
+      <section className="seo-value-section">
         <div className="landing-section-heading">
-          <p>BUILT FOR CAREER PROOF</p>
-          <h2>Use documented accomplishments everywhere your work needs to speak for you.</h2>
+          <p>BUILT AROUND YOUR EVIDENCE</p>
+          <h2>Useful when your work needs to speak for you.</h2>
+          <span className="seo-section-copy">Keep the accomplishment, context, result, and supporting proof together instead of rebuilding your story every time.</span>
         </div>
-        <div className="problem-card-grid">
+        <div className="seo-value-grid">
           {content.points.map((point, index) => (
-            <article className="problem-card" key={point}>
-              <span>0{index + 1}</span>
+            <article className="seo-value-card" key={point}>
+              <span className="seo-card-number">0{index + 1}</span>
               <h3>{point}</h3>
-              <p>BragStack keeps the source accomplishment connected to the context and proof behind it.</p>
+              <p>Use the evidence already in your BragStack to make this career moment clearer, faster, and easier to support.</p>
             </article>
           ))}
         </div>
       </section>
 
-      <section className="landing-feature-section">
-        <div className="landing-feature-copy">
-          <p className="landing-mini-label">EXPLORE BRAGSTACK</p>
-          <h2>Career proof for the moments that matter.</h2>
-          <div className="problem-card-grid">
-            {SITELINKS.filter(([, href]) => href !== path).map(([label, href], index) => (
-              <a className="problem-card" href={href} key={href} style={{ textDecoration: "none" }}>
-                <span>0{index + 1}</span>
-                <h3>{label}</h3>
-                <p>Learn more about {label.toLowerCase()} →</p>
-              </a>
-            ))}
+      <section className="seo-explore-section">
+        <div className="seo-explore-heading">
+          <div>
+            <p className="landing-mini-label">EXPLORE BRAGSTACK</p>
+            <h2>One career story. Connected tools.</h2>
           </div>
+          <p>Move between the tools without losing the evidence behind your work.</p>
         </div>
+        <nav className="seo-related-grid" aria-label="Related BragStack pages">
+          {relatedLinks.map(({ label, href }) => (
+            <a className="seo-related-card" href={href} key={href}>
+              <span>{label}</span>
+              <ArrowRight size={18} />
+            </a>
+          ))}
+        </nav>
+      </section>
+
+      <section className="seo-final-cta">
+        <div>
+          <p className="landing-mini-label">YOUR WORK ALREADY HAPPENED</p>
+          <h2>Make sure you can prove it.</h2>
+          <p>Start building a career record you can actually use when the next opportunity arrives.</p>
+        </div>
+        <a className="landing-btn" href="/register">Build your BragStack <ArrowRight size={18} /></a>
       </section>
     </main>
   );

--- a/frontend/src/SeoLandingPages.jsx
+++ b/frontend/src/SeoLandingPages.jsx
@@ -1,32 +1,12 @@
 import { useEffect } from "react";
-import {
-  ArrowRight,
-  Briefcase,
-  Check,
-  FileText,
-  ReceiptText,
-  Search,
-  Target,
-  TrendingUp,
-  UserRound,
-} from "lucide-react";
+import { ArrowRight, Briefcase, Check, FileText, ReceiptText, Search, Target, TrendingUp, UserRound } from "lucide-react";
 import { getSeoSitelinkTitle } from "./seoSitelinkMeta.js";
 import { PRIMARY_SITELINKS } from "./seoSitelinks.js";
+import "./SeoLandingPages.css";
 
-const ICONS = {
-  briefcase: Briefcase,
-  file: FileText,
-  receipt: ReceiptText,
-  search: Search,
-  target: Target,
-  trend: TrendingUp,
-  user: UserRound,
-};
+const ICONS = { briefcase: Briefcase, file: FileText, receipt: ReceiptText, search: Search, target: Target, trend: TrendingUp, user: UserRound };
 
-function setMetaContent(selector, value) {
-  const element = document.querySelector(selector);
-  if (element) element.setAttribute("content", value);
-}
+function setMetaContent(selector, value) { const element = document.querySelector(selector); if (element) element.setAttribute("content", value); }
 
 function SeoLandingPage({ content }) {
   const Icon = ICONS[content.icon] || FileText;
@@ -36,7 +16,6 @@ function SeoLandingPage({ content }) {
   useEffect(() => {
     const title = getSeoSitelinkTitle(path, `${content.eyebrow} | BragStack`);
     const canonicalUrl = `https://usebragstack.com${path}`;
-
     document.title = title;
     setMetaContent('meta[name="description"]', content.description);
     setMetaContent('meta[property="og:title"]', title);
@@ -44,99 +23,28 @@ function SeoLandingPage({ content }) {
     setMetaContent('meta[property="og:url"]', canonicalUrl);
     setMetaContent('meta[name="twitter:title"]', title);
     setMetaContent('meta[name="twitter:description"]', content.description);
-
     const canonical = document.querySelector('link[rel="canonical"]');
     if (canonical) canonical.href = canonicalUrl;
   }, [content, path]);
 
-  return (
-    <main className="landing-page seo-product-page">
-      <header className="landing-nav">
-        <a className="landing-logo" href="/" aria-label="BragStack home">BragStack</a>
-        <nav className="landing-nav-links" aria-label="BragStack products">
-          <a href="/resume-accomplishments">Resume Builder</a>
-          <a href="/interview-preparation">Interview Prep</a>
-          <a href="/impact-receipts">Impact Receipts</a>
-          <a href="/pricing">Pricing</a>
-        </nav>
-        <div className="landing-nav-actions">
-          <a className="landing-login-link" href="/login">Sign in</a>
-          <a className="landing-btn landing-btn-small" href="/register">Start free</a>
-        </div>
-      </header>
+  return <main className="landing-page seo-product-page">
+    <header className="landing-nav">
+      <a className="landing-logo" href="/" aria-label="BragStack home">BragStack</a>
+      <nav className="landing-nav-links" aria-label="BragStack products"><a href="/resume-accomplishments">Resume Builder</a><a href="/interview-preparation">Interview Prep</a><a href="/impact-receipts">Impact Receipts</a><a href="/pricing">Pricing</a></nav>
+      <div className="landing-nav-actions"><a className="landing-login-link" href="/login">Sign in</a><a className="landing-btn landing-btn-small" href="/register">Start free</a></div>
+    </header>
 
-      <section className="seo-product-hero">
-        <div className="landing-hero-copy">
-          <div className="landing-eyebrow"><Icon size={16} />{content.eyebrow}</div>
-          <h1>{content.title}</h1>
-          <p className="landing-hero-description">{content.description}</p>
-          <div className="landing-hero-actions">
-            <a className="landing-btn" href="/register">Start free <ArrowRight size={18} /></a>
-            <a className="landing-btn landing-btn-secondary" href="/how-it-works">See how it works</a>
-          </div>
-          <div className="seo-trust-row" aria-label="BragStack benefits">
-            <span><Check size={15} /> No credit card</span>
-            <span><Check size={15} /> Your proof stays connected</span>
-            <span><Check size={15} /> Built for real career moments</span>
-          </div>
-        </div>
+    <section className="seo-product-hero">
+      <div className="landing-hero-copy"><div className="landing-eyebrow"><Icon size={16}/>{content.eyebrow}</div><h1>{content.title}</h1><p className="landing-hero-description">{content.description}</p><div className="landing-hero-actions"><a className="landing-btn" href="/register">Start free <ArrowRight size={18}/></a><a className="landing-btn landing-btn-secondary" href="/how-it-works">See how it works</a></div><div className="seo-trust-row" aria-label="BragStack benefits"><span><Check size={15}/> No credit card</span><span><Check size={15}/> Your proof stays connected</span><span><Check size={15}/> Built for real career moments</span></div></div>
+      <aside className="seo-product-summary" aria-label={`${content.eyebrow} overview`}><span className="seo-summary-label">WHAT YOU GET</span><div className="seo-summary-icon"><Icon size={28}/></div><h2>Turn your work into career-ready proof.</h2><p>Capture the context behind what you did, then reuse that evidence when a resume, interview, or opportunity needs it.</p><div className="seo-summary-list">{content.points.slice(0,3).map((point)=><span key={point}><Check size={16}/> {point}</span>)}</div></aside>
+    </section>
 
-        <aside className="seo-product-summary" aria-label={`${content.eyebrow} overview`}>
-          <span className="seo-summary-label">WHAT YOU GET</span>
-          <div className="seo-summary-icon"><Icon size={28} /></div>
-          <h2>Turn your work into career-ready proof.</h2>
-          <p>Capture the context behind what you did, then reuse that evidence when a resume, interview, or opportunity needs it.</p>
-          <div className="seo-summary-list">
-            {content.points.slice(0, 3).map((point) => <span key={point}><Check size={16} /> {point}</span>)}
-          </div>
-        </aside>
-      </section>
+    <section className="seo-value-section"><div className="landing-section-heading"><p>BUILT AROUND YOUR EVIDENCE</p><h2>Useful when your work needs to speak for you.</h2><span className="seo-section-copy">Keep the accomplishment, context, result, and supporting proof together instead of rebuilding your story every time.</span></div><div className="seo-value-grid">{content.points.map((point,index)=><article className="seo-value-card" key={point}><span className="seo-card-number">0{index+1}</span><h3>{point}</h3><p>Use the evidence already in your BragStack to make this career moment clearer, faster, and easier to support.</p></article>)}</div></section>
 
-      <section className="seo-value-section">
-        <div className="landing-section-heading">
-          <p>BUILT AROUND YOUR EVIDENCE</p>
-          <h2>Useful when your work needs to speak for you.</h2>
-          <span className="seo-section-copy">Keep the accomplishment, context, result, and supporting proof together instead of rebuilding your story every time.</span>
-        </div>
-        <div className="seo-value-grid">
-          {content.points.map((point, index) => (
-            <article className="seo-value-card" key={point}>
-              <span className="seo-card-number">0{index + 1}</span>
-              <h3>{point}</h3>
-              <p>Use the evidence already in your BragStack to make this career moment clearer, faster, and easier to support.</p>
-            </article>
-          ))}
-        </div>
-      </section>
+    <section className="seo-explore-section"><div className="seo-explore-heading"><div><p className="landing-mini-label">EXPLORE BRAGSTACK</p><h2>One career story. Connected tools.</h2></div><p>Move between the tools without losing the evidence behind your work.</p></div><nav className="seo-related-grid" aria-label="Related BragStack pages">{relatedLinks.map(({label,href})=><a className="seo-related-card" href={href} key={href}><span>{label}</span><ArrowRight size={18}/></a>)}</nav></section>
 
-      <section className="seo-explore-section">
-        <div className="seo-explore-heading">
-          <div>
-            <p className="landing-mini-label">EXPLORE BRAGSTACK</p>
-            <h2>One career story. Connected tools.</h2>
-          </div>
-          <p>Move between the tools without losing the evidence behind your work.</p>
-        </div>
-        <nav className="seo-related-grid" aria-label="Related BragStack pages">
-          {relatedLinks.map(({ label, href }) => (
-            <a className="seo-related-card" href={href} key={href}>
-              <span>{label}</span>
-              <ArrowRight size={18} />
-            </a>
-          ))}
-        </nav>
-      </section>
-
-      <section className="seo-final-cta">
-        <div>
-          <p className="landing-mini-label">YOUR WORK ALREADY HAPPENED</p>
-          <h2>Make sure you can prove it.</h2>
-          <p>Start building a career record you can actually use when the next opportunity arrives.</p>
-        </div>
-        <a className="landing-btn" href="/register">Build your BragStack <ArrowRight size={18} /></a>
-      </section>
-    </main>
-  );
+    <section className="seo-final-cta"><div><p className="landing-mini-label">YOUR WORK ALREADY HAPPENED</p><h2>Make sure you can prove it.</h2><p>Start building a career record you can actually use when the next opportunity arrives.</p></div><a className="landing-btn" href="/register">Build your BragStack <ArrowRight size={18}/></a></section>
+  </main>;
 }
 
 export default SeoLandingPage;


### PR DESCRIPTION
Modernizes the public BragStack product/SEO landing-page experience while preserving the canonical search architecture from #148.

- Cleaner, more focused hero and CTA hierarchy
- Modern product summary panel and evidence-led value cards
- Shared canonical PRIMARY_SITELINKS for related-page navigation
- Strong visible internal linking between BragStack product pages
- Responsive mobile/tablet layout
- Accessible navigation labels and semantic sections
- Keeps page-specific titles, descriptions, canonical URLs, Open Graph, and Twitter metadata
- Removes the older generic Docs-heavy related-links presentation

Designed to improve both user experience and legitimate Google site-hierarchy signals without crawler-only content or SEO tricks.