### PR TITLE
fix: move sensitive packet context out of URLs on current main

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,7 +21,15 @@ RATE_LIMIT_AUTH_CONFIRM=20
 RATE_LIMIT_OAUTH=30
 RATE_LIMIT_RECEIPT_VERIFICATION_SEND=10
 RATE_LIMIT_RECEIPT_VERIFICATION_PUBLIC=60
+RATE_LIMIT_PACKET_SHARE_ACCESS=10
 RATE_LIMIT_PUBLIC_PROFILE=180
+
+# Protected packet shares
+# Use a dedicated random secret in production. JWT_SECRET is the fallback signing key.
+PACKET_SHARE_GRANT_SECRET=replace-with-a-long-random-secret
+PACKET_SHARE_GRANT_TTL_SECONDS=3600
+# Keep true in production HTTPS. Set false only for local HTTP share testing.
+PACKET_SHARE_COOKIE_SECURE=true
 
 # Internal Ops Console
 OPS_COMPANY_DOMAIN=usebragstack.com

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -14,29 +14,20 @@ from app.oauth_routes import router as oauth_router
 from app.billing_routes import router as billing_router
 from app.beta_metrics_routes import router as beta_metrics_router
 from app.career_intelligence_routes import router as career_intelligence_router
-from app.certification_packet_export_routes import router as certification_packet_export_router
-from app.certification_packet_routes import router as certification_packet_router
 from app.core_output_routes import router as core_output_router
 from app.database import client as mongo_client, entries_collection, impact_receipts_collection
 from app.impact_receipt_routes import router as impact_receipts_router
 from app.receipt_verification_routes import router as receipt_verification_router
 from app.interview_catalog_routes import router as interview_catalog_router
-from app.interview_packet_export_routes import router as interview_packet_export_router
-from app.interview_packet_routes import router as interview_packet_router
 from app.observability import record_persistent_request
 from app.ops_debug import new_request_id, record_request
 from app.ops_routes import router as ops_router
 from app.ops_user_routes import router as ops_user_router
 from app.packet_audit_routes import router as packet_audit_router
-from app.packet_platform_export_routes import router as packet_platform_export_router
-from app.packet_platform_routes import router as packet_platform_router
-from app.packet_share_routes import router as packet_share_router
-from app.performance_packet_export_routes import router as performance_packet_export_router
-from app.performance_packet_routes import router as performance_packet_router
 from app.plans import enforce_usage_limit
+from app.private_packet_routes import router as private_packet_router
+from app.private_packet_share_routes import router as private_packet_share_router
 from app.profile_media_routes import router as profile_media_router
-from app.promotion_packet_export_routes import router as promotion_packet_export_router
-from app.promotion_packet_routes import router as promotion_packet_router
 from app.public_slug_routes import router as public_slug_router
 from app.rate_limit import check_rate_limit
 from app.reports_routes import router as reports_router
@@ -130,19 +121,10 @@ app.include_router(core_output_router)
 app.include_router(beta_metrics_router)
 app.include_router(career_intelligence_router)
 app.include_router(reports_router)
-app.include_router(performance_packet_router)
-app.include_router(performance_packet_export_router)
-app.include_router(packet_platform_router)
-app.include_router(packet_platform_export_router)
+app.include_router(private_packet_router)
 app.include_router(packet_audit_router)
-app.include_router(packet_share_router)
-app.include_router(promotion_packet_router)
-app.include_router(promotion_packet_export_router)
+app.include_router(private_packet_share_router)
 app.include_router(interview_catalog_router)
-app.include_router(interview_packet_router)
-app.include_router(interview_packet_export_router)
-app.include_router(certification_packet_router)
-app.include_router(certification_packet_export_router)
 app.include_router(resume_builder_router)
 app.include_router(ops_router)
 app.include_router(ops_user_router)

--- a/backend/app/packet_request_models.py
+++ b/backend/app/packet_request_models.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+from app.packet_platform import OPTIONAL_SECTIONS
+
+
+class BasePacketRequest(BaseModel):
+    start_date: str | None = None
+    end_date: str | None = None
+    career_area: str | None = Field(default=None, max_length=120)
+    role_title: str | None = Field(default=None, max_length=160)
+    organization: str | None = Field(default=None, max_length=180)
+    confidential: bool = True
+
+
+class PromotionPacketRequest(BasePacketRequest):
+    target_role: str | None = Field(default=None, max_length=160)
+    target_level: str | None = Field(default=None, max_length=120)
+
+
+class InterviewPacketRequest(BasePacketRequest):
+    selected_entry_ids: list[str] = Field(default_factory=list, max_length=8)
+    target_role: str | None = Field(default=None, max_length=160)
+    target_organization: str | None = Field(default=None, max_length=180)
+    include_evidence_references: bool = False
+
+
+class CertificationPacketRequest(BasePacketRequest):
+    credential_name: str | None = Field(default=None, max_length=180)
+    issuing_body: str | None = Field(default=None, max_length=180)
+    review_type: str | None = Field(default=None, max_length=120)
+    requirement_notes: str | None = Field(default=None, max_length=1200)
+
+
+class PlatformPacketRequest(BasePacketRequest):
+    signature_entry_ids: list[str] = Field(default_factory=list, max_length=8)
+    sections: list[str] | None = Field(default=None, max_length=len(OPTIONAL_SECTIONS))
+    packet_note: str | None = Field(default=None, max_length=1500)
+    item_notes: dict[str, str] = Field(default_factory=dict, max_length=20)
+    include_notes: bool = True
+    theme: str | None = Field(default="classic-dossier", max_length=40)
+    brand_name: str | None = Field(default=None, max_length=120)
+    department_label: str | None = Field(default=None, max_length=120)
+    reviewer_name: str | None = Field(default=None, max_length=120)
+    review_cycle_label: str | None = Field(default=None, max_length=120)
+
+    def normalized_sections(self) -> list[str] | None:
+        if self.sections is None:
+            return None
+        requested = set(self.sections)
+        return [section for section in OPTIONAL_SECTIONS if section in requested]

