### PR TITLE
perf: remove observability writes from API response path

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,6 +7,7 @@ from fastapi import Depends, FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from pymongo.errors import PyMongoError
+from starlette.background import BackgroundTask, BackgroundTasks
 
 from app.auth import get_current_user
 from app.auth_routes import router as auth_router
@@ -34,15 +35,59 @@ from app.reports_routes import router as reports_router
 from app.resume_builder_routes import router as resume_builder_router
 from app.routes import router as entries_router
 
-app = FastAPI(title="BragStack API", description="Evidence-backed career proof for accomplishments, impact, and reports.", version="1.0.0")
+app = FastAPI(
+    title="BragStack API",
+    description="Evidence-backed career proof for accomplishments, impact, and reports.",
+    version="1.0.0",
+)
 frontend_url = os.getenv("FRONTEND_URL", "http://localhost:5173").rstrip("/")
 ENTRY_EDIT_WINDOW = timedelta(hours=1)
 mongo_admin = mongo_client.admin
 
+
+def _defer_persistent_request(
+    response,
+    *,
+    request_id: str,
+    method: str,
+    path: str,
+    status_code: int,
+    duration_ms: float,
+) -> None:
+    """Persist sanitized request telemetry after the response has been sent.
+
+    `record_persistent_request` performs MongoDB I/O. Keeping that write on the
+    response critical path makes otherwise trivial requests wait on an external
+    database round-trip. Starlette background tasks run synchronous work in its
+    thread pool after the response body is sent, preserving observability
+    without adding that latency to customer requests.
+    """
+    telemetry_task = BackgroundTask(
+        record_persistent_request,
+        request_id=request_id,
+        method=method,
+        path=path,
+        status_code=status_code,
+        duration_ms=duration_ms,
+    )
+    existing = response.background
+    if existing is None:
+        response.background = telemetry_task
+        return
+    if isinstance(existing, BackgroundTasks):
+        existing.tasks.append(telemetry_task)
+        return
+    combined = BackgroundTasks()
+    combined.tasks.append(existing)
+    combined.tasks.append(telemetry_task)
+    response.background = combined
+
+
 @app.middleware("http")
 async def add_security_headers_and_telemetry(request: Request, call_next):
     request_id = request.headers.get("x-request-id") or new_request_id()
-    started = time.perf_counter(); status_code = 500
+    started = time.perf_counter()
+    status_code = 500
     try:
         decision = check_rate_limit(request)
         if decision:
@@ -60,21 +105,54 @@ async def add_security_headers_and_telemetry(request: Request, call_next):
         status_code = response.status_code
     except Exception as exc:
         duration_ms = (time.perf_counter() - started) * 1000
-        record_request(request_id=request_id, method=request.method, path=request.url.path, status_code=500, duration_ms=duration_ms)
-        record_persistent_request(request_id=request_id, method=request.method, path=request.url.path, status_code=500, duration_ms=duration_ms, error_type=type(exc).__name__)
+        record_request(
+            request_id=request_id,
+            method=request.method,
+            path=request.url.path,
+            status_code=500,
+            duration_ms=duration_ms,
+        )
+        # Exception telemetry is intentionally written synchronously because
+        # there is no response object to attach a background task to.
+        record_persistent_request(
+            request_id=request_id,
+            method=request.method,
+            path=request.url.path,
+            status_code=500,
+            duration_ms=duration_ms,
+            error_type=type(exc).__name__,
+        )
         raise
+
     response.headers["X-Request-ID"] = request_id
     response.headers["X-Content-Type-Options"] = "nosniff"
     response.headers["X-Frame-Options"] = "DENY"
     response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
     response.headers["Permissions-Policy"] = "camera=(), geolocation=(), microphone=()"
-    if "cache-control" not in response.headers: response.headers["Cache-Control"] = "no-store"
+    if "cache-control" not in response.headers:
+        response.headers["Cache-Control"] = "no-store"
     forwarded_proto = request.headers.get("x-forwarded-proto", "")
-    if request.url.scheme == "https" or forwarded_proto == "https": response.headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains"
+    if request.url.scheme == "https" or forwarded_proto == "https":
+        response.headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains"
+
     duration_ms = (time.perf_counter() - started) * 1000
