### PR TITLE
fix: stabilize click audit during page navigation

### DIFF
--- a/frontend/scripts/audit-all-clicks.mjs
+++ b/frontend/scripts/audit-all-clicks.mjs
@@ -128,10 +128,35 @@ class CDP {
   close() { this.ws.close(); }
 }
 
-async function evaluate(cdp, expression) {
-  const result = await cdp.send("Runtime.evaluate", { expression, awaitPromise: true, returnByValue: true, userGesture: true });
-  if (result.exceptionDetails) throw new Error(result.exceptionDetails.text || "Runtime evaluation failed");
-  return result.result?.value;
+function isTransientNavigationError(error) {
+  const message = String(error?.message || error || "");
+  return [
+    "Not attached to an active page",
+    "Execution context was destroyed",
+    "Cannot find context with specified id",
+    "Inspected target navigated or closed",
+  ].some((fragment) => message.includes(fragment));
+}
+
+async function evaluate(cdp, expression, timeoutMs = 5000) {
+  const started = Date.now();
+  let lastError;
+  while (Date.now() - started < timeoutMs) {
+    try {
+      const result = await cdp.send("Runtime.evaluate", { expression, awaitPromise: true, returnByValue: true, userGesture: true });
+      if (result.exceptionDetails) throw new Error(result.exceptionDetails.text || "Runtime evaluation failed");
+      return result.result?.value;
+    } catch (error) {
+      if (!isTransientNavigationError(error)) throw error;
+      lastError = error;
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+  }
+  throw lastError || new Error(`Timed out waiting for an active page after ${timeoutMs}ms`);
+}
+
+async function waitForPageReady(cdp, timeoutMs = 5000) {
+  await waitFor(async () => evaluate(cdp, 'document.readyState !== "loading"', 750), timeoutMs);
 }
 
 async function navigate(cdp, route, authenticated) {
@@ -202,7 +227,8 @@ async function clickControl(cdp, control) {
   await cdp.send("Input.dispatchMouseEvent", { type: "mouseMoved", x: point.x, y: point.y });
   await cdp.send("Input.dispatchMouseEvent", { type: "mousePressed", x: point.x, y: point.y, button: "left", clickCount: 1 });
   await cdp.send("Input.dispatchMouseEvent", { type: "mouseReleased", x: point.x, y: point.y, button: "left", clickCount: 1 });
-  await new Promise((resolve) => setTimeout(resolve, 250));
+  await new Promise((resolve) => setTimeout(resolve, 100));
+  await waitForPageReady(cdp);
 }
 
 async function exerciseControl(cdp, route, authenticated, control, initialSemanticIdentities) {


### PR DESCRIPTION
## What changed
- Retry only known transient Chrome DevTools navigation/detach errors during runtime evaluation.
- Wait for the destination document to leave the loading state after a real mouse click before continuing assertions.
- Keep real JavaScript/runtime errors fatal so the audit does not become permissive.

## Why
Frontend CI on current `main` fails while exercising `/app/intelligence` → `View Impact Receipts` with `Not attached to an active page`. The link is valid; the CDP harness races cross-document navigation and evaluates during the brief target-detach window.

## Merge gate
Do not merge unless Frontend CI is green on this exact head, and Backend/Security CI remain green.