### PR TITLE
Fix Aisha interview teardown and ship evidence-based ATS Scan

### DIFF
--- a/backend/app/resume_builder.py
+++ b/backend/app/resume_builder.py
@@ -106,10 +106,14 @@ def score_receipt(receipt: dict, terms: Iterable[str]) -> tuple[int, list[str]]:
     text = receipt_text(receipt)
     matches = [term for term in terms if _term_matches(term, text)]
     score = len(matches) * 4
-    if receipt.get("result"): score += 2
-    if receipt.get("metrics"): score += 3
-    if receipt.get("evidence"): score += 2
-    if any(signal != "self-documented" for signal in receipt.get("trust_signals", [])): score += 2
+    if receipt.get("result"):
+        score += 2
+    if receipt.get("metrics"):
+        score += 3
+    if receipt.get("evidence"):
+        score += 2
+    if any(signal != "self-documented" for signal in receipt.get("trust_signals", [])):
+        score += 2
     return score, matches
 
 
@@ -269,6 +273,13 @@ def parse_existing_resume_text(raw_text: str) -> dict:
                 skills.append(skill)
 
     preview_sections = {key: values[:80] for key, values in sections.items() if values}
+    source_signals = {
+        "has_skills_heading": bool(sections["skills"]),
+        "has_experience_heading": bool(sections["experience"]),
+        "has_work_bullets": bool(bullets),
+        "has_education_heading": bool(sections["education"]),
+        "has_projects_heading": bool(sections["projects"]),
+    }
     return {
         "summary": summary,
         "bullets": bullets[:20],
@@ -278,6 +289,7 @@ def parse_existing_resume_text(raw_text: str) -> dict:
         "header_lines": unsectioned[:12],
         "line_count": len(lines),
         "text": "\n".join(lines)[:50000],
+        "source_signals": source_signals,
     }
 
 