--- a/backend/app/private_packet_routes.py
+++ b/backend/app/private_packet_routes.py
@@ -1,0 +1,260 @@
+from __future__ import annotations
+
+import io
+
+from fastapi import APIRouter, Depends
+from fastapi.responses import StreamingResponse
+
+from app.auth import get_current_user
+from app.certification_packet_pdf import (
+    build_certification_packet_pdf,
+    make_certification_packet_filename,
+)
+from app.certification_packet_routes import _build_certification_packet
+from app.interview_packet_pdf import build_interview_packet_pdf, make_interview_packet_filename
+from app.interview_packet_routes import _build_interview_packet
+from app.packet_audit import record_packet_export
+from app.packet_platform_pdf import build_platform_packet_pdf, make_platform_packet_filename
+from app.packet_platform_routes import build_platform_packet
+from app.packet_request_models import (
+    BasePacketRequest,
+    CertificationPacketRequest,
+    InterviewPacketRequest,
+    PlatformPacketRequest,
+    PromotionPacketRequest,
+)
+from app.performance_packet_pdf import build_performance_packet_pdf, make_packet_filename
+from app.performance_packet_routes import _build_packet, _parse_period
+from app.plans import require_feature
+from app.promotion_packet_pdf import build_promotion_packet_pdf, make_promotion_packet_filename
+from app.promotion_packet_routes import _build_promotion_packet
+
+
+router = APIRouter(prefix="/packets", tags=["packets"])
+
+
+def _period(payload: BasePacketRequest):
+    return _parse_period(payload.start_date, payload.end_date)
+
+
+def _build_base(payload: BasePacketRequest, current_user: dict) -> dict:
+    start_date, end_date = _period(payload)
+    return _build_packet(
+        current_user=current_user,
+        start_date=start_date,
+        end_date=end_date,
+        career_area=payload.career_area,
+        role_title=payload.role_title,
+        organization=payload.organization,
+        confidential=payload.confidential,
+    )["packet"]
+
+
+def _build_platform(payload: PlatformPacketRequest, current_user: dict) -> dict:
+    start_date, end_date = _period(payload)
+    return build_platform_packet(
+        current_user=current_user,
+        start_date=start_date,
+        end_date=end_date,
+        career_area=payload.career_area,
+        role_title=payload.role_title,
+        organization=payload.organization,
+        confidential=payload.confidential,
+        signature_entry_ids=payload.signature_entry_ids,
+        sections=payload.normalized_sections(),
+        packet_note=payload.packet_note,
+        item_notes=payload.item_notes,
+        include_notes=payload.include_notes,
+        theme=payload.theme,
+        brand_name=payload.brand_name,
+        department_label=payload.department_label,
+        reviewer_name=payload.reviewer_name,
+        review_cycle_label=payload.review_cycle_label,
+    )
+
+
+def _build_promotion(payload: PromotionPacketRequest, current_user: dict) -> dict:
+    start_date, end_date = _period(payload)
+    return _build_promotion_packet(
+        current_user=current_user,
+        start_date=start_date,
+        end_date=end_date,
+        career_area=payload.career_area,
+        role_title=payload.role_title,
+        organization=payload.organization,
+        confidential=payload.confidential,
+        target_role=payload.target_role,
+        target_level=payload.target_level,
+    )["packet"]
+
+
+def _build_interview(payload: InterviewPacketRequest, current_user: dict) -> dict:
+    start_date, end_date = _period(payload)
+    return _build_interview_packet(
+        current_user=current_user,
+        start_date=start_date,
+        end_date=end_date,
+        career_area=payload.career_area,
+        role_title=payload.role_title,
+        organization=payload.organization,
+        confidential=payload.confidential,
+        selected_entry_ids=payload.selected_entry_ids,
+        target_role=payload.target_role,
+        target_organization=payload.target_organization,
+        include_evidence_references=payload.include_evidence_references,
+    )["packet"]
+
+
+def _build_certification(payload: CertificationPacketRequest, current_user: dict) -> dict:
+    start_date, end_date = _period(payload)
+    return _build_certification_packet(
+        current_user=current_user,
+        start_date=start_date,
+        end_date=end_date,
+        career_area=payload.career_area,
+        role_title=payload.role_title,
+        organization=payload.organization,
+        confidential=payload.confidential,
+        credential_name=payload.credential_name,
+        issuing_body=payload.issuing_body,
+        review_type=payload.review_type,
+        requirement_notes=payload.requirement_notes,
+    )["packet"]
+
+
+def _pdf_response(*, current_user: dict, packet: dict, pdf_bytes: bytes, filename: str):
+    record_packet_export(
+        user_id=str(current_user["_id"]),
+        packet=packet,
+        filename=filename,
+        pdf_bytes=pdf_bytes,
+    )
+    return StreamingResponse(
+        io.BytesIO(pdf_bytes),
+        media_type="application/pdf",
+        headers={
+            "Content-Disposition": f'attachment; filename="{filename}"',
+            "Cache-Control": "private, no-store",
+            "X-Content-Type-Options": "nosniff",
+        },
+    )
+
+
+@router.post("/performance-review")
+def create_performance_review_packet(
+    payload: BasePacketRequest,
+    current_user: dict = Depends(get_current_user),
+):
+    return {"packet": _build_base(payload, current_user)}
+
+
+@router.post("/performance-review-v12")
+def create_performance_review_packet_v12(
+    payload: PlatformPacketRequest,
+    current_user: dict = Depends(get_current_user),
+):
+    return {"packet": _build_platform(payload, current_user)}
+
+
+@router.post("/promotion")
+def create_promotion_packet(
+    payload: PromotionPacketRequest,
+    current_user: dict = Depends(get_current_user),
+):
+    return {"packet": _build_promotion(payload, current_user)}
+
+
+@router.post("/interview")
+def create_interview_packet(
+    payload: InterviewPacketRequest,
+    current_user: dict = Depends(get_current_user),
+):
+    return {"packet": _build_interview(payload, current_user)}
+
+
+@router.post("/certification")
+def create_certification_packet(
+    payload: CertificationPacketRequest,
+    current_user: dict = Depends(get_current_user),
+):
+    return {"packet": _build_certification(payload, current_user)}
+
+
+@router.post("/performance-review.pdf")
+def download_performance_review_packet_pdf(
+    payload: BasePacketRequest,
+    current_user: dict = Depends(get_current_user),
+):
+    require_feature(current_user, "export_pdf")
+    packet = _build_base(payload, current_user)
+    pdf_bytes = build_performance_packet_pdf(packet)
+    return _pdf_response(
+        current_user=current_user,
+        packet=packet,
+        pdf_bytes=pdf_bytes,
+        filename=make_packet_filename(packet),
+    )
+
+
+@router.post("/performance-review-v12.pdf")
+def download_performance_review_packet_v12_pdf(
+    payload: PlatformPacketRequest,
+    current_user: dict = Depends(get_current_user),
+):
+    require_feature(current_user, "export_pdf")
+    packet = _build_platform(payload, current_user)
+    pdf_bytes = build_platform_packet_pdf(packet)
+    return _pdf_response(
+        current_user=current_user,
+        packet=packet,
+        pdf_bytes=pdf_bytes,
+        filename=make_platform_packet_filename(packet),
+    )
+
+
+@router.post("/promotion.pdf")
+def download_promotion_packet_pdf(
+    payload: PromotionPacketRequest,
+    current_user: dict = Depends(get_current_user),
+):
+    require_feature(current_user, "export_pdf")
+    packet = _build_promotion(payload, current_user)
+    pdf_bytes = build_promotion_packet_pdf(packet)
+    return _pdf_response(
+        current_user=current_user,
+        packet=packet,
+        pdf_bytes=pdf_bytes,
+        filename=make_promotion_packet_filename(packet),
+    )
+
+
+@router.post("/interview.pdf")
+def download_interview_packet_pdf(
+    payload: InterviewPacketRequest,
+    current_user: dict = Depends(get_current_user),
+):
+    require_feature(current_user, "export_pdf")
+    packet = _build_interview(payload, current_user)
+    pdf_bytes = build_interview_packet_pdf(packet)
+    return _pdf_response(
+        current_user=current_user,
+        packet=packet,
+        pdf_bytes=pdf_bytes,
+        filename=make_interview_packet_filename(packet),
+    )
+
+
+@router.post("/certification.pdf")
+def download_certification_packet_pdf(
+    payload: CertificationPacketRequest,
+    current_user: dict = Depends(get_current_user),
+):
+    require_feature(current_user, "export_pdf")
+    packet = _build_certification(payload, current_user)
+    pdf_bytes = build_certification_packet_pdf(packet)
+    return _pdf_response(
+        current_user=current_user,
+        packet=packet,
+        pdf_bytes=pdf_bytes,
+        filename=make_certification_packet_filename(packet),
+    )

