### PR TITLE
Hotfix SEO landing navbar styles

### DIFF
--- a/frontend/src/SeoLandingPages.css
+++ b/frontend/src/SeoLandingPages.css
@@ -1,3 +1,5 @@
+@import "./LandingPage.css";
+
 .seo-product-page { padding-bottom: 3rem; }
 
 .seo-product-hero,


### PR DESCRIPTION
Production hotfix for the broken public navbar on SEO landing pages such as /how-it-works.

Root cause: SeoLandingPages.jsx renders shared `landing-*` header/button classes, but SeoLandingPages.css did not load the shared LandingPage.css definitions. This left the header links as raw browser-default anchors while page-specific SEO styles still loaded.

Fix: import LandingPage.css from SeoLandingPages.css so shared navbar, logo, button, colors, spacing, and responsive styles are available on every SEO landing route.

This is intentionally a one-file hotfix.