### PR TITLE
ci: make required Frontend check report on every PR

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -2,9 +2,6 @@ name: Frontend CI
 
 on:
   pull_request:
-    paths:
-      - "frontend/**"
-      - ".github/workflows/frontend-ci.yml"
   push:
     branches:
       - main
@@ -24,8 +21,33 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect frontend-relevant pull request changes
+        if: github.event_name == 'pull_request'
+        id: changes
+        working-directory: .
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          changed_files="$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")"
+          printf '%s\n' "$changed_files"
+
+          if printf '%s\n' "$changed_files" | grep -Eq '^(frontend/|\.github/workflows/frontend-ci\.yml$)'; then
+            echo "run_frontend=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run_frontend=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: No frontend validation needed
+        if: github.event_name == 'pull_request' && steps.changes.outputs.run_frontend != 'true'
+        working-directory: .
+        run: echo "No frontend or Frontend CI workflow files changed; required Frontend CI check passes without running the expensive browser/build suite."
 
       - name: Set up Node
+        if: github.event_name != 'pull_request' || steps.changes.outputs.run_frontend == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: 22
@@ -33,31 +55,41 @@ jobs:
           cache-dependency-path: frontend/package-lock.json
 
       - name: Install dependencies
+        if: github.event_name != 'pull_request' || steps.changes.outputs.run_frontend == 'true'
         run: npm ci
 
       - name: Verify Aisha source and real-browser render
+        if: github.event_name != 'pull_request' || steps.changes.outputs.run_frontend == 'true'
         run: node scripts/verify-aisha-source.mjs
 
       - name: Test interview intelligence engine
+        if: github.event_name != 'pull_request' || steps.changes.outputs.run_frontend == 'true'
         run: npm run test:interview
 
       - name: Test structured resume helpers
+        if: github.event_name != 'pull_request' || steps.changes.outputs.run_frontend == 'true'
         run: npm run test:resume
 
       - name: Verify search appearance and sitelink signals
+        if: github.event_name != 'pull_request' || steps.changes.outputs.run_frontend == 'true'
         run: npm run test:seo
 
       - name: Audit every visible click path in real Chrome
+        if: github.event_name != 'pull_request' || steps.changes.outputs.run_frontend == 'true'
         run: npm run test:clicks
 
       - name: Lint
+        if: github.event_name != 'pull_request' || steps.changes.outputs.run_frontend == 'true'
         run: npm run lint
 
       - name: Build
+        if: github.event_name != 'pull_request' || steps.changes.outputs.run_frontend == 'true'
         run: npm run build
 
       - name: Enforce production bundle budgets
+        if: github.event_name != 'pull_request' || steps.changes.outputs.run_frontend == 'true'
         run: npm run test:bundle
 
       - name: Verify Aisha production bundle
+        if: github.event_name != 'pull_request' || steps.changes.outputs.run_frontend == 'true'
         run: node scripts/verify-aisha-build.mjs


### PR DESCRIPTION
## Problem
`Test, lint and build frontend` is now a globally required branch-protection check, but Frontend CI only triggers when frontend files change. Docs-only or backend-only PRs can therefore remain blocked waiting for a required check that never starts.

## Fix
- Trigger Frontend CI on every pull request so the required check always reports.
- Detect whether the PR actually changes `frontend/**` or the Frontend CI workflow itself.
- Run the full Node/browser/lint/build/bundle suite only for frontend-relevant PRs.
- For non-frontend PRs, complete the same required job successfully after a lightweight change-detection step.
- Keep `push` to `main` path-filtered so unnecessary post-merge frontend work is not added.

## Why this preserves protection
The globally required job still exists and reports on every PR. Frontend changes still run the full existing validation suite, including the real-Chrome click audit. Non-frontend changes no longer wait indefinitely or spend several minutes running irrelevant browser tests.

## Merge gate
Do not merge unless Backend, Frontend, and Security checks are green on this exact head, the branch is current with `main`, the PR is mergeable, and there are no unresolved blocker comments/reviews.