-    record_request(request_id=request_id, method=request.method, path=request.url.path, status_code=status_code, duration_ms=duration_ms)
-    record_persistent_request(request_id=request_id, method=request.method, path=request.url.path, status_code=status_code, duration_ms=duration_ms)
+    record_request(
+        request_id=request_id,
+        method=request.method,
+        path=request.url.path,
+        status_code=status_code,
+        duration_ms=duration_ms,
+    )
+    _defer_persistent_request(
+        response,
+        request_id=request_id,
+        method=request.method,
+        path=request.url.path,
+        status_code=status_code,
+        duration_ms=duration_ms,
+    )
     return response
+
 
 # Keep CORS outside the application middleware above so early responses such as
 # rate-limit 429s still carry browser-readable CORS headers.
@@ -87,27 +165,57 @@ app.add_middleware(
     allow_headers=["Authorization", "Content-Type", "Accept", "X-Request-ID"],
 )
 
+
 def _as_utc(value: datetime) -> datetime:
-    if value.tzinfo is None: return value.replace(tzinfo=timezone.utc)
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
     return value.astimezone(timezone.utc)
 
+
 def enforce_entry_usage(request: Request, current_user: dict = Depends(get_current_user)):
-    path=request.url.path.rstrip("/"); user_id=str(current_user["_id"])
-    if request.method=="POST" and path=="/entries":
-        enforce_usage_limit(user=current_user,entitlement_name="max_entries",current_count=entries_collection.count_documents({"user_id":user_id}),resource_name="proof entries"); return
-    if request.method!="PUT" or not path.startswith("/entries/"): return
-    entry_id=path.removeprefix("/entries/")
-    if not ObjectId.is_valid(entry_id): return
-    existing_entry=entries_collection.find_one({"_id":ObjectId(entry_id),"user_id":user_id},{"created_at":1})
-    if not existing_entry: return
-    created_at=existing_entry.get("created_at")
-    if not isinstance(created_at,datetime): raise HTTPException(status_code=403,detail="This accomplishment can no longer be edited.")
-    if datetime.now(timezone.utc)-_as_utc(created_at)>=ENTRY_EDIT_WINDOW: raise HTTPException(status_code=403,detail="The 60-minute edit window for this accomplishment has ended.")
+    path = request.url.path.rstrip("/")
+    user_id = str(current_user["_id"])
+    if request.method == "POST" and path == "/entries":
+        enforce_usage_limit(
+            user=current_user,
+            entitlement_name="max_entries",
+            current_count=entries_collection.count_documents({"user_id": user_id}),
+            resource_name="proof entries",
+        )
+        return
+    if request.method != "PUT" or not path.startswith("/entries/"):
+        return
+    entry_id = path.removeprefix("/entries/")
+    if not ObjectId.is_valid(entry_id):
+        return
+    existing_entry = entries_collection.find_one(
+        {"_id": ObjectId(entry_id), "user_id": user_id},
+        {"created_at": 1},
+    )
+    if not existing_entry:
+        return
+    created_at = existing_entry.get("created_at")
+    if not isinstance(created_at, datetime):
+        raise HTTPException(status_code=403, detail="This accomplishment can no longer be edited.")
+    if datetime.now(timezone.utc) - _as_utc(created_at) >= ENTRY_EDIT_WINDOW:
+        raise HTTPException(status_code=403, detail="The 60-minute edit window for this accomplishment has ended.")
+
 
 def enforce_receipt_usage(request: Request, current_user: dict = Depends(get_current_user)):
-    path=request.url.path.rstrip("/"); is_create=request.method=="POST" and (path=="/impact-receipts" or path.startswith("/impact-receipts/from-entry/"))
-    if not is_create: return
-    user_id=str(current_user["_id"]); enforce_usage_limit(user=current_user,entitlement_name="max_impact_receipts",current_count=impact_receipts_collection.count_documents({"user_id":user_id}),resource_name="Impact Receipts")
+    path = request.url.path.rstrip("/")
+    is_create = request.method == "POST" and (
+        path == "/impact-receipts" or path.startswith("/impact-receipts/from-entry/")
+    )
+    if not is_create:
+        return
+    user_id = str(current_user["_id"])
+    enforce_usage_limit(
+        user=current_user,
+        entitlement_name="max_impact_receipts",
+        current_count=impact_receipts_collection.count_documents({"user_id": user_id}),
+        resource_name="Impact Receipts",
+    )
+
 
 app.include_router(auth_router)
 app.include_router(oauth_router)