--- a/backend/app/private_packet_share_routes.py
+++ b/backend/app/private_packet_share_routes.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import hmac
+import hashlib
+import os
+import time
+from datetime import datetime, timezone
+from html import escape
+
+from fastapi import APIRouter, Depends, Form, HTTPException, Request, status
+from fastapi.responses import HTMLResponse, RedirectResponse, StreamingResponse
+
+from app.auth import get_current_user, verify_password
+import app.packet_share_routes as packet_share_routes
+from app.packet_share_routes import (
+    PacketShareCreate,
+    _aware,
+    _build_shared_packet,
+    _shared_html,
+    _token_hash,
+    create_packet_share as _create_packet_share,
+    list_packet_shares as _list_packet_shares,
+    revoke_packet_share as _revoke_packet_share,
+)
+from app.packet_platform_pdf import build_platform_packet_pdf, make_platform_packet_filename
+from app.packet_audit import record_packet_export
+
+
+router = APIRouter(tags=["packet-sharing"])
+
+
+def _env_int(name: str, default: int, minimum: int = 1) -> int:
+    try:
+        return max(minimum, int(os.getenv(name, str(default))))
+    except (TypeError, ValueError):
+        return default
+
+
+SHARE_GRANT_SECRET = os.getenv("PACKET_SHARE_GRANT_SECRET") or os.getenv("JWT_SECRET") or "bragstack-share-grant"
+SHARE_GRANT_TTL_SECONDS = _env_int("PACKET_SHARE_GRANT_TTL_SECONDS", 3600, minimum=300)
+SHARE_COOKIE_SECURE = os.getenv("PACKET_SHARE_COOKIE_SECURE", "true").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _share_or_404(token: str) -> dict:
+    item = packet_share_routes.packet_shares_collection.find_one({"token_hash": _token_hash(token)})
+    if not item or item.get("revoked"):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Shared packet not found")
+    expires_at = _aware(item.get("expires_at"))
+    if expires_at and expires_at <= datetime.now(timezone.utc):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Shared packet not found")
+    return item
+
+
+def _cookie_name(token: str) -> str:
+    return f"bragstack_share_{_token_hash(token)[:16]}"
+
+
+def _grant_signature(token: str, item: dict, expires_epoch: int) -> str:
+    access_hash = str(item.get("access_code_hash") or "open")
+    message = f"{_token_hash(token)}:{access_hash}:{expires_epoch}".encode("utf-8")
+    return hmac.new(SHARE_GRANT_SECRET.encode("utf-8"), message, hashlib.sha256).hexdigest()
+
+
+def _grant_value(token: str, item: dict, expires_epoch: int) -> str:
+    return f"{expires_epoch}.{_grant_signature(token, item, expires_epoch)}"
+
+
+def _has_access(request: Request, token: str, item: dict) -> bool:
+    if not item.get("access_code_hash"):
+        return True
+    supplied = request.cookies.get(_cookie_name(token), "")
+    if "." not in supplied:
+        return False
+    expires_text, signature = supplied.split(".", 1)
+    try:
+        expires_epoch = int(expires_text)
+    except ValueError:
+        return False
+    if expires_epoch <= int(time.time()):
+        return False
+    expected = _grant_signature(token, item, expires_epoch)
+    return hmac.compare_digest(signature, expected)
+
+
+def _access_form(token: str, *, error: str = "") -> HTMLResponse:
+    error_html = f"<p role='alert'>{escape(error)}</p>" if error else ""
+    return HTMLResponse(
+        f"""<!doctype html><html><head><meta charset='utf-8'><meta name='viewport' content='width=device-width,initial-scale=1'><meta name='robots' content='noindex,nofollow'><meta name='referrer' content='no-referrer'><title>Protected BragStack packet</title><style>body{{font-family:Inter,system-ui,sans-serif;background:#eef0f1;color:#172126;margin:0}}main{{max-width:480px;margin:10vh auto;background:white;padding:36px;box-shadow:0 18px 60px #0001}}label{{display:block;font-weight:700;margin:18px 0 8px}}input{{box-sizing:border-box;width:100%;padding:12px;border:1px solid #b8c0c2;border-radius:8px}}button{{margin-top:16px;padding:12px 16px;border:0;border-radius:8px;background:#173f43;color:white;font-weight:700}}p{{line-height:1.5;color:#5d686e}}</style></head><body><main><h1>Protected packet</h1><p>Enter the access code shared with you. The code is submitted securely and is not placed in the page URL.</p>{error_html}<form method='post' action='/shared/packets/{escape(token)}/access'><label for='access_code'>Access code</label><input id='access_code' name='access_code' type='password' minlength='4' maxlength='64' required autocomplete='one-time-code'><button type='submit'>Open packet</button></form></main></body></html>""",
+        status_code=status.HTTP_401_UNAUTHORIZED if error else status.HTTP_200_OK,
+        headers={
+            "Cache-Control": "private, no-store",
+            "Referrer-Policy": "no-referrer",
+            "X-Robots-Tag": "noindex, nofollow",
+            "X-Content-Type-Options": "nosniff",
+        },
+    )
+
+
+@router.post("/packets/shares")
+def create_packet_share(payload: PacketShareCreate, current_user: dict = Depends(get_current_user)):
+    return _create_packet_share(payload, current_user)
+
+
+@router.get("/packets/shares")
+def list_packet_shares(current_user: dict = Depends(get_current_user)):
+    return _list_packet_shares(current_user)
+
+
+@router.delete("/packets/shares/{share_id}")
+def revoke_packet_share(share_id: str, current_user: dict = Depends(get_current_user)):
+    return _revoke_packet_share(share_id, current_user)
+
+
+@router.get("/shared/packets/{token}", response_class=HTMLResponse)
+def view_shared_packet(token: str, request: Request):
+    item = _share_or_404(token)
+    if not _has_access(request, token, item):
+        return _access_form(token)
+    _, packet = _build_shared_packet(item)
+    return HTMLResponse(
+        _shared_html(packet, allow_download=bool(item.get("allow_download")), token=token, access_code=None),
+        headers={
+            "Cache-Control": "private, no-store",
+            "Referrer-Policy": "no-referrer",
+            "X-Robots-Tag": "noindex, nofollow",
+            "X-Content-Type-Options": "nosniff",
+        },
+    )
+
+
+@router.post("/shared/packets/{token}/access")
+def grant_shared_packet_access(token: str, access_code: str = Form(..., min_length=4, max_length=64)):
+    item = _share_or_404(token)
+    code_hash = item.get("access_code_hash")
+    if not code_hash:
+        return RedirectResponse(url=f"/shared/packets/{token}", status_code=status.HTTP_303_SEE_OTHER)
+    if not verify_password(access_code, code_hash):
+        return _access_form(token, error="That access code is not valid.")
+
+    now_epoch = int(time.time())
+    max_age = SHARE_GRANT_TTL_SECONDS
+    expires_at = _aware(item.get("expires_at"))
+    if expires_at:
+        remaining = int((expires_at - datetime.now(timezone.utc)).total_seconds())
+        max_age = max(1, min(max_age, remaining))
+    grant_expires_epoch = now_epoch + max_age
+
+    response = RedirectResponse(url=f"/shared/packets/{token}", status_code=status.HTTP_303_SEE_OTHER)
+    response.set_cookie(
+        key=_cookie_name(token),
+        value=_grant_value(token, item, grant_expires_epoch),
+        max_age=max_age,
+        httponly=True,
+        secure=SHARE_COOKIE_SECURE,
+        samesite="lax",
+        path="/shared/packets",
+    )
+    response.headers["Cache-Control"] = "no-store"
+    response.headers["Referrer-Policy"] = "no-referrer"
+    return response
+
+
+@router.get("/shared/packets/{token}/download.pdf")
+def download_shared_packet(token: str, request: Request):
+    item = _share_or_404(token)
+    if not _has_access(request, token, item):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Access code required")
+    if not item.get("allow_download"):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Download is disabled for this share")
+    owner, packet = _build_shared_packet(item)
+    pdf_bytes = build_platform_packet_pdf(packet)
+    filename = make_platform_packet_filename(packet)
+    audit_packet = dict(packet)
+    audit_packet["kind"] = "shared-performance-review"
+    record_packet_export(user_id=str(owner["_id"]), packet=audit_packet, filename=filename, pdf_bytes=pdf_bytes)
+    return StreamingResponse(
+        iter([pdf_bytes]),
+        media_type="application/pdf",
+        headers={
+            "Content-Disposition": f'attachment; filename="{filename}"',
+            "Cache-Control": "private, no-store",
+            "Referrer-Policy": "no-referrer",
+            "X-Content-Type-Options": "nosniff",
+        },
+    )

--- a/backend/app/rate_limit.py
+++ b/backend/app/rate_limit.py
@@ -68,11 +68,17 @@ POLICIES = {
         _env_int("RATE_LIMIT_RECEIPT_VERIFICATION_PUBLIC", 60),
         60,
     ),
+    "packet_share_access": RateLimitPolicy(
+        "packet_share_access",
+        _env_int("RATE_LIMIT_PACKET_SHARE_ACCESS", 10),
+        10 * 60,
+    ),
     "public_profile": RateLimitPolicy("public_profile", _env_int("RATE_LIMIT_PUBLIC_PROFILE", 180), 60),
 }
 
 _RECEIPT_SEND_RE = re.compile(r"^/impact-receipts/[^/]+/verification-requests/?$")
 _RECEIPT_PUBLIC_RE = re.compile(r"^/receipt-verifications/[^/]+(?:/decision)?/?$")
+_PACKET_SHARE_ACCESS_RE = re.compile(r"^/shared/packets/[^/]+/access/?$")
 
 
 def policy_for_request(request: Request) -> RateLimitPolicy | None:
@@ -97,6 +103,8 @@ def policy_for_request(request: Request) -> RateLimitPolicy | None:
             return POLICIES["receipt_verification_send"]
         if _RECEIPT_PUBLIC_RE.fullmatch(path):
             return POLICIES["receipt_verification_public"]
+        if _PACKET_SHARE_ACCESS_RE.fullmatch(path):
+            return POLICIES["packet_share_access"]
 
     if method == "GET":
         if path in {

--- a/backend/tests/test_certification_packet.py
+++ b/backend/tests/test_certification_packet.py
@@ -115,7 +115,7 @@ def test_free_user_cannot_build_certification_packet(certification_context):
     }
     app.dependency_overrides[packet_routes.get_current_user] = lambda: user
 
-    response = client.get("/packets/certification")
+    response = client.post("/packets/certification", json={})
 
     assert response.status_code == 403
     assert response.json()["detail"]["feature"] == "certification_packet"
