### PR TITLE
fix: disable legacy global public brag endpoints

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -39,7 +39,7 @@ from app.promotion_packet_routes import router as promotion_packet_router
 from app.public_slug_routes import router as public_slug_router
 from app.reports_routes import router as reports_router
 from app.resume_builder_routes import router as resume_builder_router
-from app.routes import public_router, router as entries_router
+from app.routes import router as entries_router
 
 app = FastAPI(title="BragStack API", description="Evidence-backed career proof for accomplishments, impact, and reports.", version="1.0.0")
 frontend_url = os.getenv("FRONTEND_URL", "http://localhost:5173").rstrip("/")
@@ -105,7 +105,6 @@ app.include_router(oauth_router)
 app.include_router(profile_media_router)
 app.include_router(billing_router)
 app.include_router(entries_router, dependencies=[Depends(enforce_entry_usage)])
-app.include_router(public_router)
 app.include_router(public_slug_router)
 app.include_router(impact_receipts_router, dependencies=[Depends(enforce_receipt_usage)])
 app.include_router(receipt_verification_router)

--- a/backend/tests/test_public_routes.py
+++ b/backend/tests/test_public_routes.py
@@ -37,18 +37,20 @@ def test_root_returns_health_message():
     assert response.json() == {"message": "BragStack API is running"}
 
 
-def test_public_brag_route_returns_public_payload():
-    """Verify the public brag route returns a public entries response."""
-    response = client.get("/public/brag")
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/public/brag",
+        "/public/brag/reports/weekly",
+        "/public/brag/tags/summary",
+        "/public/brag/categories/summary",
+    ],
+)
+def test_legacy_global_public_brag_routes_are_unavailable(path):
+    """Legacy aggregate public routes must not expose cross-user public data."""
+    response = client.get(path)
 
-    assert response.status_code == 200
-
-    data = response.json()
-
-    assert "total_entries" in data
-    assert "entries" in data
-    assert "message" in data
-    assert isinstance(data["entries"], list)
+    assert response.status_code == 404
 
 
 def test_public_brag_slug_route_returns_only_that_users_public_entries():


### PR DESCRIPTION
Closes #182

## What changed
- Stop registering the legacy global `public_router` from `app.routes`.
- Preserve the slug-scoped public Proof Profile router.
- Add regression coverage proving the four aggregate global endpoints now return 404 while slug-scoped routes continue to work.

## Privacy rationale
Public proof should be intentionally scoped to a user's public slug, not exposed through a cross-user aggregate feed.

## Merge gate
Do not merge unless Backend CI, Frontend CI, and Security CI are green on the current head and there are no unresolved blocker findings.