@@ -129,14 +237,26 @@ app.include_router(resume_builder_router)
 app.include_router(ops_router)
 app.include_router(ops_user_router)
 
+
 @app.get("/")
-def root(): return {"message":"BragStack API is running"}
+def root():
+    return {"message": "BragStack API is running"}
+
+
 @app.head("/", include_in_schema=False)
-def root_head(): return None
+def root_head():
+    return None
+
+
 @app.get("/health")
-def health(): return {"status": "ok"}
+def health():
+    return {"status": "ok"}
+
+
 @app.get("/ready")
 def ready():
-    try: mongo_admin.command("ping")
-    except PyMongoError as exc: raise HTTPException(status_code=503, detail="Service is not ready") from exc
+    try:
+        mongo_admin.command("ping")
+    except PyMongoError as exc:
+        raise HTTPException(status_code=503, detail="Service is not ready") from exc
     return {"status": "ready"}

--- a/backend/tests/test_request_telemetry_background.py
+++ b/backend/tests/test_request_telemetry_background.py
@@ -1,0 +1,49 @@
+import asyncio
+
+from starlette.background import BackgroundTask, BackgroundTasks
+from starlette.responses import Response
+
+import app.main as main
+
+
+def _telemetry_kwargs():
+    return {
+        "request_id": "req-background",
+        "method": "GET",
+        "path": "/health",
+        "status_code": 200,
+        "duration_ms": 12.5,
+    }
+
+
+def test_persistent_request_is_deferred_until_background_runs(monkeypatch):
+    calls = []
+    monkeypatch.setattr(main, "record_persistent_request", lambda **kwargs: calls.append(kwargs))
+    response = Response("ok")
+
+    main._defer_persistent_request(response, **_telemetry_kwargs())
+
+    assert calls == []
+    assert isinstance(response.background, BackgroundTask)
+
+    asyncio.run(response.background())
+
+    assert calls == [_telemetry_kwargs()]
+
+
+def test_existing_background_task_is_preserved(monkeypatch):
+    order = []
+    monkeypatch.setattr(
+        main,
+        "record_persistent_request",
+        lambda **kwargs: order.append(("telemetry", kwargs["request_id"])),
+    )
+    response = Response("ok")
+    response.background = BackgroundTask(lambda: order.append(("existing", None)))
+
+    main._defer_persistent_request(response, **_telemetry_kwargs())
+
+    assert isinstance(response.background, BackgroundTasks)
+    asyncio.run(response.background())
+
+    assert order == [("existing", None), ("telemetry", "req-background")]


### PR DESCRIPTION
Addresses the highest-impact part of #211.

## Production finding
Render logs confirm `bragstack-api` is a Free web service and spins down exactly 15 minutes after the last request. Some first-request latency is therefore unavoidable on the current free compute plan.

Separately, BragStack was adding avoidable latency to **every successful request** by calling `record_persistent_request(...)` synchronously in the HTTP middleware. That function performs MongoDB index checks/inserts, so even `/` and `/health` could wait on an external database round-trip before the middleware returned the response.

## What changed
- Defer sanitized persistent request telemetry to a Starlette background task that runs after the response body is sent.
- Preserve any existing response background task(s) instead of replacing them.
- Keep in-memory request timing, correlation IDs, headers, and security behavior unchanged.
- Keep exception-path persistent telemetry synchronous so unexpected server errors are not silently lost.
- Add focused regression tests proving telemetry is deferred and existing background work is preserved.

## Intentionally unchanged
- No bcrypt cost reduction.
- No auth/rate-limit weakening.
- No paid Render upgrade.
- No 24/7 keepalive that could consume the workspace's entire free-instance-hour allowance.

## Follow-up in #211
The heavy PDF/DOCX imports identified during cold-start analysis can be lazy-loaded separately after this high-confidence request-path fix lands.

## Merge gate
Merge only if Backend CI, Frontend CI, Security CI, and any other required checks are green on the exact PR head and the PR remains current/mergeable.