### PR TITLE
fix: stabilize Aisha interview audio, microphone, and avatar

### DIFF
--- a/frontend/src/AnimatedInterviewerAvatar.jsx
+++ b/frontend/src/AnimatedInterviewerAvatar.jsx
@@ -3,7 +3,7 @@ import aishaJordanPhoto from "./assets/aisha-jordan-interviewer.jpg";
 const STATE_COPY = {
   idle: "Ready when you are",
   speaking: "Aisha is speaking",
-  listening: "Listening to you",
+  listening: "Your turn — listening",
   thinking: "Reviewing your answer",
   encouraging: "Follow-up coaching",
 };
@@ -26,9 +26,9 @@ const AVATAR_STYLES = `
   display: block;
   object-fit: cover;
   object-position: center 28%;
-  transform: scale(1.04);
-  transform-origin: 50% 45%;
-  will-change: transform, filter;
+  transform: none;
+  filter: none;
+  image-rendering: auto;
   user-select: none;
   pointer-events: none;
 }
@@ -38,8 +38,34 @@ const AVATAR_STYLES = `
   z-index: 2;
   pointer-events: none;
   background:
-    linear-gradient(180deg, rgba(4,8,18,.02) 45%, rgba(4,8,18,.78) 100%),
-    radial-gradient(circle at 50% 38%, transparent 48%, rgba(4,8,18,.2) 100%);
+    linear-gradient(180deg, rgba(4,8,18,.01) 48%, rgba(4,8,18,.76) 100%),
+    radial-gradient(circle at 50% 38%, transparent 52%, rgba(4,8,18,.16) 100%);
+}
+.aisha-avatar-shell::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: 3;
+  pointer-events: none;
+  border: 1px solid rgba(255,255,255,.08);
+  box-shadow: inset 0 0 0 1px rgba(165,180,252,.04);
+  transition: box-shadow .2s ease, border-color .2s ease;
+}
+.aisha-avatar-shell.state-speaking::after {
+  border-color: rgba(196,181,253,.24);
+  box-shadow: inset 0 0 34px rgba(139,92,246,.08);
+}
+.aisha-avatar-shell.state-listening::after {
+  border-color: rgba(110,231,183,.28);
+  box-shadow: inset 0 0 34px rgba(16,185,129,.08);
+}
+.aisha-avatar-shell.state-thinking::after {
+  border-color: rgba(252,211,77,.22);
+  box-shadow: inset 0 0 30px rgba(245,158,11,.06);
+}
+.aisha-avatar-shell.state-encouraging::after {
+  border-color: rgba(249,168,212,.22);
+  box-shadow: inset 0 0 30px rgba(236,72,153,.06);
 }
 .avatar-state-pill {
   position: absolute;
@@ -54,7 +80,7 @@ const AVATAR_STYLES = `
   border: 1px solid rgba(255,255,255,.16);
   border-radius: 999px;
   color: #eef2ff;
-  background: rgba(7,16,31,.72);
+  background: rgba(7,16,31,.78);
   backdrop-filter: blur(9px);
   font-size: clamp(.72rem, 1.7vw, .82rem);
   line-height: 1;
@@ -68,21 +94,8 @@ const AVATAR_STYLES = `
   background: #a5b4fc;
   box-shadow: 0 0 0 4px rgba(165,180,252,.12);
 }
