### PR TITLE
Add BragStack ChatGPT/Codex skill pack

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,20 @@
+# BragStack ChatGPT Skills
+
+Reusable workflows for ChatGPT/Codex work on BragStack. These skills follow the SKILL.md pattern described by OpenAI and the Agent Skills open standard.
+
+## Skills
+
+- `ui-regression-guard` — prevents mobile/tablet/desktop layout regressions and loading-state leaks.
+- `api-contract-quality` — keeps FastAPI behavior, schemas, auth boundaries, and tests aligned.
+- `security-privacy-review` — reviews changes against BragStack's privacy, evidence, and authorization rules.
+- `product-discovery` — converts customer/product signals into evidence-backed feature decisions.
+- `career-proof-integrity` — prevents invented career claims, opaque employment scoring, and unsafe evidence exposure.
+- `release-readiness` — verifies CI, UX, observability, docs, and rollout safety before merge/release.
+
+## Usage
+
+Each skill lives in its own directory with a `SKILL.md` playbook. Install or copy the relevant skill into a ChatGPT/Codex skill surface, or use the files directly as the source of truth when working in this repository.
+
+## Design principle
+
+Keep skills small and composable. A feature PR may use several skills together: for example, `ui-regression-guard` + `security-privacy-review` + `release-readiness`.

--- a/skills/api-contract-quality/SKILL.md
+++ b/skills/api-contract-quality/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: bragstack-api-contract-quality
+description: Keep BragStack FastAPI endpoints, schemas, authorization boundaries, persistence behavior, and tests aligned as the API evolves.
+---
+
+# BragStack API Contract Quality
+
+## Use this skill when
+
+- adding or changing FastAPI routes, Pydantic models, MongoDB persistence, auth, exports, or integrations
+- fixing backend bugs
+- reviewing a backend PR
+
+## Workflow
+
+1. Define the user-visible contract first: request shape, response shape, status codes, auth requirement, ownership rule, privacy behavior, and failure modes.
+2. Trace the route through validation, authorization, persistence, serialization, and side effects. Do not validate only the happy path.
+3. Keep authentication and authorization distinct. A valid token does not imply access to another user's record.
+4. Make ownership/tenant checks explicit for every read, update, delete, export, and share operation involving private data.
+5. Use typed request/response models and avoid leaking internal MongoDB fields or implementation details.
+6. Check pagination, filtering, sorting, date boundaries, empty collections, malformed IDs, duplicates, retries, and idempotency where relevant.
+7. Add focused tests for success, validation failure, unauthenticated access, unauthorized cross-user access, missing records, and regression cases.
+8. For important APIs, consider schema/property-based tests (for example Hypothesis/Schemathesis patterns) to discover combinations hand-written tests miss.
+9. Verify OpenAPI remains coherent and that frontend assumptions still match the backend contract.
+10. Run backend CI/tests on the exact branch head before recommending merge.
+
+## Required output
+
+- contract summary
+- authorization/privacy rules checked
+- edge cases covered
+- tests added or updated
+- compatibility concerns
+- CI/test result
+
+## Final checks
+
+- no cross-user data exposure
+- no invented/default values that alter user evidence
+- consistent error semantics
+- stable response shapes
+- tests reproduce the bug or contract change

--- a/skills/career-proof-integrity/SKILL.md
+++ b/skills/career-proof-integrity/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: bragstack-career-proof-integrity
+description: Preserve factual, user-controlled career evidence when generating summaries, packets, recommendations, and AI-assisted content in BragStack.
+---
+
+# BragStack Career-Proof Integrity
+
+## Use this skill when
+
+- generating résumé bullets, reports, packets, summaries, interview prep, promotion material, certification material, or AI-assisted career content
+- changing evidence, confirmation, trust, or public-profile behavior
+
+## Workflow
+
+1. Treat user-entered evidence as the factual source of truth. Never invent metrics, dates, scope, titles, outcomes, skills, confirmations, or third-party endorsements.
+2. Distinguish clearly between what the user did, what changed, what is supported by evidence, and what has been independently confirmed.
+3. Preserve shared credit. Do not rewrite team outcomes as sole individual ownership unless the evidence explicitly supports that claim.
+4. When information is missing, ask for it or mark the gap. Do not fill a gap with a plausible guess.
+5. Keep private evidence references out of public profiles, exports, and shared packets unless the user explicitly includes them.
+6. Avoid opaque employment-decision scoring. BragStack may surface completeness, missing evidence, or preparation gaps, but must not present an unexplained hiring/promotion verdict as fact.
+7. Make transformations traceable: generated bullets or summaries should remain derivable from stored accomplishment/result/evidence fields.
+8. When compressing text, preserve qualifiers and uncertainty rather than upgrading claims.
+9. For public/share surfaces, re-check every field against visibility and user intent.
+10. Add regression tests for any bug that could inflate, fabricate, expose, or misattribute career proof.
+
+## Required output
+
+- source facts used
+- transformations made
+- evidence/confirmation status preserved
+- gaps or unsupported claims removed
+- privacy/share checks
+
+## Final checks
+
+- no invented claims
+- no accidental sole-credit inflation
+- no private evidence leakage
+- no opaque employment decision score
+- output can be traced back to user-controlled source data

