### PR TITLE
fix: reclassify skill-only Technical Projects as Skills

### DIFF
--- a/backend/app/resume_import_parser.py
+++ b/backend/app/resume_import_parser.py
@@ -44,6 +44,14 @@ DATE_RANGE_RE = re.compile(
 )
 SIMPLE_DATE_RANGE_RE = re.compile(r"\b(?:19|20)\d{2}\s*[-–—]\s*(?:(?:19|20)\d{2}|present|current)\b", re.I)
 SEPARATOR_RE = re.compile(r"\s*(?:[|·•]|\s+[–—]\s+|\s+-\s+)\s*")
+SKILL_LABELS = {
+    "languages", "frameworks", "libraries", "tools", "platforms", "databases", "cloud", "operating systems"
+}
+PROJECT_SIGNAL_RE = re.compile(
+    r"\b(?:app|application|website|web site|site|api|service|dashboard|bot|cli|pipeline|system|portfolio|"
+    r"repository|repo|project|tracker|tooling|extension|plugin|integration|automation)\b",
+    re.I,
+)
 
 
 def _clean(value: str) -> str:
@@ -379,6 +387,30 @@ def _structured_experience_lines(entries: list[dict]) -> list[str]:
     return out
 
 
+def _projects_are_skill_only(lines: list[str]) -> bool:
+    """Return True only when a projects section is clearly mislabeled skills."""
+    cleaned = [_clean(line) for line in lines if _clean(line)]
+    if not cleaned:
+        return False
+
+    label_count = 0
+    value_count = 0
+    for line in cleaned:
+        normalized = line.strip(" :|").lower()
+        if normalized in SKILL_LABELS:
+            label_count += 1
+            continue
+        if BULLET_RE.match(line) or _date_match(line):
+            return False
+        if PROJECT_SIGNAL_RE.search(line):
+            return False
+        if re.search(r"[.!?]$", line) or len(line.split()) > 12:
+            return False
+        value_count += 1
+
+    return label_count > 0 and value_count > 0
+
+
 def parse_existing_resume_text(raw_text: str) -> dict:
     lines = _repair(raw_text)
     sections = {key: [] for key in SECTION_KEYS}
@@ -394,6 +426,10 @@ def parse_existing_resume_text(raw_text: str) -> dict:
         else:
             sections[current].append(line)
 
+    if _projects_are_skill_only(sections["projects"]):
+        sections["skills"].extend(sections["projects"])
+        sections["projects"] = []
+
     skill_lines = sections["skills"]
     compact_skills: list[str] = []
     pending_label = ""
@@ -403,7 +439,7 @@ def parse_existing_resume_text(raw_text: str) -> dict:
         if (
             _looks_short_label(line)
             and not any(ch in line for ch in ",;|")
-            and line.lower() in {"languages", "frameworks", "libraries", "tools", "platforms", "databases", "cloud", "operating systems"}
+            and line.lower() in SKILL_LABELS
         ):
             pending_label = line
             continue

--- a/backend/tests/test_resume_import_parser.py
+++ b/backend/tests/test_resume_import_parser.py
@@ -169,3 +169,50 @@ State University
     assert parsed["experience"][0]["company"] == "Acme Cloud"
     assert "experience" in parsed["sections_found"]
     assert any("inferred" in warning.lower() for warning in parsed["parse_warnings"])
+
+
+def test_skill_only_technical_projects_is_reclassified_as_skills():
+    raw = """Jane Doe
+jane@example.com
+TECHNICAL PROJECTS
+Languages
+Python, JavaScript
+Frameworks
+React
+Tools
+Jira, Git
+EXPERIENCE
+Acme Cloud | Support Engineer
+Jan 2024 - Present
+• Supported production services for enterprise customers.
+"""
+    parsed = parse_existing_resume_text(raw)
+
+    assert "skills" in parsed["sections_found"]
+    assert "projects" not in parsed["sections_found"]
+    assert parsed["sections"]["skills"] == [
+        "Languages | Python, JavaScript",
+        "Frameworks | React",
+        "Tools | Jira, Git",
+    ]
+    assert {"Python", "JavaScript", "React", "Jira", "Git"}.issubset(set(parsed["skills"]))
+    assert not {"Languages", "Frameworks", "Tools"}.intersection(parsed["skills"])
+
+
+def test_legitimate_technical_projects_remains_projects():
+    raw = """Jane Doe
+jane@example.com
+TECHNICAL PROJECTS
+Incident Tracker
+React, FastAPI, PostgreSQL
+• Built a dashboard and API that tracks production incidents and ownership.
+EXPERIENCE
+Acme Cloud | Support Engineer
+Jan 2024 - Present
+• Supported production services for enterprise customers.
+"""
+    parsed = parse_existing_resume_text(raw)
+
+    assert "projects" in parsed["sections_found"]
+    assert "Incident Tracker" in parsed["sections"]["projects"]
+    assert any(line.startswith("• Built a dashboard") for line in parsed["sections"]["projects"])


### PR DESCRIPTION
Closes #152

## What changed
- Detect `TECHNICAL PROJECTS` sections that are clearly skill labels/values rather than actual project evidence.
- Reclassify only those conservative cases into Skills before normal skill compaction.
- Preserve real project sections when they contain project signals, dates, bullets, or descriptive prose.
- Reuse the existing skill-label vocabulary instead of inventing a second classification model.

## Regression coverage
- Skill-only Technical Projects with Languages / Frameworks / Tools becomes Skills.
- Legitimate Incident Tracker + dashboard/API project remains Projects.
- Existing fragmented Technical Projects fixture remains covered.

## Merge gate
Do not merge unless all applicable CI checks are green on the current head, there are no unresolved blocker findings, and the branch is based on current `main`.