-.aisha-avatar-shell.state-speaking .aisha-photo-avatar {
-  animation: aishaSpeaking 1.6s ease-in-out infinite;
-}
-.aisha-avatar-shell.state-listening .aisha-photo-avatar {
-  animation: aishaListening 2.6s ease-in-out infinite;
-}
-.aisha-avatar-shell.state-thinking .aisha-photo-avatar {
-  animation: aishaThinking 2.2s ease-in-out infinite;
-  filter: saturate(.96) brightness(.96);
-}
-.aisha-avatar-shell.state-encouraging .aisha-photo-avatar {
-  animation: aishaEncouraging 1.9s ease-in-out infinite;
-}
 .aisha-avatar-shell.state-speaking .avatar-state-dot {
-  animation: aishaPulse .85s ease-in-out infinite;
+  animation: aishaPulse .9s ease-in-out infinite;
   background: #c4b5fd;
 }
 .aisha-avatar-shell.state-listening .avatar-state-dot {
@@ -92,23 +105,6 @@ const AVATAR_STYLES = `
 }
 .aisha-avatar-shell.state-thinking .avatar-state-dot { background: #fcd34d; }
 .aisha-avatar-shell.state-encouraging .avatar-state-dot { background: #f9a8d4; }
-@keyframes aishaSpeaking {
-  0%,100% { transform: scale(1.045) translate3d(0,0,0) rotate(0deg); }
-  30% { transform: scale(1.065) translate3d(.25%, -.35%, 0) rotate(.18deg); }
-  60% { transform: scale(1.055) translate3d(-.2%, .2%, 0) rotate(-.14deg); }
-}
-@keyframes aishaListening {
-  0%,100% { transform: scale(1.045) translate3d(0,0,0); }
-  50% { transform: scale(1.06) translate3d(-.35%, -.25%, 0); }
-}
-@keyframes aishaThinking {
-  0%,100% { transform: scale(1.045) translate3d(0,0,0); }
-  50% { transform: scale(1.055) translate3d(.45%, -.15%, 0); }
-}
-@keyframes aishaEncouraging {
-  0%,100% { transform: scale(1.045) translate3d(0,0,0) rotate(0deg); }
-  50% { transform: scale(1.065) translate3d(0,-.35%,0) rotate(.22deg); }
-}
 @keyframes aishaPulse {
   0%,100% { transform: scale(.9); opacity: .78; }
   50% { transform: scale(1.22); opacity: 1; }
@@ -117,13 +113,15 @@ const AVATAR_STYLES = `
   .aisha-photo-avatar { object-position: center 25%; }
 }
 @media (max-width: 620px) {
-  .aisha-photo-avatar { object-position: center 22%; transform: scale(1.08); }
+  .aisha-photo-avatar { object-position: center 22%; }
   .avatar-state-pill { left: 10px; top: 10px; max-width: calc(100% - 20px); padding: 7px 9px; }
 }
 @media (prefers-reduced-motion: reduce) {
-  .aisha-avatar-shell .aisha-photo-avatar,
   .aisha-avatar-shell .avatar-state-dot {
     animation: none !important;
+    transition: none !important;
+  }
+  .aisha-avatar-shell::after {
     transition: none !important;
   }
 }