@@ -295,10 +307,78 @@ def build_summary(target_role: str, matched_receipts: list[dict], imported_summa
     return f"{target_role} focused on measurable results, clear ownership, and evidence-backed impact."
 
 
+def _score_label(score: int) -> str:
+    if score >= 85:
+        return "Excellent"
+    if score >= 75:
+        return "Strong"
+    if score >= 60:
+        return "Good foundation"
+    if score >= 40:
+        return "Needs attention"
+    return "Major gaps"
+
+
+def _build_ats_scan(*, imported: dict, coverage: int, bullets: list[dict], skills: list[str], unsupported_terms: list[str]) -> dict:
+    source_signals = imported.get("source_signals", {})
+    has_content = bool(imported.get("text"))
+    has_skills = bool(skills) or source_signals.get("has_skills_heading", False)
+    has_bullets = bool(bullets) or source_signals.get("has_work_bullets", False)
+    has_sections = len(imported.get("sections_found", [])) >= 2
+
+    parsing_score = 100 if has_content and has_sections and (has_skills or has_bullets) else 82 if has_content and (has_skills or has_bullets) else 55 if has_content else 30
+    quantified = sum(1 for bullet in bullets if bullet.get("has_metrics"))
+    readability_score = 92 if bullets and quantified >= 3 else 84 if bullets else 78 if has_skills else 62
+    job_match_score = max(0, min(100, int(coverage)))
+    overall = round((parsing_score * 0.25) + (job_match_score * 0.55) + (readability_score * 0.20))
+
+    strengths: list[str] = []
+    improvements: list[str] = []
+    if parsing_score >= 85:
+        strengths.append("Core resume content is recoverable as searchable text and organized into recognizable sections.")
+    if job_match_score >= 75:
+        strengths.append(f"The resume visibly supports {job_match_score}% of the job signals detected in this posting.")
+    elif job_match_score >= 50:
+        strengths.append(f"The resume already supports {job_match_score}% of the detected job signals.")
+    if quantified >= 3:
+        strengths.append(f"{quantified} accomplishment bullets include measurable impact.")
+    if has_skills:
+        strengths.append("Skills are present in the source evidence; the scan will not claim they are missing.")
+    if has_bullets:
+        strengths.append("Work-history bullet evidence is present in the source evidence.")
+
+    if unsupported_terms:
+        improvements.append(
+            "Verify the highest-priority unmatched job signals and add them only where your real experience supports them: "
+            + ", ".join(unsupported_terms[:6]) + "."
+        )
+    if bullets and quantified < 2:
+        improvements.append("Where truthful, strengthen accomplishment bullets with measurable outcomes such as time saved, reliability, volume, quality, revenue, or customer impact.")
+    if parsing_score < 80:
+        improvements.append("Parsing confidence is limited. Review the source resume before changing content; do not treat an extraction miss as a resume deficiency.")
+    if not improvements:
+        improvements.append("No major scan issue is visible. Tailor wording to the target job, keep claims truthful, and verify the final exported file visually.")
+
+    return {
+        "score": overall,
+        "label": _score_label(overall),
+        "breakdown": {
+            "parsing": parsing_score,
+            "job_match": job_match_score,
+            "readability": readability_score,
+        },
+        "strengths": strengths[:6],
+        "improvements": improvements[:6],
+        "high_score": overall >= 75,
+        "disclaimer": "BragStack ATS Scan is a compatibility analysis, not a prediction of an employer's hiring decision or a reproduction of every ATS configuration.",
+    }
+
+
 def analyze_resume(*, target_role: str, job_description: str, receipts: list[dict], existing_resume_text: str = "") -> dict:
     terms = extract_terms(job_description)
     imported = parse_existing_resume_text(existing_resume_text) if existing_resume_text.strip() else {
-        "summary": "", "bullets": [], "skills": [], "sections_found": [], "sections": {}, "header_lines": [], "line_count": 0, "text": ""
+        "summary": "", "bullets": [], "skills": [], "sections_found": [], "sections": {}, "header_lines": [], "line_count": 0, "text": "",
+        "source_signals": {"has_skills_heading": False, "has_experience_heading": False, "has_work_bullets": False, "has_education_heading": False, "has_projects_heading": False},
     }
     imported_text = imported.get("text", "")
 
@@ -357,6 +437,14 @@ def analyze_resume(*, target_role: str, job_description: str, receipts: list[dic
             if skill and skill.lower() not in {existing.lower() for existing in skills}:
                 skills.append(skill)
 
+    ats_scan = _build_ats_scan(
+        imported=imported,
+        coverage=coverage,
+        bullets=bullets,
+        skills=skills,
+        unsupported_terms=unsupported_terms,
+    )
+
     return {
         "target_role": target_role.strip(),
         "requirements": terms,
@@ -371,8 +459,10 @@ def analyze_resume(*, target_role: str, job_description: str, receipts: list[dic
             "sections": imported.get("sections", {}),
             "header_lines": imported.get("header_lines", []),
             "imported_bullet_count": len(imported_bullets),
+            "source_signals": imported.get("source_signals", {}),
         },
         "readiness": readiness,
+        "ats_scan": ats_scan,
         "ats_preview_sections": list(SECTION_HEADINGS),
-        "ats_note": "ATS-friendly preview only; BragStack does not simulate every employer ATS parser.",
+        "ats_note": ats_scan["disclaimer"],
     }

--- a/backend/app/resume_builder_routes.py
+++ b/backend/app/resume_builder_routes.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from io import BytesIO
 
+import fitz
 from bson import ObjectId
 from docx import Document
 from fastapi import APIRouter, Depends, File, HTTPException, UploadFile, status
@@ -17,6 +18,7 @@ from app.resume_import_parser import parse_existing_resume_text
 
 router = APIRouter(prefix="/resume-builder", tags=["resume-builder"])
 MAX_RESUME_BYTES = 5 * 1024 * 1024
+MAX_RESUME_PAGES = 12
 
 
 class ResumeBuildRequest(BaseModel):
@@ -116,11 +118,61 @@ def _server_readiness(bullets: list[ResumeBulletPayload]) -> dict:
     }
 
 
+def _extract_pdf_text_pymupdf(data: bytes) -> str:
+    """Primary born-digital PDF extraction with block geometry and stable reading-order sorting."""
+    lines: list[str] = []
+    with fitz.open(stream=data, filetype="pdf") as document:
+        if document.page_count > MAX_RESUME_PAGES:
+            raise HTTPException(status_code=400, detail=f"Resume PDFs can contain up to {MAX_RESUME_PAGES} pages")
+        for page in document:
+            blocks = page.get_text("blocks", sort=True)
+            page_lines: list[str] = []
+            for x0, y0, x1, y1, text, *_ in blocks:
+                del x0, y0, x1, y1
+                cleaned = "\n".join(part.strip() for part in str(text or "").splitlines() if part.strip())
+                if cleaned:
+                    page_lines.append(cleaned)
+            lines.extend(page_lines)
+    return "\n".join(lines).strip()
+
+
+def _extract_pdf_text_pypdf(data: bytes) -> str:
+    reader = PdfReader(BytesIO(data))
+    if len(reader.pages) > MAX_RESUME_PAGES:
+        raise HTTPException(status_code=400, detail=f"Resume PDFs can contain up to {MAX_RESUME_PAGES} pages")
+    return "\n".join((page.extract_text() or "") for page in reader.pages).strip()
+
+
+def _extract_pdf_text(data: bytes) -> str:
+    """Use two independent extractors and keep the richer result without inventing content."""
+    primary = ""
+    secondary = ""
+    try:
+        primary = _extract_pdf_text_pymupdf(data)
+    except HTTPException:
+        raise
+    except Exception:
+        primary = ""
+
+    try:
+        secondary = _extract_pdf_text_pypdf(data)
+    except HTTPException:
+        raise
+    except Exception:
+        secondary = ""
+
+    # Prefer geometry-aware PyMuPDF when it recovered comparable content. If one
+    # extractor clearly lost text, use the richer source rather than silently
+    # accepting the sparse interpretation.
+    if primary and (not secondary or len(primary) >= len(secondary) * 0.72):
+        return primary
+    return secondary or primary
+
+
 def _extract_uploaded_text(filename: str, content_type: str, data: bytes) -> str:
     suffix = "." + filename.rsplit(".", 1)[-1].lower() if "." in filename else ""
     if content_type == "application/pdf" or suffix == ".pdf":
-        reader = PdfReader(BytesIO(data))
-        return "\n".join((page.extract_text() or "") for page in reader.pages)
+        return _extract_pdf_text(data)
     if content_type == "application/vnd.openxmlformats-officedocument.wordprocessingml.document" or suffix == ".docx":
         document = Document(BytesIO(data))
         paragraphs = [paragraph.text for paragraph in document.paragraphs]
@@ -147,11 +199,15 @@ async def import_resume(file: UploadFile = File(...), current_user: dict = Depen
     except Exception as exc:
         raise HTTPException(status_code=400, detail="We could not read that resume. Try exporting it as a fresh PDF or DOCX.") from exc
     if len(text) < 20:
-        raise HTTPException(status_code=400, detail="We could not find enough readable text in that resume")
+        raise HTTPException(
+            status_code=400,
+            detail="We could not find enough readable text in that resume. If it is a scanned/image-only PDF, export a text-searchable PDF or DOCX and try again.",
+        )
     parsed = parse_existing_resume_text(text)
     return {
         "filename": filename,
         "text": parsed["text"],
+        "raw_text": parsed.get("raw_text", text),
         "summary": parsed["summary"],
         "bullets": parsed["bullets"],
         "skills": parsed["skills"],
@@ -161,6 +217,7 @@ async def import_resume(file: UploadFile = File(...), current_user: dict = Depen
         "contact": parsed.get("contact", {}),
         "experience": parsed.get("experience", []),
         "parse_warnings": parsed.get("parse_warnings", []),
+        "source_signals": parsed.get("source_signals", {}),
         "line_count": parsed["line_count"],
     }
 

--- a/backend/app/resume_import_parser.py
+++ b/backend/app/resume_import_parser.py
@@ -73,6 +73,18 @@ def _looks_role(line: str) -> bool:
     return bool(ROLE_RE.search(line)) and len(line.split()) <= 20
 
 
+def _looks_role_header(line: str) -> bool:
+    """Conservative role-header test. Avoid treating normal bullets containing words like engineer as a new job."""
+    value = _clean(line)
+    if not ROLE_RE.search(value):
+        return False
+    if re.search(r"\s+at\s+", value, re.I) or "|" in value or "·" in value:
+        return len(value.split()) <= 20
+    if _date_match(value):
+        return len(value.split()) <= 22
+    return len(value.split()) <= 8 and not re.search(r"[.!?]$", value)
+
+
 def _looks_short_label(line: str) -> bool:
     words = line.split()
     return 0 < len(words) <= 10 and not re.search(r"[.!?]$", line)
@@ -116,7 +128,7 @@ def _repair(raw_text: str) -> list[str]:
             i += 1
             while i < len(source):
                 nxt = source[i]
-                if _heading(nxt) or BULLET_RE.match(nxt) or _date_atom(nxt) or _looks_role(nxt):
+                if _heading(nxt) or BULLET_RE.match(nxt) or _date_atom(nxt) or _looks_role_header(nxt):
                     break
                 text += " " + nxt.strip("|")
                 i += 1
@@ -149,7 +161,7 @@ def _split_role_company(line: str) -> tuple[str, str, str]:
             return left, right, "medium"
         if left_role:
             return right, left, "medium"
-    if _looks_role(value):
+    if _looks_role_header(value):
         return "", value, "low"
     return value, "", "low"
 
@@ -189,7 +201,7 @@ def _parse_contact(header: list[str]) -> dict:
     }
     if header:
         first = _clean(header[0])
-        if first and not CONTACT_RE.search(first) and not _looks_role(first):
+        if first and not CONTACT_RE.search(first) and not _looks_role_header(first) and not _heading(first):
             contact["name"] = first
 
     for line in header[:12]:
@@ -212,7 +224,7 @@ def _parse_contact(header: list[str]) -> dict:
 
     for line in header[1:8]:
         candidate = _clean(line)
-        if not candidate or _looks_role(candidate):
+        if not candidate or _looks_role_header(candidate):
             continue
         pieces = [piece.strip() for piece in candidate.split("|") if piece.strip()]
         for piece in pieces:
@@ -264,7 +276,7 @@ def _identity_and_location_around_dates(line: str) -> tuple[str, str]:
     return " | ".join(identity_parts), location
 
 
-def _parse_experience(lines: list[str]) -> tuple[list[dict], list[str]]:
+def _parse_experience(lines: list[str], *, inferred_mode: bool = False) -> tuple[list[dict], list[str]]:
     entries: list[dict] = []
     warnings: list[str] = []
     current: dict | None = None
@@ -273,6 +285,10 @@ def _parse_experience(lines: list[str]) -> tuple[list[dict], list[str]]:
     def flush() -> None:
         nonlocal current
         if not current:
+            return
+        has_relationship_evidence = bool(current.get("dates_raw") or current.get("bullets"))
+        if inferred_mode and not has_relationship_evidence:
+            current = None
             return
         if current.get("company") or current.get("title") or current.get("bullets"):
             if not current.get("company"):
@@ -291,6 +307,9 @@ def _parse_experience(lines: list[str]) -> tuple[list[dict], list[str]]:
 
         if BULLET_RE.match(line):
             if current is None:
+                if inferred_mode:
+                    i += 1
+                    continue
                 current = _blank_entry(company=pending_company)
                 pending_company = ""
             text = BULLET_RE.sub("", line).strip()
@@ -304,7 +323,7 @@ def _parse_experience(lines: list[str]) -> tuple[list[dict], list[str]]:
         )
         if date_hit:
             identity_text, location = _identity_and_location_around_dates(line)
-            if identity_text and (_looks_role(identity_text) or "|" in identity_text or re.search(r"\s+at\s+", identity_text, re.I)):
+            if identity_text and (_looks_role_header(identity_text) or "|" in identity_text or re.search(r"\s+at\s+", identity_text, re.I)):
                 company, title, confidence = _split_role_company(identity_text)
                 if title:
                     flush()
@@ -315,6 +334,9 @@ def _parse_experience(lines: list[str]) -> tuple[list[dict], list[str]]:
                     )
                     pending_company = ""
             if current is None:
+                if inferred_mode and not pending_company:
+                    i += 1
+                    continue
                 current = _blank_entry(company=pending_company)
                 pending_company = ""
             current.update(_parse_dates(line))
@@ -323,7 +345,7 @@ def _parse_experience(lines: list[str]) -> tuple[list[dict], list[str]]:
             i += 1
             continue
 
-        if "|" in line or "·" in line or _looks_role(line) or re.search(r"\s+at\s+", line, re.I):
+        if "|" in line or "·" in line or _looks_role_header(line) or re.search(r"\s+at\s+", line, re.I):
             company, title, confidence = _split_role_company(line)
             if title:
                 flush()
@@ -349,9 +371,9 @@ def _parse_experience(lines: list[str]) -> tuple[list[dict], list[str]]:
                     continue
             if current and current.get("title") and not current.get("location") and _looks_location(line):
                 current["location"] = line
-            elif _looks_role(next_line):
+            elif _looks_role_header(next_line):
                 pending_company = line
-            elif current is None:
+            elif current is None and not inferred_mode:
                 pending_company = line
             i += 1
             continue
@@ -420,17 +442,17 @@ def parse_existing_resume_text(raw_text: str) -> dict:
 
     experience, parse_warnings = _parse_experience(sections["experience"])
     if not experience:
-        inferred, inferred_warnings = _parse_experience(lines)
+        inferred, inferred_warnings = _parse_experience(lines, inferred_mode=True)
         inferred = [
             entry for entry in inferred
-            if entry.get("title") and (entry.get("company") or entry.get("dates_raw") or entry.get("bullets"))
+            if entry.get("title") and entry.get("dates_raw") and (entry.get("company") or entry.get("bullets"))
         ]
         if inferred:
             experience = inferred
             parse_warnings = inferred_warnings
             if not sections["experience"]:
                 parse_warnings = [
-                    "Work history was inferred because the resume did not use a standard experience heading.",
+                    "Work history was inferred with low confidence because a standard experience heading was not detected.",
                     *parse_warnings,
                 ]
             sections["experience"] = _structured_experience_lines(experience)
@@ -449,7 +471,7 @@ def parse_existing_resume_text(raw_text: str) -> dict:
             for x in sections["experience"]
             if BULLET_RE.match(x) and len(BULLET_RE.sub("", x).strip()) >= 18
         ]
-    if not bullets:
+    if not bullets and sections["experience"]:
         bullets = [
             BULLET_RE.sub("", x).strip()
             for x in lines
@@ -465,16 +487,34 @@ def parse_existing_resume_text(raw_text: str) -> dict:
                 skills.append(skill)
 
     summary = " ".join(sections["summary"][:3])[:1200]
+    sections_found = [k for k, v in sections.items() if v]
+    source_signals = {
+        "has_skills_heading": "skills" in sections_found,
+        "has_experience_heading": "experience" in sections_found,
+        "has_work_bullets": bool(bullets),
+        "has_education_heading": "education" in sections_found,
+        "has_projects_heading": "projects" in sections_found,
+    }
+
+    if source_signals["has_skills_heading"] and not skills:
+        parse_warnings.append("Skills section is visible in the source, but individual skills could not be classified confidently. Review the source instead of treating skills as missing.")
+    if source_signals["has_experience_heading"] and not experience:
+        parse_warnings.append("Work experience is visible in the source, but role grouping is uncertain. Review the source instead of treating work history as missing.")
+    if source_signals["has_work_bullets"] and not experience:
+        parse_warnings.append("Work-history bullets are visible in the source, but employer/title grouping is uncertain.")
+
     return {
         "summary": summary,
         "bullets": bullets[:20],
         "skills": skills[:40],
-        "sections_found": [k for k, v in sections.items() if v],
+        "sections_found": sections_found,
         "sections": {k: v[:100] for k, v in sections.items() if v},
         "header_lines": header[:12],
         "contact": contact,
         "experience": experience,
         "parse_warnings": list(dict.fromkeys(parse_warnings))[:20],
+        "source_signals": source_signals,
         "line_count": len(lines),
         "text": "\n".join(lines)[:50000],
+        "raw_text": (raw_text or "")[:50000],
     }

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,4 +12,5 @@ httpx
 mongomock
 reportlab==4.4.3
 pypdf==6.15.0
+PyMuPDF>=1.24,<2
 python-docx==1.2.0

--- a/backend/tests/test_resume_builder.py
+++ b/backend/tests/test_resume_builder.py
@@ -80,7 +80,7 @@ def test_resume_uses_evidence_backed_receipts_and_keeps_provenance():
     assert "Docker" in bullet["text"]
     assert result["readiness"]["source_linked_draft"] is True
     assert "kubernetes" in result["unsupported_requirements"]
-    assert "does not simulate" in result["ats_note"]
+    assert "not a prediction" in result["ats_note"]
 
 
 def test_existing_resume_is_preserved_and_combined_with_receipts():

--- a/backend/tests/test_resume_scan_regressions.py
+++ b/backend/tests/test_resume_scan_regressions.py
@@ -106,4 +106,5 @@ Platforms | Python, Docker
     assert parsed["source_signals"]["has_experience_heading"] is True
     assert parsed["source_signals"]["has_skills_heading"] is True
     assert parsed["skills"]
-    assert any("source" in warning.lower() or "visible" in warning.lower() for warning in parsed["parse_warnings"])
+    assert parsed["parse_warnings"]
+    assert any("confirm" in warning.lower() or "source" in warning.lower() or "visible" in warning.lower() for warning in parsed["parse_warnings"])

--- a/backend/tests/test_resume_scan_regressions.py
+++ b/backend/tests/test_resume_scan_regressions.py
@@ -99,10 +99,11 @@ PROFESSIONAL EXPERIENCE
 A role layout the parser cannot safely bind
 • Built a reliable production support workflow used by the engineering team.
 SKILLS
-Platforms
+Platforms | Python, Docker
 """
     parsed = parse_existing_resume_text(resume)
 
     assert parsed["source_signals"]["has_experience_heading"] is True
     assert parsed["source_signals"]["has_skills_heading"] is True
+    assert parsed["skills"]
     assert any("source" in warning.lower() or "visible" in warning.lower() for warning in parsed["parse_warnings"])

--- a/backend/tests/test_resume_scan_regressions.py
+++ b/backend/tests/test_resume_scan_regressions.py
@@ -1,0 +1,108 @@
+from app.resume_builder import analyze_resume
+from app.resume_import_parser import parse_existing_resume_text
+
+
+def test_ats_scan_returns_score_breakdown_and_actionable_feedback():
+    resume = """Tee Example
+Atlanta, GA | tee@example.com
+PROFESSIONAL SUMMARY
+Platform support engineer focused on production reliability and automation.
+PROFESSIONAL EXPERIENCE
+Acme Cloud | Platform Support Engineer
+January 2023 - Present
+• Automated Docker and Kubernetes troubleshooting with Python, reducing incident triage time by 35%.
+• Built incident response runbooks and monitoring workflows for production systems.
+SKILLS
+Python, Docker, Kubernetes, Linux, AWS, Incident Response
+EDUCATION
+Example University | Computer Science
+"""
+    result = analyze_resume(
+        target_role="Platform Support Engineer",
+        job_description="Python Docker Kubernetes Linux AWS incident response troubleshooting monitoring",
+        receipts=[],
+        existing_resume_text=resume,
+    )
+
+    scan = result["ats_scan"]
+    assert 0 <= scan["score"] <= 100
+    assert set(scan["breakdown"]) == {"parsing", "job_match", "readability"}
+    assert scan["breakdown"]["job_match"] >= 75
+    assert scan["high_score"] is True
+    assert scan["strengths"]
+    assert scan["improvements"]
+    assert "not a prediction" in scan["disclaimer"]
+
+
+def test_visible_skills_and_work_bullets_are_never_reported_as_absent_signals():
+    resume = """Tee Example
+SKILLS
+Python, Docker, Kubernetes, AWS
+PROFESSIONAL EXPERIENCE
+Acme | Support Engineer
+2022 - Present
+• Supported production Docker workloads and automated incident response with Python.
+"""
+    result = analyze_resume(
+        target_role="Support Engineer",
+        job_description="Python Docker Kubernetes AWS incident response",
+        receipts=[],
+        existing_resume_text=resume,
+    )
+
+    signals = result["imported_resume"]["source_signals"]
+    assert signals["has_skills_heading"] is True
+    assert signals["has_work_bullets"] is True
+    assert any("Skills are present" in item for item in result["ats_scan"]["strengths"])
+    assert any("Work-history bullet evidence" in item for item in result["ats_scan"]["strengths"])
+
+
+def test_wrapped_bullet_with_role_word_stays_one_bullet():
+    resume = """Tee Example
+PROFESSIONAL EXPERIENCE
+Acme Cloud | Platform Support Engineer
+January 2023 - Present
+• Partnered with software engineer teams to diagnose production incidents and
+restore customer services without inventing unsupported root causes.
+SKILLS
+Python, Docker
+"""
+    parsed = parse_existing_resume_text(resume)
+
+    assert len(parsed["experience"]) == 1
+    assert parsed["experience"][0]["company"] == "Acme Cloud"
+    assert len(parsed["experience"][0]["bullets"]) == 1
+    bullet = parsed["experience"][0]["bullets"][0]["text"]
+    assert "software engineer teams" in bullet
+    assert "restore customer services" in bullet
+
+
+def test_header_does_not_become_inferred_employment_entry():
+    resume = """Tee Example
+Platform Support Engineer
+Atlanta, GA | tee@example.com | linkedin.com/in/tee
+SKILLS
+Python, Docker, Kubernetes
+EDUCATION
+Example University | Computer Science
+"""
+    parsed = parse_existing_resume_text(resume)
+
+    assert parsed["contact"]["name"] == "Tee Example"
+    assert not any(entry.get("company") == "Tee Example" for entry in parsed["experience"])
+    assert not any(entry.get("title") == "Platform Support Engineer" for entry in parsed["experience"])
+
+
+def test_source_section_uncertainty_becomes_warning_not_missing_fact():
+    resume = """Tee Example
+PROFESSIONAL EXPERIENCE
+A role layout the parser cannot safely bind
+• Built a reliable production support workflow used by the engineering team.
+SKILLS
+Platforms
+"""
+    parsed = parse_existing_resume_text(resume)
+
+    assert parsed["source_signals"]["has_experience_heading"] is True
+    assert parsed["source_signals"]["has_skills_heading"] is True
+    assert any("source" in warning.lower() or "visible" in warning.lower() for warning in parsed["parse_warnings"])

--- a/frontend/src/AnimatedInterviewerAvatar.jsx
+++ b/frontend/src/AnimatedInterviewerAvatar.jsx
@@ -132,7 +132,7 @@ const AVATAR_STYLES = `
 export default function AnimatedInterviewerAvatar({ state = "idle", name = "Aisha Jordan" }) {
   const safeState = STATE_COPY[state] ? state : "idle";
   return (
-    <div className={`aisha-avatar-shell state-${safeState}`} data-aisha-state={safeState} data-avatar-engine="bragstack-photo-v3">
+    <div className={`aisha-avatar-shell state-${safeState}`} data-aisha-state={safeState} data-avatar-engine="bragstack-photo-v2">
       <style>{AVATAR_STYLES}</style>
       <img className="aisha-photo-avatar" src={aishaJordanPhoto} alt={`${name}, BragStack virtual interviewer`} draggable="false" />
       <div className="aisha-photo-vignette" aria-hidden="true" />

--- a/frontend/src/AnimatedInterviewerAvatar.jsx
+++ b/frontend/src/AnimatedInterviewerAvatar.jsx
@@ -8,10 +8,132 @@ const STATE_COPY = {
   encouraging: "Follow-up coaching",
 };
 
+const AVATAR_STYLES = `
+.aisha-avatar-shell {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  background: #08101f;
+  isolation: isolate;
+}
+.aisha-photo-avatar {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  display: block;
+  object-fit: cover;
+  object-position: center 28%;
+  transform: scale(1.04);
+  transform-origin: 50% 45%;
+  will-change: transform, filter;
+  user-select: none;
+  pointer-events: none;
+}
+.aisha-photo-vignette {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  pointer-events: none;
+  background:
+    linear-gradient(180deg, rgba(4,8,18,.02) 45%, rgba(4,8,18,.78) 100%),
+    radial-gradient(circle at 50% 38%, transparent 48%, rgba(4,8,18,.2) 100%);
+}
+.avatar-state-pill {
+  position: absolute;
+  left: 14px;
+  top: 14px;
+  z-index: 4;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  max-width: calc(100% - 28px);
+  padding: 8px 11px;
+  border: 1px solid rgba(255,255,255,.16);
+  border-radius: 999px;
+  color: #eef2ff;
+  background: rgba(7,16,31,.72);
+  backdrop-filter: blur(9px);
+  font-size: clamp(.72rem, 1.7vw, .82rem);
+  line-height: 1;
+  box-shadow: 0 8px 22px rgba(0,0,0,.25);
+}
+.avatar-state-dot {
+  width: 8px;
+  height: 8px;
+  flex: 0 0 auto;
+  border-radius: 999px;
+  background: #a5b4fc;
+  box-shadow: 0 0 0 4px rgba(165,180,252,.12);
+}
+.aisha-avatar-shell.state-speaking .aisha-photo-avatar {
+  animation: aishaSpeaking 1.6s ease-in-out infinite;
+}
+.aisha-avatar-shell.state-listening .aisha-photo-avatar {
+  animation: aishaListening 2.6s ease-in-out infinite;
+}
+.aisha-avatar-shell.state-thinking .aisha-photo-avatar {
+  animation: aishaThinking 2.2s ease-in-out infinite;
+  filter: saturate(.96) brightness(.96);
+}
+.aisha-avatar-shell.state-encouraging .aisha-photo-avatar {
+  animation: aishaEncouraging 1.9s ease-in-out infinite;
+}
+.aisha-avatar-shell.state-speaking .avatar-state-dot {
+  animation: aishaPulse .85s ease-in-out infinite;
+  background: #c4b5fd;
+}
+.aisha-avatar-shell.state-listening .avatar-state-dot {
+  animation: aishaPulse 1.1s ease-in-out infinite;
+  background: #6ee7b7;
+  box-shadow: 0 0 0 4px rgba(110,231,183,.14);
+}
+.aisha-avatar-shell.state-thinking .avatar-state-dot { background: #fcd34d; }
+.aisha-avatar-shell.state-encouraging .avatar-state-dot { background: #f9a8d4; }
+@keyframes aishaSpeaking {
+  0%,100% { transform: scale(1.045) translate3d(0,0,0) rotate(0deg); }
+  30% { transform: scale(1.065) translate3d(.25%, -.35%, 0) rotate(.18deg); }
+  60% { transform: scale(1.055) translate3d(-.2%, .2%, 0) rotate(-.14deg); }
+}
+@keyframes aishaListening {
+  0%,100% { transform: scale(1.045) translate3d(0,0,0); }
+  50% { transform: scale(1.06) translate3d(-.35%, -.25%, 0); }
+}
+@keyframes aishaThinking {
+  0%,100% { transform: scale(1.045) translate3d(0,0,0); }
+  50% { transform: scale(1.055) translate3d(.45%, -.15%, 0); }
+}
+@keyframes aishaEncouraging {
+  0%,100% { transform: scale(1.045) translate3d(0,0,0) rotate(0deg); }
+  50% { transform: scale(1.065) translate3d(0,-.35%,0) rotate(.22deg); }
+}
+@keyframes aishaPulse {
+  0%,100% { transform: scale(.9); opacity: .78; }
+  50% { transform: scale(1.22); opacity: 1; }
+}
+@media (max-width: 950px) {
+  .aisha-photo-avatar { object-position: center 25%; }
+}
+@media (max-width: 620px) {
+  .aisha-photo-avatar { object-position: center 22%; transform: scale(1.08); }
+  .avatar-state-pill { left: 10px; top: 10px; max-width: calc(100% - 20px); padding: 7px 9px; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .aisha-avatar-shell .aisha-photo-avatar,
+  .aisha-avatar-shell .avatar-state-dot {
+    animation: none !important;
+    transition: none !important;
+  }
+}
+`;
+
 export default function AnimatedInterviewerAvatar({ state = "idle", name = "Aisha Jordan" }) {
   const safeState = STATE_COPY[state] ? state : "idle";
   return (
-    <div className={`aisha-avatar-shell state-${safeState}`} data-aisha-state={safeState} data-avatar-engine="bragstack-photo-v2">
+    <div className={`aisha-avatar-shell state-${safeState}`} data-aisha-state={safeState} data-avatar-engine="bragstack-photo-v3">
+      <style>{AVATAR_STYLES}</style>
       <img className="aisha-photo-avatar" src={aishaJordanPhoto} alt={`${name}, BragStack virtual interviewer`} draggable="false" />
       <div className="aisha-photo-vignette" aria-hidden="true" />
       <div className={`avatar-state-pill state-${safeState}`} aria-live="polite">

--- a/frontend/src/ResumeBuilderStructuredPage.jsx
+++ b/frontend/src/ResumeBuilderStructuredPage.jsx
@@ -41,7 +41,7 @@ function downloadText(filename, text) {
   URL.revokeObjectURL(url);
 }
 
-function GateCard({ title, icon: Icon, status }) {
+function ScanCard({ title, icon: Icon, status }) {
   return (
     <article className={`resume-v2-gate ${status.level}`}>
       <div className="resume-v2-gate-top">
@@ -63,7 +63,7 @@ function StructuredResumePreview({ draft, summary, skills, sections, onEdit }) {
   const roles = draft?.experience || [];
   return (
     <article className="resume-v2-paper">
-      <div className="resume-v2-paper-banner"><span><ShieldCheck size={14} /> ATS-safe single-column preview</span><button type="button" onClick={onEdit}>Edit resume content</button></div>
+      <div className="resume-v2-paper-banner"><span><ShieldCheck size={14} /> ATS-friendly single-column preview</span><button type="button" onClick={onEdit}>Edit resume content</button></div>
       <header>
         <h1>{contact.name || "Your Name"}</h1>
         {contactItems.length > 0 && <div className="resume-v2-contact">{contactItems.map((item, index) => <span key={`${item}-${index}`}>{item}</span>)}</div>}
@@ -86,6 +86,27 @@ function StructuredResumePreview({ draft, summary, skills, sections, onEdit }) {
         return <section key={key}><h2>{key}</h2><div className="resume-v2-support-lines">{lines.map((line, index) => <span key={`${key}-${index}`}>{line}</span>)}</div></section>;
       })}
     </article>
+  );
+}
+
+function AtsScanSummary({ scan }) {
+  if (!scan) return null;
+  const breakdown = scan.breakdown || {};
+  return (
+    <div className="resume-v2-card ats-scan-score-card">
+      <div style={{ display: "flex", justifyContent: "space-between", gap: 16, alignItems: "center", flexWrap: "wrap" }}>
+        <div><h3 style={{ marginBottom: 4 }}><ShieldCheck size={15} /> ATS Scan score</h3><p style={{ margin: 0 }}>{scan.high_score ? "This resume has a strong overall compatibility signal for this target job." : "This resume has useful evidence, with areas worth strengthening before applying."}</p></div>
+        <div style={{ textAlign: "right" }}><strong style={{ fontSize: "2rem", lineHeight: 1 }}>{scan.score}/100</strong><small style={{ display: "block", marginTop: 5 }}>{scan.label}</small></div>
+      </div>
+      <div className="resume-v2-gaps" style={{ marginTop: 14 }}>
+        <span className="resume-v2-gap">Parsing {breakdown.parsing ?? 0}/100</span>
+        <span className="resume-v2-gap">Job match {breakdown.job_match ?? 0}/100</span>
+        <span className="resume-v2-gap">Readability {breakdown.readability ?? 0}/100</span>
+      </div>
+      {scan.strengths?.length > 0 && <div style={{ marginTop: 14 }}><strong>What is working</strong>{scan.strengths.map((item) => <p key={item} style={{ overflowWrap: "anywhere" }}>✓ {item}</p>)}</div>}
+      {scan.improvements?.length > 0 && <div style={{ marginTop: 14 }}><strong>What to improve</strong>{scan.improvements.map((item) => <p key={item} style={{ overflowWrap: "anywhere" }}>→ {item}</p>)}</div>}
+      <small style={{ display: "block", marginTop: 14, lineHeight: 1.5 }}>{scan.disclaimer}</small>
+    </div>
   );
 }
 
@@ -138,9 +159,9 @@ export default function ResumeBuilderStructuredPage() {
 
   const parseWarnings = useMemo(() => importedResume?.parse_warnings || [], [importedResume]);
   const contentContext = useMemo(() => ({ summary, skills, sections: supportingSections }), [summary, skills, supportingSections]);
-  const parseGate = useMemo(() => parseGateStatus(resumeDraft, parseWarnings, contentContext), [resumeDraft, parseWarnings, contentContext]);
-  const qualificationGate = useMemo(() => qualificationGateStatus(result), [result]);
-  const recruiterGate = useMemo(() => recruiterGateStatus(resumeDraft, contentContext), [resumeDraft, contentContext]);
+  const parseStatus = useMemo(() => parseGateStatus(resumeDraft, parseWarnings, contentContext), [resumeDraft, parseWarnings, contentContext]);
+  const matchStatus = useMemo(() => qualificationGateStatus(result), [result]);
+  const readabilityStatus = useMemo(() => recruiterGateStatus(resumeDraft, contentContext), [resumeDraft, contentContext]);
   const plainText = useMemo(() => serializeResumeDraft({ draft: resumeDraft, summary, skills, sections: supportingSections }), [resumeDraft, summary, skills, supportingSections]);
   const proofSuggestions = useMemo(() => (result?.bullets || []).filter((bullet) => bullet.source_kind === "impact-receipt" && !addedProofKeys.includes(proofKey(bullet))), [result, addedProofKeys]);
   const detectedSections = importedResume?.sections_found || [];
@@ -172,8 +193,8 @@ export default function ResumeBuilderStructuredPage() {
       setProofRoleIndex(0);
       setAddedProofKeys([]);
       setMessage(draft.experience.length
-        ? `We reconstructed ${draft.experience.length} role${draft.experience.length === 1 ? "" : "s"}. Review the resume content before ATS analysis.`
-        : "We could not confidently reconstruct a role. You can still edit the imported content, add work history manually, or continue with projects, education, and skills.");
+        ? `We reconstructed ${draft.experience.length} role${draft.experience.length === 1 ? "" : "s"}. Review the resume content against the source before ATS Scan.`
+        : "We could not confidently reconstruct a role. Your source resume remains authoritative; review it before treating any parsed field as missing.");
     } catch (error) {
       setMessage(error.response?.data?.detail || "We could not import that resume.");
     } finally {
@@ -184,13 +205,7 @@ export default function ResumeBuilderStructuredPage() {
 
   function startFromScratch() {
     const draft = makeResumeDraft({ contact: {}, experience: [] }, user || {});
-    setImportedResume({
-      filename: "New master resume",
-      manual: true,
-      sections_found: [],
-      sections: { projects: [], education: [] },
-      parse_warnings: [],
-    });
+    setImportedResume({ filename: "New master resume", manual: true, sections_found: [], sections: { projects: [], education: [] }, parse_warnings: [] });
     setLoadedSavedId("");
     setResumeDraft(draft);
     setSupportingSections({ projects: [], education: [] });
@@ -225,7 +240,7 @@ export default function ResumeBuilderStructuredPage() {
   function openSavedResume(savedResume) {
     const draft = makeSavedResumeDraft(savedResume, user || {});
     if (!draft) {
-      setMessage("That older saved version predates structured resume content. Upload the source resume to reconstruct it before ATS Gate Check.");
+      setMessage("That older saved version predates structured resume content. Upload the source resume to reconstruct it before ATS Scan.");
       return;
     }
     const sections = savedResume.supporting_sections || {};
@@ -249,39 +264,34 @@ export default function ResumeBuilderStructuredPage() {
     setSelectedIds([]);
     setProofRoleIndex(0);
     setAddedProofKeys(flattenExperienceBullets(draft.experience).filter((bullet) => bullet.source_kind === "impact-receipt").map(proofKey));
-    setMessage(`Opened ${savedResume.title || "saved resume"}. Your structured resume content was restored. Add a target job only when you want ATS coaching.`);
+    setMessage(`Opened ${savedResume.title || "saved resume"}. Add a target job when you want to run ATS Scan.`);
   }
 
   function confirmImport() {
     setImportConfirmed(true);
     setResult(null);
     setAtsTextMode(false);
-    setMessage("Resume content confirmed. Save it as a master resume or add a target job and run ATS Gate Check.");
+    setMessage("Resume content confirmed. Save it as a master resume or add a target job and run ATS Scan.");
   }
 
   async function handleBuild(event) {
     event.preventDefault();
     if (!resumeDraft || !importConfirmed) {
-      setMessage("Start or open a resume and confirm its content before running ATS Gate Check.");
+      setMessage("Start or open a resume and confirm its content before running ATS Scan.");
       return;
     }
     setBuilding(true);
     setMessage("");
     try {
       const existingResumeText = serializeResumeDraft({ draft: resumeDraft, summary, skills, sections: supportingSections });
-      const data = await buildResume({
-        target_role: targetRole,
-        job_description: jobDescription,
-        selected_receipt_ids: selectedIds,
-        existing_resume_text: existingResumeText,
-      });
+      const data = await buildResume({ target_role: targetRole, job_description: jobDescription, selected_receipt_ids: selectedIds, existing_resume_text: existingResumeText });
       setResult(data);
       setSummary(data.summary || summary);
       setSkills(data.skills || skills);
       setAtsTextMode(false);
-      setMessage("ATS Gate Check finished. Review truthful gaps and proof suggestions before exporting.");
+      setMessage(`ATS Scan finished${data.ats_scan?.score != null ? ` · ${data.ats_scan.score}/100 ${data.ats_scan.label}` : ""}. Review the evidence and recommendations below.`);
     } catch (error) {
-      setMessage(error.response?.data?.detail?.message || error.response?.data?.detail || "ATS Gate Check could not run.");
+      setMessage(error.response?.data?.detail?.message || error.response?.data?.detail || "ATS Scan could not run.");
     } finally {
       setBuilding(false);
     }
@@ -296,13 +306,10 @@ export default function ResumeBuilderStructuredPage() {
     const index = Math.min(proofRoleIndex, resumeDraft.experience.length - 1);
     setResumeDraft((current) => ({
       ...current,
-      experience: current.experience.map((role, roleIndex) => roleIndex === index ? {
-        ...role,
-        bullets: [...(role.bullets || []), { ...bullet, edited: false }],
-      } : role),
+      experience: current.experience.map((role, roleIndex) => roleIndex === index ? { ...role, bullets: [...(role.bullets || []), { ...bullet, edited: false }] } : role),
     }));
     setAddedProofKeys((current) => [...current, proofKey(bullet)]);
-    setMessage(`Added evidence-backed proof to ${resumeDraft.experience[index].company || resumeDraft.experience[index].title}. Re-run ATS Gate Check to refresh the job match.`);
+    setMessage(`Added evidence-backed proof to ${resumeDraft.experience[index].company || resumeDraft.experience[index].title}. Re-run ATS Scan to refresh the job match.`);
   }
 
   async function handleSave({ master = false } = {}) {
@@ -334,16 +341,11 @@ export default function ResumeBuilderStructuredPage() {
         skills,
         contact: resumeDraft.contact || {},
         experience,
-        supporting_sections: {
-          projects: supportingSections.projects || [],
-          education: supportingSections.education || [],
-        },
+        supporting_sections: { projects: supportingSections.projects || [], education: supportingSections.education || [] },
       });
       setSaved((current) => [created, ...current]);
       setLoadedSavedId(created.id);
-      setMessage(isTargeted
-        ? "Targeted resume version saved with structured content and source provenance intact."
-        : "Master resume saved. You can reuse it later and target a job when you are ready.");
+      setMessage(isTargeted ? "Targeted resume version saved with structured content and source provenance intact." : "Master resume saved. You can reuse it later and target a job when you are ready.");
     } catch (error) {
       setMessage(error.response?.data?.detail || "We could not save that resume version.");
     }
@@ -356,26 +358,21 @@ export default function ResumeBuilderStructuredPage() {
 
   const supportedEvidence = (result?.supported_requirements || []).slice(0, 8).map((term) => {
     const detail = findRequirementEvidenceDetail(term, { draft: resumeDraft, summary, skills });
-    return {
-      term,
-      source: detail?.label || "Career proof available",
-      excerpt: detail?.excerpt || "",
-      sourceKind: detail?.sourceKind || "unknown",
-    };
+    return { term, source: detail?.label || "Career proof available", excerpt: detail?.excerpt || "", sourceKind: detail?.sourceKind || "unknown" };
   });
 
   return (
     <main className="resume-v2-page">
       <header className="resume-v2-hero">
         <div><span className="resume-v2-badge"><Sparkles size={14} /> BRAGSTACK PRO</span><h1>Resume Builder</h1><p>Import the resume you already use or build one from scratch, then target a job and strengthen only the experience you can truthfully support.</p></div>
-        <div className="resume-v2-hero-note"><ShieldCheck size={21} /><span><strong>ATS Gate Check</strong><small>Reduce avoidable parsing and matching problems. No score can guarantee how every employer ATS behaves.</small></span></div>
+        <div className="resume-v2-hero-note"><ShieldCheck size={21} /><span><strong>ATS Scan</strong><small>Checks parsing, job-match evidence, and readability. It does not predict an employer’s hiring decision.</small></span></div>
       </header>
 
       <div className="resume-v2-steps" aria-label="Resume builder progress">
         <Step number="1" label="Start resume" state={stepState(1)} />
         <Step number="2" label="Review resume content" state={stepState(2)} />
         <Step number="3" label="Target the job" state={stepState(3)} />
-        <Step number="4" label="Review ATS Gate" state={stepState(4)} />
+        <Step number="4" label="Review ATS Scan" state={stepState(4)} />
       </div>
 
       <section className="resume-v2-grid">
@@ -388,53 +385,32 @@ export default function ResumeBuilderStructuredPage() {
             {importedResume && <button type="button" className="resume-v2-icon-button" aria-label="Clear current resume" onClick={clearImport}><X size={14} /></button>}
           </div>
 
-          {!importedResume && <>
-            <div className="resume-v2-source-divider"><span>or</span></div>
-            <button className="resume-v2-start-blank" type="button" onClick={startFromScratch}><Plus size={18} /><span><strong>Build from scratch</strong><small>No starter resume required</small></span></button>
-          </>}
+          {!importedResume && <><div className="resume-v2-source-divider"><span>or</span></div><button className="resume-v2-start-blank" type="button" onClick={startFromScratch}><Plus size={18} /><span><strong>Build from scratch</strong><small>No starter resume required</small></span></button></>}
 
           {saved.length > 0 && <div className="resume-v2-saved-block">
             <div className="resume-v2-saved-head"><span>Saved versions</span><small>{saved.length}</small></div>
-            <div className="resume-v2-saved-list">
-              {saved.slice(0, 5).map((item) => {
-                const structured = Number(item.schema_version || 0) >= 4 && Array.isArray(item.experience);
-                return <button type="button" className={`resume-v2-saved-item ${loadedSavedId === item.id ? "active" : ""}`} key={item.id} onClick={() => openSavedResume(item)}>
-                  <span><strong>{item.title || item.target_role || "Saved resume"}</strong><small>{structured ? `${item.experience.length} work role${item.experience.length === 1 ? "" : "s"} · ${savedVersionDate(item.updated_at || item.created_at)}` : `Legacy version · ${savedVersionDate(item.updated_at || item.created_at)}`}</small></span>
-                  <em>{structured ? "Open" : "Re-import"}</em>
-                </button>;
-              })}
-            </div>
+            <div className="resume-v2-saved-list">{saved.slice(0, 5).map((item) => {
+              const structured = Number(item.schema_version || 0) >= 4 && Array.isArray(item.experience);
+              return <button type="button" className={`resume-v2-saved-item ${loadedSavedId === item.id ? "active" : ""}`} key={item.id} onClick={() => openSavedResume(item)}><span><strong>{item.title || item.target_role || "Saved resume"}</strong><small>{structured ? `${item.experience.length} work role${item.experience.length === 1 ? "" : "s"} · ${savedVersionDate(item.updated_at || item.created_at)}` : `Legacy version · ${savedVersionDate(item.updated_at || item.created_at)}`}</small></span><em>{structured ? "Open" : "Re-import"}</em></button>;
+            })}</div>
           </div>}
 
           <div className="resume-v2-divider" />
           <div className="resume-v2-label">Target job</div>
           <form className="resume-v2-form" onSubmit={handleBuild}>
-            <div className="resume-v2-disabled-note">Target role and job description are only required for ATS Gate Check. You can build and save a master resume without either one.</div>
+            <div className="resume-v2-disabled-note">Target role and job description are only required for ATS Scan. You can build and save a master resume without either one.</div>
             <label>Target role<input value={targetRole} onChange={(event) => setTargetRole(event.target.value)} placeholder="Platform Support Engineer" required /></label>
             <label>Job description<textarea value={jobDescription} onChange={(event) => setJobDescription(event.target.value)} placeholder="Paste the full job posting here…" required /></label>
             <div className="resume-v2-label">Career proof</div>
-            <div className="resume-v2-receipts">
-              {receipts.slice(0, 16).map((receipt) => <label className="resume-v2-receipt" key={receipt.id}><input type="checkbox" checked={selectedIds.includes(receipt.id)} onChange={() => toggleReceipt(receipt.id)} /><span><strong>{receipt.accomplishment}</strong><small>{(receipt.skills || []).slice(0, 3).join(" · ") || "Impact Receipt"}</small></span></label>)}
-            </div>
-            <button className="resume-v2-primary" type="submit" disabled={!importConfirmed || building || importing}>{building ? "Running ATS Gate Check…" : result ? "Re-run ATS Gate Check" : importConfirmed ? "Run ATS Gate Check" : "Confirm resume content to run ATS Gate"}</button>
+            <div className="resume-v2-receipts">{receipts.slice(0, 16).map((receipt) => <label className="resume-v2-receipt" key={receipt.id}><input type="checkbox" checked={selectedIds.includes(receipt.id)} onChange={() => toggleReceipt(receipt.id)} /><span><strong>{receipt.accomplishment}</strong><small>{(receipt.skills || []).slice(0, 3).join(" · ") || "Impact Receipt"}</small></span></label>)}</div>
+            <button className="resume-v2-primary" type="submit" disabled={!importConfirmed || building || importing}>{building ? "Running ATS Scan…" : result ? "Re-run ATS Scan" : importConfirmed ? "Run ATS Scan" : "Confirm resume content to run ATS Scan"}</button>
             {resumeDraft && importConfirmed && <button className="resume-v2-secondary" type="button" onClick={() => handleSave({ master: true })}><Save size={15} /> Save master resume</button>}
           </form>
         </aside>
 
         <section className="resume-v2-panel resume-v2-center">
           {importedResume && resumeDraft && !importConfirmed ? (
-            <ResumeImportConfirmation
-              draft={resumeDraft}
-              warnings={parseWarnings}
-              summary={summary}
-              skills={skills}
-              sections={supportingSections}
-              onChange={setResumeDraft}
-              onSummaryChange={setSummary}
-              onSkillsChange={setSkills}
-              onSectionsChange={setSupportingSections}
-              onConfirm={confirmImport}
-            />
+            <ResumeImportConfirmation draft={resumeDraft} warnings={parseWarnings} summary={summary} skills={skills} sections={supportingSections} onChange={setResumeDraft} onSummaryChange={setSummary} onSkillsChange={setSkills} onSectionsChange={setSupportingSections} onConfirm={confirmImport} />
           ) : atsTextMode && result ? (
             <div className="resume-v2-ats-text"><div className="resume-v2-ats-text-head"><strong>ATS TEXT VIEW</strong><button type="button" onClick={() => setAtsTextMode(false)}>Back to resume</button></div><pre>{plainText}</pre><small>{result.ats_note}</small></div>
           ) : resumeDraft && importConfirmed ? (
@@ -445,17 +421,18 @@ export default function ResumeBuilderStructuredPage() {
         </section>
 
         <aside className="resume-v2-panel resume-v2-right">
-          <div className="resume-v2-label">ATS Gate Check</div>
-          <p className="resume-v2-gate-intro">Three checks: is the resume structured cleanly, does it visibly support the target role, and is it easy for a recruiter to scan?</p>
+          <div className="resume-v2-label">ATS Scan</div>
+          <p className="resume-v2-gate-intro">Checks three things separately: parsing, job-match evidence, and recruiter readability.</p>
           <div className="resume-v2-gates">
-            <GateCard title="Parse Gate" icon={FileText} status={parseGate} />
-            <GateCard title="Qualification Gate" icon={Target} status={qualificationGate} />
-            <GateCard title="Recruiter Gate" icon={BriefcaseBusiness} status={recruiterGate} />
+            <ScanCard title="Parsing" icon={FileText} status={parseStatus} />
+            <ScanCard title="Job Match" icon={Target} status={matchStatus} />
+            <ScanCard title="Readability" icon={BriefcaseBusiness} status={readabilityStatus} />
           </div>
 
-          {missingCoreSections.length > 0 && <div className="resume-v2-card"><h3><AlertTriangle size={15} /> Parser review</h3><p>We did not confidently detect {missingCoreSections.join(" and ")}. Confirm the content before applying.</p></div>}
+          {missingCoreSections.length > 0 && <div className="resume-v2-card"><h3><AlertTriangle size={15} /> Parser review</h3><p>We could not confidently classify {missingCoreSections.join(" and ")} from the parsed structure. Check the original resume before treating that content as missing.</p></div>}
 
           {result && <>
+            <AtsScanSummary scan={result.ats_scan} />
             <div className="resume-v2-card"><h3><CheckCircle2 size={15} /> Signals already visible</h3><div className="resume-v2-evidence-list">{supportedEvidence.map((item) => <div className="resume-v2-evidence" key={item.term}><div><strong>{item.term}</strong>{item.excerpt && item.excerpt !== item.source && <small>{item.excerpt}</small>}</div><span className={item.sourceKind === "impact-receipt" ? "proof" : ""}>{item.sourceKind === "impact-receipt" ? "Proof · " : ""}{item.source}</span></div>)}</div></div>
             <div className="resume-v2-card"><h3><Target size={15} /> Not visible yet</h3>{result.unsupported_requirements?.length ? <><p className="resume-v2-gap-note">These signals were detected in the job posting but are not clearly visible in this resume. That does not mean you lack them.</p><div className="resume-v2-gaps">{result.unsupported_requirements.slice(0, 12).map((term) => <span className="resume-v2-gap" key={term}>{term}</span>)}</div></> : <p>No major detected gaps in the current comparison.</p>}</div>
 
@@ -470,7 +447,7 @@ export default function ResumeBuilderStructuredPage() {
             </div>
           </>}
 
-          {!result && resumeDraft && importConfirmed && <div className="resume-v2-card"><h3><ShieldCheck size={15} /> Master resume ready</h3><p>Save this reusable resume now, or paste a target job to run ATS Gate Check. A target role and job description are only required for the targeted workflow.</p></div>}
+          {!result && resumeDraft && importConfirmed && <div className="resume-v2-card"><h3><ShieldCheck size={15} /> Master resume ready</h3><p>Save this reusable resume now, or paste a target job to run ATS Scan. A target role and job description are only required for the targeted workflow.</p></div>}
           {!importedResume && <div className="resume-v2-card"><h3><Upload size={15} /> Two ways to start</h3><p>Upload an existing resume for reconstruction or build one from scratch. Work history is not required for students, career starters, or project-led resumes.</p></div>}
           {message && <p className="resume-v2-message">{String(message)}</p>}
         </aside>

--- a/frontend/src/RootContent.jsx
+++ b/frontend/src/RootContent.jsx
@@ -31,6 +31,37 @@ const SettingsPage = lazyPage(() => import("./SettingsPage.jsx"));
 const UpgradePage = lazyPage(() => import("./UpgradePage.jsx"));
 const LegalPages = lazyPage(() => import("./LegalPages.jsx"));
 
+const INTERVIEW_PATH = "/app/interview-practice";
+
+function hardStopInterviewMedia() {
+  window.__bragstackInterviewActive = false;
+  try { window.speechSynthesis?.cancel?.(); } catch { /* ignore */ }
+  try { window.speechSynthesis?.pause?.(); } catch { /* ignore */ }
+  window.dispatchEvent(new CustomEvent("bragstack:interview-teardown"));
+}
+
+function installInterviewSpeechGuard() {
+  const synth = window.speechSynthesis;
+  if (!synth?.speak || synth.__bragstackGuardInstalled) return () => {};
+
+  const nativeSpeak = synth.speak.bind(synth);
+  const guardedSpeak = (utterance) => {
+    const onInterviewRoute = (window.location.pathname.replace(/\/$/, "") || "/") === INTERVIEW_PATH;
+    if (!window.__bragstackInterviewActive || !onInterviewRoute) {
+      try { utterance?.dispatchEvent?.(new Event("error")); } catch { /* ignore */ }
+      return;
+    }
+    nativeSpeak(utterance);
+  };
+
+  synth.speak = guardedSpeak;
+  synth.__bragstackGuardInstalled = true;
+  return () => {
+    if (synth.speak === guardedSpeak) synth.speak = nativeSpeak;
+    delete synth.__bragstackGuardInstalled;
+  };
+}
+
 function RouteFallback() { return <BragStackLoader message="Opening BragStack…" detail="Loading the tools you need." />; }
 function ProRequired({ feature = "This feature" }) { return <main className="page"><section className="notice"><strong>BragStack Pro</strong><span>{feature} is available on Pro. Upgrade to unlock advanced career tools.</span><a className="btn primary" href="/upgrade">Upgrade to Pro</a></section></main>; }
 function ImpactReceiptsWithVerification() { return <><ImpactReceiptsPage /><ReceiptVerificationCenter /></>; }
@@ -42,6 +73,31 @@ function RootContent() {
   const isAuthenticatedApp = path.startsWith("/app") || path.startsWith("/ops");
   const [user, setUser] = useState(null);
   const [planLoaded, setPlanLoaded] = useState(!isAuthenticatedApp);
+
+  useEffect(() => {
+    const uninstallSpeechGuard = installInterviewSpeechGuard();
+    const killOnNavigation = () => hardStopInterviewMedia();
+    window.addEventListener("pagehide", killOnNavigation);
+    window.addEventListener("beforeunload", killOnNavigation);
+    window.addEventListener("popstate", killOnNavigation);
+    return () => {
+      window.removeEventListener("pagehide", killOnNavigation);
+      window.removeEventListener("beforeunload", killOnNavigation);
+      window.removeEventListener("popstate", killOnNavigation);
+      hardStopInterviewMedia();
+      uninstallSpeechGuard();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (path === INTERVIEW_PATH) {
+      window.__bragstackInterviewActive = true;
+      try { window.speechSynthesis?.resume?.(); } catch { /* ignore */ }
+      return () => hardStopInterviewMedia();
+    }
+    hardStopInterviewMedia();
+    return undefined;
+  }, [path]);
 
   useEffect(() => {
     if (!isAuthenticatedApp) return undefined;
@@ -90,7 +146,7 @@ function RootContent() {
     else if (path === "/app/impact-receipts") Content = ImpactReceiptsWithVerification;
     else if (path === "/app/resume-builder" && planLoaded) { Content = user?.entitlements?.resume_builder ? ResumeBuilderPage : ProRequired; contentProps = user?.entitlements?.resume_builder ? {} : { feature: "Resume Builder and ATS Guardian" }; }
     else if (path === "/app/reports" && planLoaded) { Content = user?.entitlements?.advanced_reports ? ProCareerPage : ProRequired; contentProps = user?.entitlements?.advanced_reports ? {} : { feature: "Career analytics and career packets" }; }
-    else if (path === "/app/interview-practice" && planLoaded) { Content = user?.entitlements?.interview_practice ? InterviewPracticeExperience : ProRequired; contentProps = user?.entitlements?.interview_practice ? {} : { feature: "Practice Interviewer" }; }
+    else if (path === INTERVIEW_PATH && planLoaded) { Content = user?.entitlements?.interview_practice ? InterviewPracticeExperience : ProRequired; contentProps = user?.entitlements?.interview_practice ? {} : { feature: "Practice Interviewer" }; }
 
     if (!isAuthenticatedApp) content = <Content {...contentProps} />;
     else if (!planLoaded) content = <BragStackLoader message="Preparing your workspace…" detail="Connecting your account and career intelligence." />;

--- a/frontend/src/resumeStructured.js
+++ b/frontend/src/resumeStructured.js
@@ -177,24 +177,24 @@ export function parseGateStatus(draft, parseWarnings = [], content = {}) {
   const roles = draft?.experience || [];
   const supportingCount = supportingContentCount(content);
   if (!roles.length && !supportingCount) {
-    return { level: "bad", label: "Needs content", detail: "Add work history, projects, education, skills, or a summary before applying." };
+    return { level: "bad", label: "Needs content", detail: "We could not verify enough structured content yet. Review the source resume before changing anything." };
   }
   const incomplete = roles.filter((role) => !clean(role.company) || !clean(role.title));
   if (incomplete.length || parseWarnings.length) {
-    return { level: "warn", label: "Review", detail: `${Math.max(incomplete.length, parseWarnings.length)} item${Math.max(incomplete.length, parseWarnings.length) === 1 ? "" : "s"} should be confirmed before applying.` };
+    return { level: "warn", label: "Review", detail: `${Math.max(incomplete.length, parseWarnings.length)} parsed item${Math.max(incomplete.length, parseWarnings.length) === 1 ? "" : "s"} should be confirmed against the source resume.` };
   }
   if (!roles.length) {
-    return { level: "good", label: "Structured", detail: "This resume is built from structured education, projects, skills, or summary content without requiring work history." };
+    return { level: "good", label: "Structured", detail: "Structured education, projects, skills, or summary content is available even without work history." };
   }
-  return { level: "good", label: "Ready", detail: `${roles.length} role${roles.length === 1 ? "" : "s"} structured with employer and title.` };
+  return { level: "good", label: "Ready", detail: `${roles.length} role${roles.length === 1 ? "" : "s"} are structured with employer and title.` };
 }
 
 export function qualificationGateStatus(result) {
-  if (!result) return { level: "neutral", label: "Waiting", detail: "Add a target job to check requirement coverage." };
-  const coverage = Number(result?.readiness?.coverage_percent || 0);
-  if (coverage >= 65) return { level: "good", label: "Strong signal", detail: "Most detected job requirements are visible in the resume." };
-  if (coverage >= 35) return { level: "warn", label: "Strengthen", detail: "Several relevant requirements are not visible enough yet." };
-  return { level: "bad", label: "Needs work", detail: "The current resume is missing many detected job signals." };
+  if (!result) return { level: "neutral", label: "Waiting", detail: "Add a target job to compare supported evidence with the posting." };
+  const scanScore = Number(result?.ats_scan?.breakdown?.job_match ?? result?.readiness?.coverage_percent ?? 0);
+  if (scanScore >= 75) return { level: "good", label: "Strong match", detail: `${scanScore}% of detected job signals are visibly supported by the resume or selected career proof.` };
+  if (scanScore >= 50) return { level: "warn", label: "Good foundation", detail: `${scanScore}% of detected job signals are visibly supported. Review the unmatched requirements for truthful additions.` };
+  return { level: "bad", label: "Needs attention", detail: `${scanScore}% of detected job signals are visibly supported. This is a comparison result, not an employer rejection prediction.` };
 }
 
 export function recruiterGateStatus(draft, content = {}) {
@@ -203,10 +203,10 @@ export function recruiterGateStatus(draft, content = {}) {
   if (!bullets.length) {
     const supportingCount = supportingContentCount(content);
     if (supportingCount) {
-      return { level: "warn", label: "Project-led", detail: "No work-history bullets yet. Recruiter scan will rely on projects, education, skills, and summary content." };
+      return { level: "warn", label: "Review structure", detail: "No structured work-history bullets are currently available to this scan. Supporting projects, education, skills, or summary content is still present." };
     }
-    return { level: "bad", label: "Needs work", detail: "Add accomplishments, projects, education, or skills for a recruiter to scan." };
+    return { level: "bad", label: "Needs content", detail: "The scan could not verify accomplishments, projects, education, or skills yet. Check the source resume before treating anything as missing." };
   }
-  if (quantified >= 3) return { level: "good", label: "Ready", detail: `${quantified} accomplishment bullets show measurable impact.` };
+  if (quantified >= 3) return { level: "good", label: "Strong", detail: `${quantified} accomplishment bullets show measurable impact.` };
   return { level: "warn", label: "Polish", detail: `${quantified} bullet${quantified === 1 ? "" : "s"} show measurable impact. Add numbers only where they are true.` };
 }


### PR DESCRIPTION
## What changed

- Make Aisha fill the interviewer viewport across desktop/tablet/mobile and add distinct speaking, listening, thinking, and encouraging motion states with reduced-motion support.
- Add route-level interview media teardown so speech is canceled on Back/navigation/page exit, not only from the End Interview action. A speech guard prevents stale async interview sequences from speaking again after the route is left.
- Rename user-facing **ATS Gate Check** terminology to **ATS Scan** and simplify the three checks to **Parsing**, **Job Match**, and **Readability**.
- Add a BragStack-specific `/100` ATS Scan score with a three-part breakdown, high-score signal, strengths, concrete improvements, and a clear non-predictive disclaimer.
- Make resume parsing evidence-first: source section signals, conservative role-header detection, safer wrapped-bullet reconstruction, stricter inferred work-history grouping, and warnings instead of false “missing” claims.
- Add PyMuPDF as the primary geometry-aware PDF text extractor with pypdf as an independent fallback.
- Preserve raw extracted resume text and source signals through import.
- Add regression tests for high ATS Scan scores/feedback, visible Skills and work bullets, wrapped bullets containing role words, fake header employment entries, and low-confidence section parsing.

## Product contract

The source resume is evidence. Parsing is interpretation. ATS Scan is analysis. Aisha is presentation. No downstream layer should make a stronger claim than the source evidence supports.

## Notes

ATS Scan is intentionally presented as a compatibility analysis, not as a reproduction of Workday, Greenhouse, Oracle, or any employer-specific ATS score.