--- a/skills/product-discovery/SKILL.md
+++ b/skills/product-discovery/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: bragstack-product-discovery
+description: Turn BragStack customer signals, analytics, bugs, and product ideas into evidence-backed improvements and small testable feature bets.
+---
+
+# BragStack Product Discovery
+
+## Use this skill when
+
+- considering a new feature
+- prioritizing roadmap work
+- responding to repeated support/UX problems
+- reviewing PostHog or customer feedback
+
+## Workflow
+
+1. State the user problem before proposing a solution. Identify who experiences it, when, and what they are trying to accomplish.
+2. Gather evidence from actual signals available: support reports, analytics, user feedback, failed flows, search behavior, drop-off, existing issues, and product constraints.
+3. Separate problem evidence from solution enthusiasm. Do not treat a requested feature as proof that the proposed implementation is right.
+4. Define the desired outcome and a measurable success signal. Prefer activation, completion, retention, time-to-value, evidence quality, or reduced failure/support burden over vanity metrics.
+5. Generate at least two solution shapes: a small/low-cost improvement and a broader bet. Reuse existing BragStack primitives before inventing parallel systems.
+6. Check the proposal against BragStack's trust principles: user control, private-by-default evidence, shared credit, explicit verification, no surveillance, and no invented employment claims.
+7. Design the smallest reversible experiment that can validate the riskiest assumption.
+8. Specify instrumentation before launch: entry point, completion event, failure event, abandonment point, and a privacy-safe property set.
+9. Define rollout/rollback criteria and what would cause the idea to be stopped or reshaped.
+10. Convert validated work into an implementation issue with problem, scope, acceptance criteria, metrics, risks, and non-goals.
+
+## Required output
+
+- problem statement
+- evidence/signals
+- target outcome and metric
+- smallest viable improvement
+- optional larger feature bet
+- instrumentation plan
+- risks/non-goals
+- recommendation: do now, test, later, or reject
+
+## Final checks
+
+- problem is real enough to justify work
+- success is measurable
+- feature does not duplicate an existing BragStack primitive
+- privacy/trust model remains intact
+- experiment is reversible where practical

--- a/skills/release-readiness/SKILL.md
+++ b/skills/release-readiness/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: bragstack-release-readiness
+description: Verify BragStack changes are safe to merge and release across CI, UX, security, observability, documentation, and rollback concerns.
+---
+
+# BragStack Release Readiness
+
+## Use this skill when
+
+- preparing a PR for merge
+- releasing user-facing, security, reliability, billing, auth, or operational changes
+- deciding whether a fix is actually done
+
+## Workflow
+
+1. Confirm the exact PR head SHA and ensure reviews/tests refer to that revision.
+2. Verify required CI on that head: backend, frontend, security, and any feature-specific workflow.
+3. Apply the relevant BragStack skills for the changed area: UI regression, API contract, security/privacy, and career-proof integrity.
+4. Test the changed user journey end-to-end, including loading, empty, error, retry, and success states.
+5. Check responsive behavior for user-facing UI and verify no known high-severity accessibility regression.
+6. Confirm migrations/index changes are safe and backward-compatible where applicable. Avoid deployments that require fragile manual ordering unless documented.
+7. Verify observability exists for meaningful new failure modes: structured logs, analytics events, health checks, or alerts as appropriate, without logging sensitive evidence.
+8. Confirm rollout and rollback paths. Feature flags or staged rollout are preferred for higher-risk behavior.
+9. Update user-facing/repository documentation and changelog when the change is notable.
+10. Merge only when the branch is current, mergeable, required checks are green, and no unresolved blocker remains.
+
+## Required output
+
+- PR/head SHA
+- CI status
+- journey/viewport checks
+- security/privacy status
+- observability/rollback status
+- docs/changelog status
+- merge recommendation with blockers, if any
+
+## Final checks
+
+- exact head is green
+- no known blocker hidden behind "works on my machine"
+- production failure states are intentional
+- rollback is understood
+- notable changes are documented