@@ -132,12 +130,12 @@ const AVATAR_STYLES = `
 export default function AnimatedInterviewerAvatar({ state = "idle", name = "Aisha Jordan" }) {
   const safeState = STATE_COPY[state] ? state : "idle";
   return (
-    <div className={`aisha-avatar-shell state-${safeState}`} data-aisha-state={safeState} data-avatar-engine="bragstack-photo-v2">
+    <div className={`aisha-avatar-shell state-${safeState}`} data-aisha-state={safeState} data-avatar-engine="bragstack-photo-v3-stable">
       <style>{AVATAR_STYLES}</style>
       <img className="aisha-photo-avatar" src={aishaJordanPhoto} alt={`${name}, BragStack virtual interviewer`} draggable="false" />
       <div className="aisha-photo-vignette" aria-hidden="true" />
       <div className={`avatar-state-pill state-${safeState}`} aria-live="polite">
-        <span className="avatar-state-dot" />
+        <span className="avatar-state-dot" aria-hidden="true" />
         <strong>{STATE_COPY[safeState]}</strong>
       </div>
     </div>

--- a/frontend/src/AnimatedInterviewerAvatar.jsx
+++ b/frontend/src/AnimatedInterviewerAvatar.jsx
@@ -130,7 +130,7 @@ const AVATAR_STYLES = `
 export default function AnimatedInterviewerAvatar({ state = "idle", name = "Aisha Jordan" }) {
   const safeState = STATE_COPY[state] ? state : "idle";
   return (
-    <div className={`aisha-avatar-shell state-${safeState}`} data-aisha-state={safeState} data-avatar-engine="bragstack-photo-v3-stable">
+    <div className={`aisha-avatar-shell state-${safeState}`} data-aisha-state={safeState} data-avatar-engine="bragstack-photo-v2">
       <style>{AVATAR_STYLES}</style>
       <img className="aisha-photo-avatar" src={aishaJordanPhoto} alt={`${name}, BragStack virtual interviewer`} draggable="false" />
       <div className="aisha-photo-vignette" aria-hidden="true" />

--- a/frontend/src/interviewBrowserPreflight.js
+++ b/frontend/src/interviewBrowserPreflight.js
@@ -15,12 +15,14 @@ function stopStream(stream) {
   }
 }
 
-export function primeInterviewBrowserAudio({ navigatorObject, speechSynthesisObject } = {}) {
+export function primeInterviewBrowserAudio({ navigatorObject, speechSynthesisObject, speechRecognitionAvailable = true } = {}) {
   try {
     speechSynthesisObject?.resume?.();
   } catch {
     // The interview page already owns spoken-audio fallback messaging.
   }
+
+  if (!speechRecognitionAvailable) return Promise.resolve(false);
 
   const getUserMedia = navigatorObject?.mediaDevices?.getUserMedia;
   if (typeof getUserMedia !== "function") return Promise.resolve(false);
@@ -49,12 +51,13 @@ export function installInterviewBrowserPreflight({
   documentObject = typeof document !== "undefined" ? document : null,
   navigatorObject = typeof navigator !== "undefined" ? navigator : null,
   speechSynthesisObject = typeof window !== "undefined" ? window.speechSynthesis : null,
+  speechRecognitionAvailable = typeof window !== "undefined" && Boolean(window.SpeechRecognition || window.webkitSpeechRecognition),
 } = {}) {
   if (!documentObject?.addEventListener || installed) return () => {};
 
   const handleStartGesture = (event) => {
     if (!isInterviewStartClick(event?.target)) return;
-    void primeInterviewBrowserAudio({ navigatorObject, speechSynthesisObject });
+    void primeInterviewBrowserAudio({ navigatorObject, speechSynthesisObject, speechRecognitionAvailable });
   };
 
   documentObject.addEventListener("click", handleStartGesture, true);

--- a/frontend/src/interviewBrowserPreflight.js
+++ b/frontend/src/interviewBrowserPreflight.js
@@ -1,10 +1,11 @@
-const START_BUTTON_SELECTOR = "form.interview-setup-card .start-interview-button";
+const START_FORM_SELECTOR = "form.interview-setup-card";
 
 let installed = false;
 let microphonePreflightPromise = null;
 
-function isInterviewStartClick(target) {
-  return Boolean(target?.closest?.(START_BUTTON_SELECTOR));
+function isInterviewStartSubmit(target) {
+  if (target?.matches?.(START_FORM_SELECTOR)) return true;
+  return Boolean(target?.closest?.(START_FORM_SELECTOR));
 }
 
 function stopStream(stream) {
@@ -56,15 +57,15 @@ export function installInterviewBrowserPreflight({
   if (!documentObject?.addEventListener || installed) return () => {};
 
   const handleStartGesture = (event) => {
-    if (!isInterviewStartClick(event?.target)) return;
+    if (!isInterviewStartSubmit(event?.target)) return;
     void primeInterviewBrowserAudio({ navigatorObject, speechSynthesisObject, speechRecognitionAvailable });
   };
 
-  documentObject.addEventListener("click", handleStartGesture, true);
+  documentObject.addEventListener("submit", handleStartGesture, true);
   installed = true;
 
   return () => {
-    documentObject.removeEventListener?.("click", handleStartGesture, true);
+    documentObject.removeEventListener?.("submit", handleStartGesture, true);
     installed = false;
   };
 }

--- a/frontend/src/interviewBrowserPreflight.js
+++ b/frontend/src/interviewBrowserPreflight.js
@@ -26,16 +26,20 @@ export function primeInterviewBrowserAudio({ navigatorObject, speechSynthesisObj
   if (typeof getUserMedia !== "function") return Promise.resolve(false);
 
   if (!microphonePreflightPromise) {
-    microphonePreflightPromise = Promise.resolve()
-      .then(() => getUserMedia.call(navigatorObject.mediaDevices, { audio: true, video: false }))
-      .then((stream) => {
-        stopStream(stream);
-        return true;
-      })
-      .catch(() => false)
-      .finally(() => {
-        microphonePreflightPromise = null;
-      });
+    try {
+      const request = getUserMedia.call(navigatorObject.mediaDevices, { audio: true, video: false });
+      microphonePreflightPromise = Promise.resolve(request)
+        .then((stream) => {
+          stopStream(stream);
+          return true;
+        })
+        .catch(() => false)
+        .finally(() => {
+          microphonePreflightPromise = null;
+        });
+    } catch {
+      return Promise.resolve(false);
+    }
   }
 
   return microphonePreflightPromise;

--- a/frontend/src/interviewBrowserPreflight.js
+++ b/frontend/src/interviewBrowserPreflight.js
@@ -1,0 +1,68 @@
+const START_BUTTON_SELECTOR = "form.interview-setup-card .start-interview-button";
+
+let installed = false;
+let microphonePreflightPromise = null;
+
+function isInterviewStartClick(target) {
+  return Boolean(target?.closest?.(START_BUTTON_SELECTOR));
+}
+
+function stopStream(stream) {
+  try {
+    stream?.getTracks?.().forEach((track) => track.stop?.());
+  } catch {
+    // Permission priming must never block the interview.
+  }
+}
+
+export function primeInterviewBrowserAudio({ navigatorObject, speechSynthesisObject } = {}) {
+  try {
+    speechSynthesisObject?.resume?.();
+  } catch {
+    // The interview page already owns spoken-audio fallback messaging.
+  }
+
+  const getUserMedia = navigatorObject?.mediaDevices?.getUserMedia;
+  if (typeof getUserMedia !== "function") return Promise.resolve(false);
+
+  if (!microphonePreflightPromise) {
+    microphonePreflightPromise = Promise.resolve()
+      .then(() => getUserMedia.call(navigatorObject.mediaDevices, { audio: true, video: false }))
+      .then((stream) => {
+        stopStream(stream);
+        return true;
+      })
+      .catch(() => false)
+      .finally(() => {
+        microphonePreflightPromise = null;
+      });
+  }
+
+  return microphonePreflightPromise;
+}
+
+export function installInterviewBrowserPreflight({
+  documentObject = typeof document !== "undefined" ? document : null,
+  navigatorObject = typeof navigator !== "undefined" ? navigator : null,
+  speechSynthesisObject = typeof window !== "undefined" ? window.speechSynthesis : null,
+} = {}) {
+  if (!documentObject?.addEventListener || installed) return () => {};
+
+  const handleStartGesture = (event) => {
+    if (!isInterviewStartClick(event?.target)) return;
+    void primeInterviewBrowserAudio({ navigatorObject, speechSynthesisObject });
+  };
+
+  documentObject.addEventListener("click", handleStartGesture, true);
+  installed = true;
+
+  return () => {
+    documentObject.removeEventListener?.("click", handleStartGesture, true);
+    installed = false;
+  };
+}
+
+export function __resetInterviewBrowserPreflightForTests() {
+  installed = false;
+  microphonePreflightPromise = null;
+}

--- a/frontend/src/interviewEngineBrowserPreflight.test.js
+++ b/frontend/src/interviewEngineBrowserPreflight.test.js
@@ -23,6 +23,7 @@ test("primes speech and microphone, then releases the temporary stream", async (
       },
     },
     speechSynthesisObject: { resume: () => { resumed += 1; } },
+    speechRecognitionAvailable: true,
   });
 
   assert.equal(allowed, true);
@@ -55,6 +56,7 @@ test("starts the microphone preflight from the interview start click", async () 
       },
     },
     speechSynthesisObject: { resume: () => {} },
+    speechRecognitionAvailable: true,
   });
 
   assert.equal(typeof clickHandler, "function");
@@ -62,6 +64,29 @@ test("starts the microphone preflight from the interview start click", async () 
   await new Promise((resolve) => setTimeout(resolve, 0));
   assert.equal(requested, 1);
   cleanup();
+});
+
+test("does not ask for microphone access when speech recognition is unavailable", async () => {
+  __resetInterviewBrowserPreflightForTests();
+  let requested = 0;
+  let resumed = 0;
+
+  const allowed = await primeInterviewBrowserAudio({
+    navigatorObject: {
+      mediaDevices: {
+        getUserMedia: async () => {
+          requested += 1;
+          return { getTracks: () => [] };
+        },
+      },
+    },
+    speechSynthesisObject: { resume: () => { resumed += 1; } },
+    speechRecognitionAvailable: false,
+  });
+
+  assert.equal(allowed, false);
+  assert.equal(resumed, 1);
+  assert.equal(requested, 0);
 });
 
 test("ignores unrelated clicks", async () => {
@@ -82,6 +107,7 @@ test("ignores unrelated clicks", async () => {
         },
       },
     },
+    speechRecognitionAvailable: true,
   });
 
   clickHandler({ target: { closest: () => null } });

--- a/frontend/src/interviewEngineBrowserPreflight.test.js
+++ b/frontend/src/interviewEngineBrowserPreflight.test.js
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  __resetInterviewBrowserPreflightForTests,
+  installInterviewBrowserPreflight,
+  primeInterviewBrowserAudio,
+} from "./interviewBrowserPreflight.js";
+
+test("primes speech and microphone, then releases the temporary stream", async () => {
+  __resetInterviewBrowserPreflightForTests();
+  let resumed = 0;
+  let requestedConstraints = null;
+  let stopped = 0;
+
+  const allowed = await primeInterviewBrowserAudio({
+    navigatorObject: {
+      mediaDevices: {
+        getUserMedia: async (constraints) => {
+          requestedConstraints = constraints;
+          return { getTracks: () => [{ stop: () => { stopped += 1; } }] };
+        },
+      },
+    },
+    speechSynthesisObject: { resume: () => { resumed += 1; } },
+  });
+
+  assert.equal(allowed, true);
+  assert.equal(resumed, 1);
+  assert.deepEqual(requestedConstraints, { audio: true, video: false });
+  assert.equal(stopped, 1);
+});
+
+test("starts the microphone preflight from the interview start click", async () => {
+  __resetInterviewBrowserPreflightForTests();
+  let clickHandler = null;
+  let requested = 0;
+  const documentObject = {
+    addEventListener: (name, handler, capture) => {
+      assert.equal(name, "click");
+      assert.equal(capture, true);
+      clickHandler = handler;
+    },
+    removeEventListener: () => {},
+  };
+
+  const cleanup = installInterviewBrowserPreflight({
+    documentObject,
+    navigatorObject: {
+      mediaDevices: {
+        getUserMedia: async () => {
+          requested += 1;
+          return { getTracks: () => [] };
+        },
+      },
+    },
+    speechSynthesisObject: { resume: () => {} },
+  });
+
+  assert.equal(typeof clickHandler, "function");
+  clickHandler({ target: { closest: () => ({}) } });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.equal(requested, 1);
+  cleanup();
+});
+
+test("ignores unrelated clicks", async () => {
+  __resetInterviewBrowserPreflightForTests();
+  let clickHandler = null;
+  let requested = 0;
+
+  installInterviewBrowserPreflight({
+    documentObject: {
+      addEventListener: (_name, handler) => { clickHandler = handler; },
+      removeEventListener: () => {},
+    },
+    navigatorObject: {
+      mediaDevices: {
+        getUserMedia: async () => {
+          requested += 1;
+          return { getTracks: () => [] };
+        },
+      },
+    },
+  });
+
+  clickHandler({ target: { closest: () => null } });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.equal(requested, 0);
+});

--- a/frontend/src/interviewEngineBrowserPreflight.test.js
+++ b/frontend/src/interviewEngineBrowserPreflight.test.js
@@ -32,15 +32,15 @@ test("primes speech and microphone, then releases the temporary stream", async (
   assert.equal(stopped, 1);
 });
 
-test("starts the microphone preflight from the interview start click", async () => {
+test("starts the microphone preflight from the validated interview submit", async () => {
   __resetInterviewBrowserPreflightForTests();
-  let clickHandler = null;
+  let submitHandler = null;
   let requested = 0;
   const documentObject = {
     addEventListener: (name, handler, capture) => {
-      assert.equal(name, "click");
+      assert.equal(name, "submit");
       assert.equal(capture, true);
-      clickHandler = handler;
+      submitHandler = handler;
     },
     removeEventListener: () => {},
   };
@@ -59,8 +59,8 @@ test("starts the microphone preflight from the interview start click", async () 
     speechRecognitionAvailable: true,
   });
 
-  assert.equal(typeof clickHandler, "function");
-  clickHandler({ target: { closest: () => ({}) } });
+  assert.equal(typeof submitHandler, "function");
+  submitHandler({ target: { matches: () => true } });
   await new Promise((resolve) => setTimeout(resolve, 0));
   assert.equal(requested, 1);
   cleanup();
@@ -89,14 +89,14 @@ test("does not ask for microphone access when speech recognition is unavailable"
   assert.equal(requested, 0);
 });
 
-test("ignores unrelated clicks", async () => {
+test("ignores unrelated form submits", async () => {
   __resetInterviewBrowserPreflightForTests();
-  let clickHandler = null;
+  let submitHandler = null;
   let requested = 0;
 
   installInterviewBrowserPreflight({
     documentObject: {
-      addEventListener: (_name, handler) => { clickHandler = handler; },
+      addEventListener: (_name, handler) => { submitHandler = handler; },
       removeEventListener: () => {},
     },
     navigatorObject: {
@@ -110,7 +110,7 @@ test("ignores unrelated clicks", async () => {
     speechRecognitionAvailable: true,
   });
 
-  clickHandler({ target: { closest: () => null } });
+  submitHandler({ target: { matches: () => false, closest: () => null } });
   await new Promise((resolve) => setTimeout(resolve, 0));
   assert.equal(requested, 0);
 });

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -5,6 +5,9 @@ import "./index.css";
 import "./ReferencePolish.css";
 import "./MarketingFooterOrder.css";
 import RootContent from "./RootContent.jsx";
+import { installInterviewBrowserPreflight } from "./interviewBrowserPreflight.js";
+
+installInterviewBrowserPreflight();
 
 createRoot(document.getElementById("root")).render(
   <StrictMode>


### PR DESCRIPTION
## What changed
- primes speech synthesis and microphone permission directly from the **Start practice interview** user gesture on all supported browsers
- releases the temporary microphone stream immediately after permission is established
- keeps the interview page's existing typed-answer and microphone-error fallbacks intact
- removes the fake zoom/pan/rotate animation from Aisha's JPG so she stays sharp instead of bobbing/blurring
- keeps lightweight state feedback through the status pill, border treatment, and dot animation only
- adds Node coverage for the browser preflight behavior

## Why
Aisha currently waits until after a long spoken intro before starting speech recognition. On some browsers, that is too late to reliably establish microphone access because the original user gesture has ended. The current avatar also continuously transforms a raster image, which makes the interviewer look soft and unnatural.

## Cost
**$0 recurring cost.** No new dependencies, avatar SaaS, API credits, or hosted speech provider.

## Follow-up
A full explicit interview state-machine refactor can be done separately after this reliability patch is proven, without coupling it to a paid avatar platform.