### PR TITLE
Hotfix SEO landing navbar styles (v2)

### DIFF
--- a/frontend/src/SeoLandingPages.css
+++ b/frontend/src/SeoLandingPages.css
@@ -1,3 +1,5 @@
+@import "./LandingPage.css";
+
 .seo-product-page { padding-bottom: 3rem; }
 
 .seo-product-hero,


### PR DESCRIPTION
Reapplies the valid one-line SEO navbar style fix from #170 on current `main` after the original branch became stale/conflicted.

## Change
- Import `LandingPage.css` from `SeoLandingPages.css` so shared `landing-*` navbar/button styles are available on SEO landing routes.

## Scope
- One CSS file only.
- No merge until Frontend, Backend, and Security CI are green on the exact current head.

Supersedes #170.