--- a/skills/security-privacy-review/SKILL.md
+++ b/skills/security-privacy-review/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: bragstack-security-privacy-review
+description: Review BragStack changes for application-security, authorization, privacy, evidence-sharing, and data-minimization risks.
+---
+
+# BragStack Security & Privacy Review
+
+## Use this skill when
+
+- touching authentication, authorization, sharing, public profiles, exports, billing, integrations, uploads, evidence, admin/team features, or secrets
+- reviewing a release candidate or security-sensitive PR
+
+## Workflow
+
+1. Identify assets and trust boundaries: account identity, private accomplishments, evidence metadata, shared credit, confirmations, public profile data, billing state, and organization data.
+2. Trace who can create, read, update, delete, export, share, and discover each affected object.
+3. Test horizontal access control explicitly: one user must not access another user's private object by changing an ID or slug.
+4. Test vertical access control for plan/admin/team/enterprise capabilities. UI hiding is never sufficient authorization.
+5. Review input handling, redirects, URLs, uploads, rendered text, and exported documents for injection or unsafe content behavior.
+6. Keep secrets out of client bundles, logs, screenshots, fixtures, analytics payloads, and error responses.
+7. Apply data minimization: public/share/export surfaces should include only fields required for that purpose. Private evidence stays private unless the user explicitly includes it.
+8. Review retention, expiration, revocation, and audit needs for share links and organization workflows.
+9. Check dependencies and CI security scans, but do not treat dependency scanning as a substitute for authorization and privacy tests.
+10. Document residual risk and block merge for credible cross-user exposure, secret leakage, unsafe sharing defaults, or privilege bypass.
+
+## Required output
+
+- assets/trust boundaries reviewed
+- authorization tests performed
+- privacy/data-minimization findings
+- secret/logging findings
+- fixes required before merge
+- residual risk
+
+## Final checks
+
+- private by default
+- explicit user intent before sharing/importing sensitive evidence
+- no cross-user access
+- no client-side-only entitlement enforcement
+- exports and analytics omit unnecessary sensitive data

--- a/skills/ui-regression-guard/SKILL.md
+++ b/skills/ui-regression-guard/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: bragstack-ui-regression-guard
+description: Prevent BragStack UI regressions across mobile, tablet, desktop, loading, error, and authenticated states before merge.
+---
+
+# BragStack UI Regression Guard
+
+## Use this skill when
+
+- changing React components, CSS, routing, navigation, forms, dashboards, auth screens, loading states, or responsive layouts
+- fixing a visual bug
+- preparing a frontend PR for merge
+
+## Required inputs
+
+- changed frontend files or PR diff
+- affected routes/components
+- available test/build commands
+
+## Workflow
+
+1. Identify every affected user state: signed out, signing in, loading, empty, populated, error, and signed in.
+2. Check responsive behavior at minimum at narrow phone, large phone, tablet portrait, tablet landscape, laptop, and wide desktop widths.
+3. Assert that no horizontal page overflow exists unless intentionally designed. Pay special attention to fixed widths, min-width, tables, dialogs, cards, sidebars, and long text.
+4. Verify BragStack-owned loading/error UI is shown instead of hosting-provider or raw infrastructure pages whenever the app can control the experience.
+5. Test navigation, focus order, keyboard access, labels, contrast-sensitive states, reduced-motion behavior where relevant, and meaningful empty/error copy.
+6. Prefer resilient layout primitives: flexible grids, wrapping, max-width containers, minmax(), overflow handling, and content-driven sizing over breakpoint-specific hacks.
+7. Add or update automated coverage. Prefer Playwright for route-level behavior and screenshots; use component tests for isolated UI logic.
+8. For visually important routes, capture deterministic screenshots at representative mobile/tablet/desktop viewports and fail CI on unexpected diffs after baselines are approved.
+9. Run lint, production build, and relevant tests on the exact branch head.
+10. Do not approve merge if the bug is fixed at one viewport by breaking another.
+
+## Required output
+
+Report:
+
+- affected routes/states
+- viewport matrix tested
+- overflow/accessibility findings
+- automated tests added or updated
+- build/test results
+- remaining visual risk, if any
+
+## Final checks
+
+- no clipped content on the right edge
+- no accidental horizontal scroll
+- no provider-branded loading/error screen in controllable app flows
+- touch targets remain usable
+- loading, empty, error, and success states all render intentionally
+- screenshots are stable and contain no secrets or user-specific data


### PR DESCRIPTION
## Summary

Adds a small, composable BragStack-specific ChatGPT/Codex skill pack derived from research through the `sindresorhus/awesome` ecosystem and tailored to BragStack's current product/engineering risks.

### Skills added

- `ui-regression-guard` — responsive viewport, overflow, loading/error state, accessibility, Playwright screenshot regression guidance
- `api-contract-quality` — FastAPI contracts, auth vs authorization, edge cases, schema/property testing
- `security-privacy-review` — privacy boundaries, cross-user access, entitlements, sharing, secret/data-minimization checks
- `product-discovery` — evidence-backed product bets, measurable outcomes, experiments, instrumentation
- `career-proof-integrity` — no invented career claims, preserve shared credit/confirmation semantics, prevent private evidence leakage
- `release-readiness` — exact-head CI, UX/security checks, observability, rollback, docs/changelog readiness

Also adds `skills/README.md` as the skill catalog and usage guide.

## Why

BragStack is growing across user-facing packets, public/private career proof, billing/entitlements, integrations, and responsive surfaces. These skills make recurring quality standards explicit and reusable instead of relying on one-off prompts.

The first practical target is preventing the recurring mobile/tablet clipping and loading-state regressions with a future Playwright visual-regression CI gate.

## Scope

Documentation/agent workflow only. This PR does not change production runtime behavior.