@@ -133,9 +133,9 @@ def test_certification_packet_distinguishes_evidence_statuses(certification_cont
     app.dependency_overrides[packet_routes.get_current_user] = lambda: user
     _seed_cosmetology_case(entries, receipts, user)
 
-    response = client.get(
+    response = client.post(
         "/packets/certification",
-        params={
+        json={
             "start_date": "2026-01-01",
             "end_date": "2026-06-30",
             "career_area": "Beauty / Cosmetology",
@@ -180,9 +180,9 @@ def test_pro_user_downloads_certification_pdf(certification_context):
     app.dependency_overrides[packet_routes.get_current_user] = lambda: user
     _seed_cosmetology_case(entries, receipts, user)
 
-    response = client.get(
+    response = client.post(
         "/packets/certification.pdf",
-        params={
+        json={
             "start_date": "2026-01-01",
             "end_date": "2026-06-30",
             "credential_name": "Cosmetology License Renewal",

--- a/backend/tests/test_cross_career_packet_regression.py
+++ b/backend/tests/test_cross_career_packet_regression.py
@@ -35,15 +35,7 @@ CAREER_CASES = [
         "category": "Student Outcomes",
         "result": "Raised reading proficiency to 86% for 28 students by the spring benchmark.",
         "skills": ["Instruction", "Student Engagement", "Assessment"],
-        "evidence": [
-            {
-                "title": "Spring reading benchmark summary",
-                "evidence_type": "documentation",
-                "reference": "READING-SPRING-2026",
-                "description": "Class-level benchmark comparison.",
-                "is_public": False,
-            }
-        ],
+        "evidence": [{"title": "Spring reading benchmark summary", "evidence_type": "documentation", "reference": "READING-SPRING-2026", "description": "Class-level benchmark comparison.", "is_public": False}],
         "confirmations": [],
         "expected_metric": "86%",
     },
@@ -56,23 +48,8 @@ CAREER_CASES = [
         "category": "Quality & Service",
         "result": "Cut average diagnostic turnaround by 2.5 hours across 36 service calls.",
         "skills": ["Diagnostics", "Customer Service", "Quality Control"],
-        "evidence": [
-            {
-                "title": "Service turnaround log",
-                "evidence_type": "metric",
-                "reference": "Q2-SERVICE-LOG",
-                "description": "Before-and-after service timing summary.",
-                "is_public": False,
-            }
-        ],
-        "confirmations": [
-            {
-                "name": "Shop Manager",
-                "role": "Service Manager",
-                "confirmation_type": "supervisor",
-                "status": "confirmed",
-            }
-        ],
+        "evidence": [{"title": "Service turnaround log", "evidence_type": "metric", "reference": "Q2-SERVICE-LOG", "description": "Before-and-after service timing summary.", "is_public": False}],
+        "confirmations": [{"name": "Shop Manager", "role": "Service Manager", "confirmation_type": "supervisor", "status": "confirmed"}],
         "expected_metric": "2.5 hours",
     },
     {
@@ -84,23 +61,8 @@ CAREER_CASES = [
         "category": "Customer Retention",
         "result": "Renewed $185,000 in annual contracts and retained 94% of at-risk accounts.",
         "skills": ["Relationship Management", "Negotiation", "Customer Success"],
-        "evidence": [
-            {
-                "title": "Renewal portfolio summary",
-                "evidence_type": "metric",
-                "reference": "FY26-RENEWALS",
-                "description": "Annual renewal value and retention summary.",
-                "is_public": False,
-            }
-        ],
-        "confirmations": [
-            {
-                "name": "Regional Director",
-                "role": "Customer Success Director",
-                "confirmation_type": "stakeholder",
-                "status": "confirmed",
-            }
-        ],
+        "evidence": [{"title": "Renewal portfolio summary", "evidence_type": "metric", "reference": "FY26-RENEWALS", "description": "Annual renewal value and retention summary.", "is_public": False}],
+        "confirmations": [{"name": "Regional Director", "role": "Customer Success Director", "confirmation_type": "stakeholder", "status": "confirmed"}],
         "expected_metric": "$185,000",
     },
     {
@@ -112,23 +74,8 @@ CAREER_CASES = [
         "category": "Quality",
         "result": "Reduced damaged shipments by 31% across 12,400 orders while maintaining daily throughput.",
         "skills": ["Quality Control", "Team Leadership", "Operations"],
-        "evidence": [
-            {
-                "title": "Damage-rate dashboard export",
-                "evidence_type": "metric",
-                "reference": "OPS-Q2-DAMAGE",
-                "description": "Shipment quality trend for the review period.",
-                "is_public": False,
-            }
-        ],
-        "confirmations": [
-            {
-                "name": "Operations Manager",
-                "role": "Operations Manager",
-                "confirmation_type": "supervisor",
-                "status": "confirmed",
-            }
-        ],
+        "evidence": [{"title": "Damage-rate dashboard export", "evidence_type": "metric", "reference": "OPS-Q2-DAMAGE", "description": "Shipment quality trend for the review period.", "is_public": False}],
+        "confirmations": [{"name": "Operations Manager", "role": "Operations Manager", "confirmation_type": "supervisor", "status": "confirmed"}],
         "expected_metric": "31%",
     },
     {
@@ -140,15 +87,7 @@ CAREER_CASES = [
         "category": "Client Impact",
         "result": "Delivered 14 client campaigns and increased repeat bookings by 22%.",
         "skills": ["Brand Design", "Client Communication", "Creative Direction"],
-        "evidence": [
-            {
-                "title": "Project delivery tracker",
-                "evidence_type": "project-artifact",
-                "reference": "2026-CLIENT-TRACKER",
-                "description": "Completed client engagements for the period.",
-                "is_public": False,
-            }
-        ],
+        "evidence": [{"title": "Project delivery tracker", "evidence_type": "project-artifact", "reference": "2026-CLIENT-TRACKER", "description": "Completed client engagements for the period.", "is_public": False}],
         "confirmations": [],
         "expected_metric": "22%",
     },
@@ -161,23 +100,8 @@ CAREER_CASES = [
         "category": "Reliability",
         "result": "Reduced deployment rollback rate from 8% to 3% and saved 6 hours per incident.",
         "skills": ["Reliability", "Automation", "Incident Response"],
-        "evidence": [
-            {
-                "title": "Release reliability report",
-                "evidence_type": "documentation",
-                "reference": "REL-2026-Q2",
-                "description": "Release and rollback trend report.",
-                "is_public": False,
-            }
-        ],
-        "confirmations": [
-            {
-                "name": "Engineering Manager",
-                "role": "Engineering Manager",
-                "confirmation_type": "supervisor",
-                "status": "confirmed",
-            }
-        ],
+        "evidence": [{"title": "Release reliability report", "evidence_type": "documentation", "reference": "REL-2026-Q2", "description": "Release and rollback trend report.", "is_public": False}],
+        "confirmations": [{"name": "Engineering Manager", "role": "Engineering Manager", "confirmation_type": "supervisor", "status": "confirmed"}],
         "expected_metric": "8%",
     },
 ]
@@ -189,75 +113,35 @@ def cross_career_context(monkeypatch):
     mock_db = mock_client["bragstack_cross_career_packet_test"]
     entries = mock_db["entries"]
     receipts = mock_db["impact_receipts"]
-
     monkeypatch.setattr(packet_routes, "entries_collection", entries)
     monkeypatch.setattr(packet_routes, "impact_receipts_collection", receipts)
-
     yield entries, receipts
     app.dependency_overrides.clear()
 
 
 def _seed_case(entries, receipts, user, case):
-    entry = entries.insert_one(
-        {
-            "user_id": str(user["_id"]),
-            "title": case["title"],
-            "category": case["category"],
-            "entry_type": "Current Job",
-            "entry_date": "2026-06-15",
-            "tags": case["skills"],
-            "impact": case["result"],
-            "resume_bullet": case["result"],
-            "created_at": datetime.now(timezone.utc),
-        }
-    )
-
-    receipts.insert_one(
-        {
-            "user_id": str(user["_id"]),
-            "source_entry_id": str(entry.inserted_id),
-            "accomplishment": case["title"],
-            "contribution": f"Led the documented work that produced this {case['category'].lower()} outcome.",
-            "result": case["result"],
-            "evidence": case["evidence"],
-            "skills": case["skills"],
-            "credit": [],
-            "confirmations": case["confirmations"],
-            "trust_signals": ["self-documented"]
-            + (["evidence-linked"] if case["evidence"] else [])
-            + (["stakeholder-verified"] if case["confirmations"] else []),
-            "is_public": False,
-            "created_at": datetime.now(timezone.utc),
-            "updated_at": datetime.now(timezone.utc),
-        }
-    )
+    entry = entries.insert_one({"user_id": str(user["_id"]), "title": case["title"], "category": case["category"], "entry_type": "Current Job", "entry_date": "2026-06-15", "tags": case["skills"], "impact": case["result"], "resume_bullet": case["result"], "created_at": datetime.now(timezone.utc)})
+    receipts.insert_one({"user_id": str(user["_id"]), "source_entry_id": str(entry.inserted_id), "accomplishment": case["title"], "contribution": f"Led the documented work that produced this {case['category'].lower()} outcome.", "result": case["result"], "evidence": case["evidence"], "skills": case["skills"], "credit": [], "confirmations": case["confirmations"], "trust_signals": ["self-documented"] + (["evidence-linked"] if case["evidence"] else []) + (["stakeholder-verified"] if case["confirmations"] else []), "is_public": False, "created_at": datetime.now(timezone.utc), "updated_at": datetime.now(timezone.utc)})
 
 
 @pytest.mark.parametrize("case", CAREER_CASES, ids=[case["id"] for case in CAREER_CASES])
 def test_performance_packet_and_pdf_work_across_careers(cross_career_context, case):
     entries, receipts = cross_career_context
-    user = {
-        "_id": ObjectId(),
-        "name": f"Regression {case['id'].title()}",
-        "email": f"{case['id']}@example.com",
-        "headline": case["role"],
-        "plan": "pro",
-    }
+    user = {"_id": ObjectId(), "name": f"Regression {case['id'].title()}", "email": f"{case['id']}@example.com", "headline": case["role"], "plan": "pro"}
     app.dependency_overrides[packet_routes.get_current_user] = lambda: user
     _seed_case(entries, receipts, user, case)
 
-    params = {
+    payload = {
         "start_date": "2026-01-01",
         "end_date": "2026-12-31",
         "career_area": case["career_area"],
         "role_title": case["role"],
         "organization": case["organization"],
-        "confidential": "true",
+        "confidential": True,
     }
 
-    response = client.get("/packets/performance-review", params=params)
+    response = client.post("/packets/performance-review", json=payload)
     assert response.status_code == 200
-
     packet = response.json()["packet"]
     assert packet["context"]["career_area"] == case["career_area"]
     assert packet["subject"]["role"] == case["role"]
@@ -281,18 +165,11 @@ def test_performance_packet_and_pdf_work_across_careers(cross_career_context, ca
     else:
         assert packet["scorecard"]["verification_coverage_percent"] == 0
 
-    # The universal packet contract should stay profession-neutral.
     serialized = response.text.lower()
-    for profession_specific_key in (
-        "pull_requests_completed",
-        "patients_seen",
-        "students_taught",
-        "units_repaired",
-        "deals_closed",
-    ):
+    for profession_specific_key in ("pull_requests_completed", "patients_seen", "students_taught", "units_repaired", "deals_closed"):
         assert profession_specific_key not in serialized
 
-    pdf_response = client.get("/packets/performance-review.pdf", params=params)
+    pdf_response = client.post("/packets/performance-review.pdf", json=payload)
     assert pdf_response.status_code == 200
     assert pdf_response.headers["content-type"].startswith("application/pdf")
     assert pdf_response.content.startswith(b"%PDF")
@@ -301,7 +178,6 @@ def test_performance_packet_and_pdf_work_across_careers(cross_career_context, ca
 
 def test_cross_career_fixture_set_covers_required_result_shapes():
     combined_results = " ".join(case["result"] for case in CAREER_CASES)
-
     assert "%" in combined_results
     assert "$" in combined_results
     assert "hours" in combined_results

--- a/backend/tests/test_interview_packet.py
+++ b/backend/tests/test_interview_packet.py
@@ -111,7 +111,7 @@ def test_free_user_cannot_build_interview_packet(interview_context):
     }
     app.dependency_overrides[packet_routes.get_current_user] = lambda: user
 
-    response = client.get("/packets/interview")
+    response = client.post("/packets/interview", json={})
 
     assert response.status_code == 403
     assert response.json()["detail"]["feature"] == "interview_packet"
@@ -129,16 +129,16 @@ def test_interview_packet_uses_only_selected_stories_and_hides_evidence_by_defau
     app.dependency_overrides[packet_routes.get_current_user] = lambda: user
     first_id, second_id, third_id = _seed_education_case(entries, receipts, user)
 
-    response = client.get(
+    response = client.post(
         "/packets/interview",
-        params={
+        json={
             "start_date": "2026-01-01",
             "end_date": "2026-06-30",
             "career_area": "Education",
             "role_title": "Elementary Educator",
             "target_role": "Instructional Coach",
             "target_organization": "Community School District",
-            "selected_entry_ids": f"{first_id},{third_id}",
+            "selected_entry_ids": [first_id, third_id],
         },
     )
 
@@ -169,11 +169,11 @@ def test_interview_packet_can_explicitly_export_evidence_references(interview_co
     app.dependency_overrides[packet_routes.get_current_user] = lambda: user
     first_id, _, _ = _seed_education_case(entries, receipts, user)
 
-    response = client.get(
+    response = client.post(
         "/packets/interview",
-        params={
-            "selected_entry_ids": first_id,
-            "include_evidence_references": "true",
+        json={
+            "selected_entry_ids": [first_id],
+            "include_evidence_references": True,
         },
     )
 
@@ -194,12 +194,12 @@ def test_interview_packet_pdf_download_is_real_and_named_for_interview(interview
     app.dependency_overrides[packet_routes.get_current_user] = lambda: user
     first_id, _, third_id = _seed_education_case(entries, receipts, user)
 
-    response = client.get(
+    response = client.post(
         "/packets/interview.pdf",
-        params={
+        json={
             "start_date": "2026-01-01",
             "end_date": "2026-06-30",
-            "selected_entry_ids": f"{first_id},{third_id}",
+            "selected_entry_ids": [first_id, third_id],
             "target_role": "Instructional Coach",
         },
     )

--- a/backend/tests/test_packet_platform_v12.py
+++ b/backend/tests/test_packet_platform_v12.py
@@ -17,7 +17,7 @@ import app.performance_packet_routes as performance_routes
 from app.main import app
 
 
-client = TestClient(app)
+client = TestClient(app, base_url="https://testserver")
 
 
 @pytest.fixture
@@ -52,15 +52,7 @@ def platform_context(monkeypatch):
     app.dependency_overrides[platform_routes.get_current_user] = lambda: user
     app.dependency_overrides[share_routes.get_current_user] = lambda: user
 
-    yield {
-        "entries": entries,
-        "receipts": receipts,
-        "users": users,
-        "audits": audits,
-        "shares": shares,
-        "user": user,
-    }
-
+    yield {"entries": entries, "receipts": receipts, "users": users, "audits": audits, "shares": shares, "user": user}
     app.dependency_overrides.clear()
 
 
@@ -69,89 +61,34 @@ def _seed_three_careers(context):
     receipts = context["receipts"]
     user = context["user"]
     user_id = str(user["_id"])
-
     fixtures = [
-        {
-            "title": "Reduced client intake wait time",
-            "category": "Operations",
-            "date": "2026-02-10",
-            "result": "Reduced average intake wait time by 22 minutes.",
-            "skills": ["Scheduling", "Process Improvement"],
-            "confirmation": {"name": "Avery", "role": "Program Client", "confirmation_type": "client", "status": "confirmed"},
-            "evidence": [{"title": "Intake timing report", "evidence_type": "documentation", "reference": "PRIVATE-INTAKE-22", "description": "Before and after timing", "is_public": False}],
-        },
-        {
-            "title": "Built peer onboarding guide",
-            "category": "Training",
-            "date": "2026-03-15",
-            "result": "Prepared 14 new team members across 3 shifts.",
-            "skills": ["Training", "Communication"],
-            "confirmation": {"name": "Sam", "role": "Peer Lead", "confirmation_type": "peer", "status": "confirmed"},
-            "evidence": [{"title": "Onboarding guide", "evidence_type": "documentation", "reference": "GUIDE-14", "description": "Training artifact", "is_public": False}],
-        },
-        {
-            "title": "Improved customer follow-up quality",
-            "category": "Service",
-            "date": "2026-04-20",
-            "result": "Raised follow-up completion to 96%.",
-            "skills": ["Customer Service", "Quality"],
-            "confirmation": {"name": "Customer survey", "role": "Feedback", "confirmation_type": "customer", "status": "confirmed"},
-            "evidence": [{"title": "Customer feedback summary", "evidence_type": "customer-feedback", "reference": "FEEDBACK-96", "description": "Customer response summary", "is_public": False}],
-        },
+        {"title": "Reduced client intake wait time", "category": "Operations", "date": "2026-02-10", "result": "Reduced average intake wait time by 22 minutes.", "skills": ["Scheduling", "Process Improvement"], "confirmation": {"name": "Avery", "role": "Program Client", "confirmation_type": "client", "status": "confirmed"}, "evidence": [{"title": "Intake timing report", "evidence_type": "documentation", "reference": "PRIVATE-INTAKE-22", "description": "Before and after timing", "is_public": False}]},
+        {"title": "Built peer onboarding guide", "category": "Training", "date": "2026-03-15", "result": "Prepared 14 new team members across 3 shifts.", "skills": ["Training", "Communication"], "confirmation": {"name": "Sam", "role": "Peer Lead", "confirmation_type": "peer", "status": "confirmed"}, "evidence": [{"title": "Onboarding guide", "evidence_type": "documentation", "reference": "GUIDE-14", "description": "Training artifact", "is_public": False}]},
+        {"title": "Improved customer follow-up quality", "category": "Service", "date": "2026-04-20", "result": "Raised follow-up completion to 96%.", "skills": ["Customer Service", "Quality"], "confirmation": {"name": "Customer survey", "role": "Feedback", "confirmation_type": "customer", "status": "confirmed"}, "evidence": [{"title": "Customer feedback summary", "evidence_type": "customer-feedback", "reference": "FEEDBACK-96", "description": "Customer response summary", "is_public": False}]},
     ]
-
     ids = []
     for fixture in fixtures:
-        inserted = entries.insert_one(
-            {
-                "user_id": user_id,
-                "title": fixture["title"],
-                "category": fixture["category"],
-                "entry_type": "Current Job",
-                "entry_date": fixture["date"],
-                "tags": fixture["skills"],
-                "impact": fixture["result"],
-                "resume_bullet": fixture["title"],
-                "created_at": datetime.now(timezone.utc),
-            }
-        )
+        inserted = entries.insert_one({"user_id": user_id, "title": fixture["title"], "category": fixture["category"], "entry_type": "Current Job", "entry_date": fixture["date"], "tags": fixture["skills"], "impact": fixture["result"], "resume_bullet": fixture["title"], "created_at": datetime.now(timezone.utc)})
         entry_id = str(inserted.inserted_id)
         ids.append(entry_id)
-        receipts.insert_one(
-            {
-                "user_id": user_id,
-                "source_entry_id": entry_id,
-                "accomplishment": fixture["title"],
-                "contribution": f"Owned the work behind {fixture['title'].lower()}.",
-                "result": fixture["result"],
-                "evidence": fixture["evidence"],
-                "skills": fixture["skills"],
-                "credit": [],
-                "confirmations": [fixture["confirmation"]],
-                "trust_signals": ["self-documented", "evidence-linked"],
-                "is_public": False,
-                "created_at": datetime.now(timezone.utc),
-                "updated_at": datetime.now(timezone.utc),
-            }
-        )
+        receipts.insert_one({"user_id": user_id, "source_entry_id": entry_id, "accomplishment": fixture["title"], "contribution": f"Owned the work behind {fixture['title'].lower()}.", "result": fixture["result"], "evidence": fixture["evidence"], "skills": fixture["skills"], "credit": [], "confirmations": [fixture["confirmation"]], "trust_signals": ["self-documented", "evidence-linked"], "is_public": False, "created_at": datetime.now(timezone.utc), "updated_at": datetime.now(timezone.utc)})
     return ids
 
 
 def test_v12_pinning_sections_notes_branding_and_recognition(platform_context):
     ids = _seed_three_careers(platform_context)
-
-    response = client.get(
+    response = client.post(
         "/packets/performance-review-v12",
-        params={
+        json={
             "start_date": "2026-01-01",
             "end_date": "2026-06-30",
             "career_area": "Operations",
             "organization": "Neighborhood Services",
-            "signature_entry_ids": f"{ids[2]},{ids[0]}",
-            "sections": "signature-accomplishments,contribution-recognition,review-summary",
+            "signature_entry_ids": [ids[2], ids[0]],
+            "sections": ["signature-accomplishments", "contribution-recognition", "review-summary"],
             "packet_note": "Scope changed mid-cycle; prioritize service quality and sustainable operations.",
-            "item_notes": '{"%s":"Use this example to discuss customer trust."}' % ids[2],
-            "include_notes": "true",
+            "item_notes": {ids[2]: "Use this example to discuss customer trust."},
+            "include_notes": True,
             "theme": "modern-minimal",
             "brand_name": "Neighborhood Services",
             "department_label": "Community Operations",
@@ -159,48 +96,29 @@ def test_v12_pinning_sections_notes_branding_and_recognition(platform_context):
             "review_cycle_label": "2026 Midyear Review",
         },
     )
-
     assert response.status_code == 200
     packet = response.json()["packet"]
     assert packet["scorecard"]["accomplishments"] == 3
     assert [item["entry_id"] for item in packet["signature_accomplishments"]] == [ids[2], ids[0]]
-    assert packet["render_config"]["sections"] == [
-        "signature-accomplishments",
-        "contribution-recognition",
-        "review-summary",
-    ]
+    assert packet["render_config"]["sections"] == ["signature-accomplishments", "contribution-recognition", "review-summary"]
     assert packet["render_config"]["theme"] == "modern-minimal"
     assert packet["annotations"]["packet_note"].startswith("Scope changed")
     assert packet["annotations"]["item_notes"][ids[2]].startswith("Use this example")
     assert packet["branding"]["brand_name"] == "Neighborhood Services"
     assert packet["branding"]["reviewer_name"] == "Annual Review Committee"
-
-    labels = {
-        recognition["label"]
-        for record in packet["receipt_records"]
-        for recognition in record.get("recognition", [])
-    }
+    labels = {recognition["label"] for record in packet["receipt_records"] for recognition in record.get("recognition", [])}
     assert {"Client confirmed", "Peer recognized", "Customer feedback attached"} <= labels
 
 
 def test_explicit_empty_sections_make_two_page_packet_and_audit_metadata(platform_context):
     _seed_three_careers(platform_context)
-
     for theme in ["classic-dossier", "modern-minimal", "executive-report"]:
-        response = client.get(
-            "/packets/performance-review-v12.pdf",
-            params={"sections": "__none__", "theme": theme},
-        )
+        response = client.post("/packets/performance-review-v12.pdf", json={"sections": [], "theme": theme})
         assert response.status_code == 200
         assert response.content.startswith(b"%PDF")
-
     audits = list(platform_context["audits"].find({}))
     assert len(audits) == 3
-    assert {item["theme"] for item in audits} == {
-        "classic-dossier",
-        "modern-minimal",
-        "executive-report",
-    }
+    assert {item["theme"] for item in audits} == {"classic-dossier", "modern-minimal", "executive-report"}
     for item in audits:
         assert item["page_count"] == 2
         assert item["packet_kind"] == "performance-review"
@@ -208,7 +126,6 @@ def test_explicit_empty_sections_make_two_page_packet_and_audit_metadata(platfor
         assert "packet" not in item
         assert "evidence" not in item
         assert "body" not in item
-
     history = client.get("/packets/export-history")
     assert history.status_code == 200
     assert len(history.json()["exports"]) == 3
@@ -217,20 +134,9 @@ def test_explicit_empty_sections_make_two_page_packet_and_audit_metadata(platfor
 def test_private_share_access_code_evidence_controls_revocation_and_expiry(platform_context):
     ids = _seed_three_careers(platform_context)
     future = (datetime.now(timezone.utc) + timedelta(days=2)).isoformat()
-
     created = client.post(
         "/packets/shares",
-        json={
-            "career_area": "Operations",
-            "signature_entry_ids": [ids[0]],
-            "sections": ["signature-accomplishments"],
-            "packet_note": "Private internal note that must not leak.",
-            "include_notes": False,
-            "expires_at": future,
-            "access_code": "2468-secure",
-            "allow_download": False,
-            "include_evidence": False,
-        },
+        json={"career_area": "Operations", "signature_entry_ids": [ids[0]], "sections": ["signature-accomplishments"], "packet_note": "Private internal note that must not leak.", "include_notes": False, "expires_at": future, "access_code": "2468-secure", "allow_download": False, "include_evidence": False},
     )
     assert created.status_code == 200
     share = created.json()["share"]
@@ -243,53 +149,44 @@ def test_private_share_access_code_evidence_controls_revocation_and_expiry(platf
     assert stored["include_evidence"] is False
     assert stored["include_notes"] is False
 
-    assert client.get(f"/shared/packets/{token}").status_code == 401
-    view = client.get(f"/shared/packets/{token}", params={"code": "2468-secure"})
+    protected = client.get(f"/shared/packets/{token}")
+    assert protected.status_code == 200
+    assert "Protected packet" in protected.text
+    query_attempt = client.get(f"/shared/packets/{token}", params={"code": "2468-secure"})
+    assert query_attempt.status_code == 200
+    assert "Protected packet" in query_attempt.text
+
+    grant = client.post(f"/shared/packets/{token}/access", data={"access_code": "2468-secure"}, follow_redirects=False)
+    assert grant.status_code == 303
+    assert "2468-secure" not in grant.headers["location"]
+    assert "2468-secure" not in grant.headers["set-cookie"]
+    assert "Path=/shared/packets" in grant.headers["set-cookie"]
+    assert "Secure" in grant.headers["set-cookie"]
+
+    view = client.get(f"/shared/packets/{token}")
     assert view.status_code == 200
     assert "PRIVATE-INTAKE-22" not in view.text
     assert "Private internal note" not in view.text
     assert view.headers["cache-control"] == "private, no-store"
     assert "noindex" in view.headers["x-robots-tag"]
 
-    blocked_download = client.get(
-        f"/shared/packets/{token}/download.pdf",
-        params={"code": "2468-secure"},
-    )
+    blocked_download = client.get(f"/shared/packets/{token}/download.pdf")
     assert blocked_download.status_code == 403
 
     revoked = client.delete(f"/packets/shares/{share['id']}")
     assert revoked.status_code == 200
-    assert client.get(f"/shared/packets/{token}", params={"code": "2468-secure"}).status_code == 404
+    assert client.get(f"/shared/packets/{token}").status_code == 404
 
-    expiring = client.post(
-        "/packets/shares",
-        json={
-            "signature_entry_ids": [ids[1]],
-            "sections": [],
-            "expires_at": future,
-        },
-    )
+    expiring = client.post("/packets/shares", json={"signature_entry_ids": [ids[1]], "sections": [], "expires_at": future})
     assert expiring.status_code == 200
     expiring_share = expiring.json()["share"]
-    platform_context["shares"].update_one(
-        {"_id": ObjectId(expiring_share["id"])},
-        {"$set": {"expires_at": datetime.now(timezone.utc) - timedelta(seconds=1)}},
-    )
+    platform_context["shares"].update_one({"_id": ObjectId(expiring_share["id"])}, {"$set": {"expires_at": datetime.now(timezone.utc) - timedelta(seconds=1)}})
     assert client.get(f"/shared/packets/{expiring_share['token']}").status_code == 404
 
 
 def test_private_share_can_explicitly_enable_pdf_and_audits_shared_export(platform_context):
     ids = _seed_three_careers(platform_context)
-    created = client.post(
-        "/packets/shares",
-        json={
-            "signature_entry_ids": [ids[0]],
-            "sections": [],
-            "allow_download": True,
-            "include_evidence": False,
-            "include_notes": False,
-        },
-    )
+    created = client.post("/packets/shares", json={"signature_entry_ids": [ids[0]], "sections": [], "allow_download": True, "include_evidence": False, "include_notes": False})
     assert created.status_code == 200
     token = created.json()["share"]["token"]
     pdf = client.get(f"/shared/packets/{token}/download.pdf")
@@ -306,22 +203,12 @@ def test_verified_recognition_is_exposed_in_interview_and_certification_packets(
     app.dependency_overrides[interview_routes.get_current_user] = lambda: user
     app.dependency_overrides[certification_routes.get_current_user] = lambda: user
 
-    interview = client.get(
-        "/packets/interview",
-        params={"selected_entry_ids": ",".join(ids)},
-    )
+    interview = client.post("/packets/interview", json={"selected_entry_ids": ids})
     assert interview.status_code == 200
-    interview_labels = {
-        recognition["label"]
-        for story in interview.json()["packet"]["interview_stories"]
-        for recognition in story.get("recognition", [])
-    }
+    interview_labels = {recognition["label"] for story in interview.json()["packet"]["interview_stories"] for recognition in story.get("recognition", [])}
     assert {"Client confirmed", "Peer recognized", "Customer feedback attached"} <= interview_labels
 
-    certification = client.get(
-        "/packets/certification",
-        params={"credential_name": "Community Service Quality Credential"},
-    )
+    certification = client.post("/packets/certification", json={"credential_name": "Community Service Quality Credential"})
     assert certification.status_code == 200
     certification_labels = set(certification.json()["packet"]["verified_recognition"])
     assert {"Client confirmed", "Peer recognized", "Customer feedback attached"} <= certification_labels

--- a/backend/tests/test_packet_privacy_routes.py
+++ b/backend/tests/test_packet_privacy_routes.py
@@ -1,0 +1,165 @@
+from datetime import datetime, timedelta, timezone
+
+import mongomock
+from bson import ObjectId
+from fastapi.testclient import TestClient
+from starlette.requests import Request
+
+import app.private_packet_routes as private_packet_routes
+import app.private_packet_share_routes as private_share_routes
+import app.rate_limit as rate_limit
+from app.auth import hash_password
+from app.main import app
+
+
+client = TestClient(app)
+
+SENSITIVE_PACKET_PATHS = [
+    "/packets/performance-review",
+    "/packets/performance-review-v12",
+    "/packets/promotion",
+    "/packets/interview",
+    "/packets/certification",
+    "/packets/performance-review.pdf",
+    "/packets/performance-review-v12.pdf",
+    "/packets/promotion.pdf",
+    "/packets/interview.pdf",
+    "/packets/certification.pdf",
+]
+
+
+def test_private_packet_builders_and_exports_are_post_only():
+    paths = app.openapi()["paths"]
+    for path in SENSITIVE_PACKET_PATHS:
+        assert path in paths
+        methods = set(paths[path])
+        assert "post" in methods
+        assert "get" not in methods
+
+
+def test_sensitive_packet_context_is_accepted_in_json_body_not_query(monkeypatch):
+    user = {"_id": ObjectId(), "email": "packet@example.com", "name": "Packet User", "plan": "pro"}
+    captured = {}
+
+    def build_platform(payload, current_user):
+        captured["payload"] = payload
+        captured["user"] = current_user
+        return {
+            "kind": "performance-review",
+            "context": {"organization": payload.organization},
+            "branding": {"reviewer_name": payload.reviewer_name},
+            "annotations": {
+                "packet_note": payload.packet_note,
+                "item_notes": payload.item_notes,
+            },
+        }
+
+    app.dependency_overrides[private_packet_routes.get_current_user] = lambda: user
+    monkeypatch.setattr(private_packet_routes, "_build_platform", build_platform)
+
+    sensitive = {
+        "organization": "Quiet Acquisition Target",
+        "reviewer_name": "Private Reviewer",
+        "packet_note": "Do not put this note in browser history",
+        "item_notes": {"entry-1": "Manager-only context"},
+        "signature_entry_ids": ["entry-1"],
+        "sections": ["review-summary"],
+        "confidential": True,
+    }
+    response = client.post("/packets/performance-review-v12", json=sensitive)
+
+    assert response.status_code == 200
+    assert captured["user"] == user
+    assert captured["payload"].organization == sensitive["organization"]
+    assert captured["payload"].reviewer_name == sensitive["reviewer_name"]
+    assert captured["payload"].packet_note == sensitive["packet_note"]
+    assert captured["payload"].item_notes == sensitive["item_notes"]
+    assert "?" not in str(response.request.url)
+    for value in [sensitive["organization"], sensitive["reviewer_name"], sensitive["packet_note"]]:
+        assert value not in str(response.request.url)
+
+    legacy = client.get(
+        "/packets/performance-review-v12",
+        params={"organization": sensitive["organization"], "reviewer_name": sensitive["reviewer_name"]},
+    )
+    assert legacy.status_code == 405
+    app.dependency_overrides.clear()
+
+
+def test_protected_share_code_is_exchanged_for_clean_cookie_grant(monkeypatch):
+    mock_db = mongomock.MongoClient()["packet_privacy_test"]
+    shares = mock_db["packet_shares"]
+    rate_limits = mock_db["rate_limits"]
+    token = "share-token-value"
+    access_code = "correct-horse-battery"
+    item = {
+        "_id": ObjectId(),
+        "token_hash": private_share_routes._token_hash(token),
+        "access_code_hash": hash_password(access_code),
+        "expires_at": datetime.now(timezone.utc) + timedelta(hours=2),
+        "revoked": False,
+        "allow_download": False,
+    }
+    shares.insert_one(item)
+
+    monkeypatch.setattr(private_share_routes.packet_share_routes, "packet_shares_collection", shares)
+    monkeypatch.setattr(rate_limit, "rate_limits_collection", rate_limits)
+    monkeypatch.setattr(private_share_routes, "SHARE_COOKIE_SECURE", False)
+    monkeypatch.setattr(
+        private_share_routes,
+        "_build_shared_packet",
+        lambda stored: ({"_id": ObjectId()}, {"title": "Unlocked packet"}),
+    )
+    monkeypatch.setattr(
+        private_share_routes,
+        "_shared_html",
+        lambda packet, **kwargs: "<html><body>Unlocked packet</body></html>",
+    )
+
+    untrusted_query = client.get(f"/shared/packets/{token}", params={"code": access_code})
+    assert untrusted_query.status_code == 200
+    assert "Protected packet" in untrusted_query.text
+    assert access_code not in untrusted_query.text
+
+    granted = client.post(
+        f"/shared/packets/{token}/access",
+        data={"access_code": access_code},
+        follow_redirects=False,
+    )
+    assert granted.status_code == 303
+    assert granted.headers["location"] == f"/shared/packets/{token}"
+    assert access_code not in granted.headers["location"]
+    assert access_code not in granted.headers["set-cookie"]
+    assert "HttpOnly" in granted.headers["set-cookie"]
+    assert "SameSite=lax" in granted.headers["set-cookie"]
+
+    clean_view = client.get(f"/shared/packets/{token}")
+    assert clean_view.status_code == 200
+    assert "Unlocked packet" in clean_view.text
+    assert access_code not in str(clean_view.request.url)
+
+
+def test_expired_signed_share_grant_is_rejected(monkeypatch):
+    token = "expiring-share"
+    item = {"access_code_hash": "stored-access-hash"}
+    expires_epoch = 2_000_000_000
+    grant = private_share_routes._grant_value(token, item, expires_epoch)
+    cookie_name = private_share_routes._cookie_name(token)
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "scheme": "https",
+        "path": f"/shared/packets/{token}",
+        "raw_path": f"/shared/packets/{token}".encode(),
+        "query_string": b"",
+        "headers": [(b"cookie", f"{cookie_name}={grant}".encode())],
+        "client": ("203.0.113.10", 1234),
+        "server": ("testserver", 443),
+    }
+    request = Request(scope)
+
+    monkeypatch.setattr(private_share_routes.time, "time", lambda: expires_epoch - 1)
+    assert private_share_routes._has_access(request, token, item) is True
+
+    monkeypatch.setattr(private_share_routes.time, "time", lambda: expires_epoch)
+    assert private_share_routes._has_access(request, token, item) is False

--- a/backend/tests/test_performance_packet.py
+++ b/backend/tests/test_performance_packet.py
@@ -36,7 +36,7 @@ def test_free_user_cannot_generate_performance_packet(packet_context):
     }
     app.dependency_overrides[packet_routes.get_current_user] = lambda: user
 
-    response = client.get("/packets/performance-review")
+    response = client.post("/packets/performance-review", json={})
 
     assert response.status_code == 403
     assert response.json()["detail"]["code"] == "paid_feature_required"
@@ -145,15 +145,15 @@ def test_pro_packet_is_career_neutral_and_contains_full_dossier_data(packet_cont
         }
     )
 
-    response = client.get(
+    response = client.post(
         "/packets/performance-review",
-        params={
+        json={
             "start_date": "2026-01-01",
             "end_date": "2026-06-30",
             "career_area": "Nonprofit",
             "role_title": "Community Programs Coordinator",
             "organization": "Neighborhood Learning Collaborative",
-            "confidential": "true",
+            "confidential": True,
         },
     )
 
@@ -228,18 +228,23 @@ def test_packet_period_validation_and_filtering(packet_context):
         ]
     )
 
-    response = client.get(
-        "/packets/performance-review?start_date=2026-07-01&end_date=2026-07-31"
+    response = client.post(
+        "/packets/performance-review",
+        json={"start_date": "2026-07-01", "end_date": "2026-07-31"},
     )
     assert response.status_code == 200
     packet = response.json()["packet"]
     assert packet["scorecard"]["accomplishments"] == 1
     assert packet["signature_accomplishments"][0]["title"] == "Summer work"
 
-    missing_end = client.get("/packets/performance-review?start_date=2026-07-01")
+    missing_end = client.post(
+        "/packets/performance-review",
+        json={"start_date": "2026-07-01"},
+    )
     assert missing_end.status_code == 422
 
-    reversed_period = client.get(
-        "/packets/performance-review?start_date=2026-08-01&end_date=2026-07-01"
+    reversed_period = client.post(
+        "/packets/performance-review",
+        json={"start_date": "2026-08-01", "end_date": "2026-07-01"},
     )
     assert reversed_period.status_code == 422

--- a/backend/tests/test_performance_packet_pdf.py
+++ b/backend/tests/test_performance_packet_pdf.py
@@ -84,7 +84,7 @@ def test_free_user_cannot_export_pdf(pdf_context):
     }
     app.dependency_overrides[packet_routes.get_current_user] = lambda: user
 
-    response = client.get("/packets/performance-review.pdf")
+    response = client.post("/packets/performance-review.pdf", json={})
 
     assert response.status_code == 403
     assert response.json()["detail"]["code"] == "paid_feature_required"
@@ -104,15 +104,15 @@ def test_pro_user_downloads_real_pdf_with_expected_filename(pdf_context):
     app.dependency_overrides[packet_routes.get_current_user] = lambda: user
     _seed_packet(entries, receipts, user)
 
-    response = client.get(
+    response = client.post(
         "/packets/performance-review.pdf",
-        params={
+        json={
             "start_date": "2026-01-01",
             "end_date": "2026-06-30",
             "career_area": "Nonprofit",
             "role_title": "Community Programs Coordinator",
             "organization": "Neighborhood Learning Collaborative",
-            "confidential": "true",
+            "confidential": True,
         },
     )
 
@@ -175,7 +175,7 @@ def test_pdf_export_handles_long_evidence_index(pdf_context):
         }
     )
 
-    response = client.get("/packets/performance-review.pdf")
+    response = client.post("/packets/performance-review.pdf", json={})
 
     assert response.status_code == 200
     assert response.content.startswith(b"%PDF")

--- a/backend/tests/test_promotion_packet.py
+++ b/backend/tests/test_promotion_packet.py
@@ -113,7 +113,7 @@ def test_free_user_cannot_build_promotion_packet(promotion_context):
     }
     app.dependency_overrides[packet_routes.get_current_user] = lambda: user
 
-    response = client.get("/packets/promotion")
+    response = client.post("/packets/promotion", json={})
 
     assert response.status_code == 403
     assert response.json()["detail"]["feature"] == "promotion_packet"
@@ -131,9 +131,9 @@ def test_pro_promotion_packet_is_evidence_backed_and_career_neutral(promotion_co
     app.dependency_overrides[packet_routes.get_current_user] = lambda: user
     _seed_operations_case(entries, receipts, user)
 
-    response = client.get(
+    response = client.post(
         "/packets/promotion",
-        params={
+        json={
             "start_date": "2026-01-01",
             "end_date": "2026-06-30",
             "career_area": "Operations",
@@ -171,9 +171,9 @@ def test_pro_user_downloads_dedicated_promotion_pdf(promotion_context):
     app.dependency_overrides[packet_routes.get_current_user] = lambda: user
     _seed_operations_case(entries, receipts, user)
 
-    response = client.get(
+    response = client.post(
         "/packets/promotion.pdf",
-        params={
+        json={
             "start_date": "2026-01-01",
             "end_date": "2026-06-30",
             "career_area": "Operations",

--- a/backend/tests/test_rate_limit.py
+++ b/backend/tests/test_rate_limit.py
@@ -83,6 +83,7 @@ def test_targeted_policy_selection_covers_abuse_sensitive_routes(monkeypatch):
         ("POST", "/impact-receipts/507f1f77bcf86cd799439011/verification-requests", "receipt_verification_send"),
         ("GET", "/receipt-verifications/token-value", "receipt_verification_public"),
         ("POST", "/receipt-verifications/token-value/decision", "receipt_verification_public"),
+        ("POST", "/shared/packets/share-token/access", "packet_share_access"),
         ("GET", "/public/brag/example-user", "public_profile"),
         ("GET", "/public/brag/example-user/profile", "public_profile"),
     ]

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -14,7 +14,7 @@ function getPublicBragPath(slug, suffix = "") {
   return normalizedSlug ? `/public/brag/${encodeURIComponent(normalizedSlug)}${suffix}` : `/public/brag${suffix}`;
 }
 
-function getPacketParams(startDate, endDate, options = {}) {
+function getPacketPayload(startDate, endDate, options = {}) {
   return {
     ...(startDate && endDate ? { start_date: startDate, end_date: endDate } : {}),
     ...(options.careerArea ? { career_area: options.careerArea } : {}),
@@ -23,16 +23,16 @@ function getPacketParams(startDate, endDate, options = {}) {
     ...(options.targetRole ? { target_role: options.targetRole } : {}),
     ...(options.targetLevel ? { target_level: options.targetLevel } : {}),
     ...(options.targetOrganization ? { target_organization: options.targetOrganization } : {}),
-    ...(options.selectedEntryIds?.length ? { selected_entry_ids: options.selectedEntryIds.join(",") } : {}),
+    ...(options.selectedEntryIds?.length ? { selected_entry_ids: options.selectedEntryIds } : {}),
     ...(options.includeEvidenceReferences ? { include_evidence_references: true } : {}),
     ...(options.credentialName ? { credential_name: options.credentialName } : {}),
     ...(options.issuingBody ? { issuing_body: options.issuingBody } : {}),
     ...(options.reviewType ? { review_type: options.reviewType } : {}),
     ...(options.requirementNotes ? { requirement_notes: options.requirementNotes } : {}),
-    ...(options.signatureEntryIds?.length ? { signature_entry_ids: options.signatureEntryIds.join(",") } : {}),
-    ...(Array.isArray(options.sections) ? { sections: options.sections.length ? options.sections.join(",") : "__none__" } : {}),
+    ...(options.signatureEntryIds?.length ? { signature_entry_ids: options.signatureEntryIds } : {}),
+    ...(Array.isArray(options.sections) ? { sections: options.sections } : {}),
     ...(options.packetNote ? { packet_note: options.packetNote } : {}),
-    ...(options.itemNotes && Object.keys(options.itemNotes).length ? { item_notes: JSON.stringify(options.itemNotes) } : {}),
+    ...(options.itemNotes && Object.keys(options.itemNotes).length ? { item_notes: options.itemNotes } : {}),
     ...(options.theme ? { theme: options.theme } : {}),
     ...(options.brandName ? { brand_name: options.brandName } : {}),
     ...(options.departmentLabel ? { department_label: options.departmentLabel } : {}),
@@ -89,10 +89,11 @@ function packetOptionsFromPacket(packet) {
 
 async function downloadPacketPdf(path, packet, fallbackFilename) {
   const options = packetOptionsFromPacket(packet);
-  const response = await api.get(path, {
-    params: getPacketParams(options.startDate, options.endDate, options),
-    responseType: "blob",
-  });
+  const response = await api.post(
+    path,
+    getPacketPayload(options.startDate, options.endDate, options),
+    { responseType: "blob" },
+  );
   return {
     blob: response.data,
     filename: parseDownloadFilename(response.headers["content-disposition"], fallbackFilename),
@@ -153,12 +154,12 @@ export async function getPerformancePacket(startDate, endDate, options = {}) {
       : options.packetType === "certification"
         ? "/packets/certification"
         : "/packets/performance-review-v12";
-  const response = await api.get(path, { params: getPacketParams(startDate, endDate, options) });
+  const response = await api.post(path, getPacketPayload(startDate, endDate, options));
   return response.data;
 }
-export async function getPromotionPacket(startDate, endDate, options = {}) { const response = await api.get("/packets/promotion", { params: getPacketParams(startDate, endDate, options) }); return response.data; }
-export async function getInterviewPacket(startDate, endDate, options = {}) { const response = await api.get("/packets/interview", { params: getPacketParams(startDate, endDate, options) }); return response.data; }
-export async function getCertificationPacket(startDate, endDate, options = {}) { const response = await api.get("/packets/certification", { params: getPacketParams(startDate, endDate, options) }); return response.data; }
+export async function getPromotionPacket(startDate, endDate, options = {}) { const response = await api.post("/packets/promotion", getPacketPayload(startDate, endDate, options)); return response.data; }
+export async function getInterviewPacket(startDate, endDate, options = {}) { const response = await api.post("/packets/interview", getPacketPayload(startDate, endDate, options)); return response.data; }
+export async function getCertificationPacket(startDate, endDate, options = {}) { const response = await api.post("/packets/certification", getPacketPayload(startDate, endDate, options)); return response.data; }
 
 export async function downloadPerformancePacketPdf(packet) { return downloadPacketPdf("/packets/performance-review-v12.pdf", packet, "bragstack-performance-review.pdf"); }
 export async function downloadPromotionPacketPdf(packet) { return downloadPacketPdf("/packets/promotion.pdf", packet, "bragstack-promotion-packet.pdf"); }


### PR DESCRIPTION
Closes #186.

Supersedes stale PR #193. This replacement reapplies the already-reviewed packet privacy remediation directly onto current protected `main`, without overwriting the newer Aisha, CI, or changelog work.

## What changed
- Use POST JSON bodies for authenticated packet builder/export routes instead of sensitive query strings.
- Remove legacy sensitive GET packet routers from app registration.
- Send packet previews and PDF exports through JSON bodies in the frontend.
- Replace shared-packet `?code=` access with a POSTed access-code form and short-lived HttpOnly signed grant cookie.
- Bound grant lifetime, apply Secure/SameSite/path cookie controls, and rate-limit access-code attempts.
- Add regression coverage for POST-only routes, legacy GET rejection, clean share access, grant expiry, and rate limiting.

## Merge gate
Merge only if Backend CI, Frontend CI, and Security CI are green on this exact current head, the PR remains current/mergeable, and review threads are resolved.