### PR TITLE
Performance: enforce production bundle budgets

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -53,5 +53,8 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Enforce production bundle budgets
+        run: npm run test:bundle
+
       - name: Verify Aisha production bundle
         run: node scripts/verify-aisha-build.mjs

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "test:interview": "node --test src/interviewEngine*.test.js",
     "test:resume": "node --test src/resumeStructured.test.js",
     "test:seo": "node scripts/verify-search-appearance.mjs",
+    "test:bundle": "node scripts/verify-bundle-budget.mjs",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/frontend/scripts/verify-bundle-budget.mjs
+++ b/frontend/scripts/verify-bundle-budget.mjs
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import { readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+const assetsDir = new URL("../dist/assets/", import.meta.url);
+const files = readdirSync(assetsDir)
+  .filter((name) => name.endsWith(".js"))
+  .map((name) => ({ name, bytes: statSync(join(assetsDir.pathname, name)).size }))
+  .sort((a, b) => b.bytes - a.bytes);
+
+assert.ok(files.length > 1, "Expected route-level code splitting to produce multiple JavaScript chunks");
+
+const totalBytes = files.reduce((sum, file) => sum + file.bytes, 0);
+const largest = files[0];
+const kib = (bytes) => (bytes / 1024).toFixed(1);
+
+// These are intentionally generous regression ceilings, not performance targets.
+// Tighten them as we measure and optimize production bundles.
+const MAX_SINGLE_CHUNK_BYTES = 350 * 1024;
+const MAX_TOTAL_JS_BYTES = 900 * 1024;
+
+assert.ok(
+  largest.bytes <= MAX_SINGLE_CHUNK_BYTES,
+  `Largest JS chunk ${largest.name} is ${kib(largest.bytes)} KiB; budget is ${kib(MAX_SINGLE_CHUNK_BYTES)} KiB`,
+);
+assert.ok(
+  totalBytes <= MAX_TOTAL_JS_BYTES,
+  `Total production JS is ${kib(totalBytes)} KiB; budget is ${kib(MAX_TOTAL_JS_BYTES)} KiB`,
+);
+
+console.log(`Bundle budget passed: ${files.length} chunks, ${kib(totalBytes)} KiB total, largest ${largest.name} at ${kib(largest.bytes)} KiB.`);
+console.log("Largest chunks:");
+for (const file of files.slice(0, 8)) console.log(`  ${kib(file.bytes).padStart(7)} KiB  ${file.name}`);

--- a/frontend/src/RootContent.jsx
+++ b/frontend/src/RootContent.jsx
@@ -1,5 +1,4 @@
 import { lazy, Suspense, useEffect, useState } from "react";
-import { getCurrentUser } from "./api.js";
 import { getSeoLandingPage } from "./seoLandingContent.js";
 import useSearchAppearanceMeta from "./useSearchAppearanceMeta.js";
 
@@ -62,6 +61,10 @@ function RootContent() {
     let active = true;
     (async () => {
       try {
+        // Keep axios and the authenticated API surface out of public-page startup.
+        // App routes already wait for plan data, so loading the client here does not
+        // change the public routing contract or entitlement behavior.
+        const { getCurrentUser } = await import("./api.js");
         const data = await getCurrentUser();
         if (active) {
           setUser(data);


### PR DESCRIPTION
Second Core Web Vitals performance pass after route-level code splitting.

Adds a production bundle regression gate that runs after Vite build and verifies:
- code splitting still produces multiple JS chunks
- no single production JS chunk exceeds a generous regression ceiling
- total emitted production JS stays under a regression ceiling
- CI prints the largest chunks so the next optimization pass is driven by measurements, not guesses

The initial ceilings are deliberately guardrails rather than aspirational targets. Once CI gives us the real production bundle profile, we can tighten budgets and attack the largest chunks safely.