### PR TITLE
Performance: defer analytics off the critical startup path

### DIFF
--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -6,12 +6,21 @@ import "./ProductPolish.css";
 import "./ReferencePolish.css";
 import "./MarketingFooterOrder.css";
 import RootContent from "./RootContent.jsx";
-import { initializeAnalytics } from "./analytics.js";
-
-initializeAnalytics();
 
 createRoot(document.getElementById("root")).render(
   <StrictMode>
     <RootContent />
   </StrictMode>,
 );
+
+function loadAnalyticsWhenIdle() {
+  import("./analytics.js")
+    .then(({ initializeAnalytics }) => initializeAnalytics())
+    .catch(() => {});
+}
+
+if ("requestIdleCallback" in window) {
+  window.requestIdleCallback(loadAnalyticsWhenIdle, { timeout: 2500 });
+} else {
+  window.setTimeout(loadAnalyticsWhenIdle, 1500);
+}


### PR DESCRIPTION
Third startup-performance pass.

Moves BragStack analytics out of the synchronous entry path and loads it after first paint/when the browser is idle, with a short timeout fallback for browsers without requestIdleCallback.

Goals:
- prioritize React render and visible content over third-party analytics startup
- keep Google Analytics functionality intact
- create a separate lazy analytics chunk rather than including analytics initialization in startup execution
- preserve the bundle-budget guardrails added in #157

CI and the production bundle report will tell us whether this meaningfully improves startup without regressions before merge.