### PR TITLE
Fix dashboard tag-summary React crash

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
     "build": "vite build",
     "lint": "eslint .",
     "test:interview": "node --test src/interviewEngine*.test.js",
-    "test:resume": "node --test src/resumeStructured.test.js",
+    "test:resume": "node --test src/resumeStructured.test.js src/dashboardTags.test.js",
     "test:seo": "node scripts/verify-search-appearance.mjs",
     "test:bundle": "node scripts/verify-bundle-budget.mjs",
     "preview": "vite preview"

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,5 +1,7 @@
 import axios from "axios";
 
+import { normalizeDashboardTags } from "./dashboardTags.js";
+
 function getDefaultApiBaseUrl() {
   if (window.location.hostname.endsWith(".app.github.dev")) return "/api";
   return import.meta.env.VITE_API_BASE_URL || import.meta.env.VITE_API_URL || "http://localhost:8000";
@@ -119,7 +121,13 @@ export async function resumeSubscription() { const response = await api.post("/b
 export async function getPublicProfile(slug) { const response = await api.get(getPublicBragPath(slug, "/profile")); return response.data; }
 export async function getEntries(limit = 10, skip = 0) { const response = await api.get("/entries", { params: { limit, skip } }); return response.data; }
 export async function getWeeklyReport() { const response = await api.get("/entries/reports/weekly"); return response.data; }
-export async function getTagsSummary() { const response = await api.get("/entries/tags/summary"); return response.data; }
+export async function getTagsSummary() {
+  const response = await api.get("/entries/tags/summary");
+  return {
+    ...response.data,
+    tags: Object.fromEntries(normalizeDashboardTags(response.data?.tags)),
+  };
+}
 export async function getCategoriesSummary() { const response = await api.get("/entries/categories/summary"); return response.data; }
 export async function createEntry(entry) { const response = await api.post("/entries", entry); return response.data; }
 export async function updateEntry(entryId, entry) { const response = await api.put(`/entries/${entryId}`, entry); return response.data; }

--- a/frontend/src/dashboardTags.js
+++ b/frontend/src/dashboardTags.js
@@ -1,0 +1,13 @@
+export function normalizeDashboardTags(tags) {
+  if (Array.isArray(tags)) {
+    return tags
+      .filter((item) => item && typeof item === "object" && typeof item.tag === "string")
+      .map((item) => [item.tag, Number(item.count) || 0]);
+  }
+
+  if (tags && typeof tags === "object") {
+    return Object.entries(tags).map(([tag, count]) => [tag, Number(count) || 0]);
+  }
+
+  return [];
+}

--- a/frontend/src/dashboardTags.test.js
+++ b/frontend/src/dashboardTags.test.js
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { normalizeDashboardTags } from "./dashboardTags.js";
+
+test("normalizes API tag summary objects without rendering objects as React children", () => {
+  const apiShape = [
+    { tag: "Docker", count: 4 },
+    { tag: "FastAPI", count: 2 },
+  ];
+
+  assert.deepEqual(normalizeDashboardTags(apiShape), [
+    ["Docker", 4],
+    ["FastAPI", 2],
+  ]);
+});
+
+test("preserves legacy tag-count maps for backward compatibility", () => {
+  assert.deepEqual(normalizeDashboardTags({ Docker: 4, FastAPI: 2 }), [
+    ["Docker", 4],
+    ["FastAPI", 2],
+  ]);
+});
+
+test("rejects malformed tag summary values safely", () => {
+  assert.deepEqual(normalizeDashboardTags(null), []);
+  assert.deepEqual(normalizeDashboardTags([null, { count: 2 }, "Docker"]), []);
+});


### PR DESCRIPTION
Fixes #153.

- normalizes the authenticated tag-summary API response at the frontend API boundary
- supports the current `[{ tag, count }]` shape as well as the legacy `{ tag: count }` map shape
- prevents `{tag, count}` objects from reaching React children on `/app`
- adds focused regression tests for both response shapes and malformed values
- runs the regression test inside the existing frontend test gate

After this is green, the next step is to refresh PR #149 against current main and rerun the full click audit.