### PR TITLE
Fix mobile interview controls and OAuth wait feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ This changelog tracks **merged, shipped repository changes only**. Open or draft
 
 ## [Unreleased]
 
-No merged changes have been recorded here yet.
+### Fixed
+- Kept the mobile Practice Interview camera and replay controls inside equal-width buttons, moved the self-view clear of the controls, and added honest progress feedback while the low-cost Render API wakes for OAuth sign-in. (#219)
 
 ## 2026-08-27
 

--- a/frontend/src/AuthPage.css
+++ b/frontend/src/AuthPage.css
@@ -15,6 +15,7 @@
 .auth-card h2 { margin:8px 0; font-size:2rem; letter-spacing:-.05em; }
 .auth-muted { margin:0 auto 24px; color:#94a3b8; line-height:1.6; }
 .auth-oauth-grid { display:grid; gap:10px; margin-bottom:18px; }
+.auth-oauth-status { margin:2px 4px 0; color:#9fb0ca; font-size:.78rem; line-height:1.45; text-align:center; }
 .auth-oauth-button { min-height:50px; display:flex; align-items:center; justify-content:center; gap:11px; border-radius:16px; border:1px solid transparent; font-weight:900; cursor:pointer; transition:transform 150ms ease,box-shadow 150ms ease,border-color 150ms ease,background 150ms ease; }
 .auth-oauth-button:hover:not(:disabled){transform:translateY(-1px)} .auth-oauth-button:disabled{cursor:wait;opacity:.72}
 .auth-oauth-google{background:#fff;color:#202124;border-color:#dadce0;box-shadow:0 8px 24px rgba(0,0,0,.16)} .auth-oauth-google:hover:not(:disabled){background:#f8f9fa;border-color:#c7c9cc;box-shadow:0 10px 28px rgba(66,133,244,.18)}

--- a/frontend/src/AuthPage.jsx
+++ b/frontend/src/AuthPage.jsx
@@ -62,6 +62,7 @@ function AuthPage({ mode = "login", onLogin }) {
   const [isSlowSubmit, setIsSlowSubmit] = useState(false);
   const [errorMessage, setErrorMessage] = useState("");
   const [connectingProvider, setConnectingProvider] = useState("");
+  const [oauthIsTakingLonger, setOauthIsTakingLonger] = useState(false);
   const [showReset, setShowReset] = useState(Boolean(initialResetToken));
   const [resetEmail, setResetEmail] = useState("");
   const [resetMessage, setResetMessage] = useState("");
@@ -209,7 +210,10 @@ function AuthPage({ mode = "login", onLogin }) {
 
   async function startOAuth(provider) {
     setConnectingProvider(provider);
+    setOauthIsTakingLonger(false);
     setErrorMessage("");
+
+    const slowTimer = window.setTimeout(() => setOauthIsTakingLonger(true), 4000);
 
     try {
       const ready = await ensureApiReady();
@@ -218,6 +222,9 @@ function AuthPage({ mode = "login", onLogin }) {
     } catch (error) {
       setErrorMessage(error.message || `Could not connect to ${provider}. Please try again.`);
       setConnectingProvider("");
+      setOauthIsTakingLonger(false);
+    } finally {
+      window.clearTimeout(slowTimer);
     }
   }
 
@@ -425,6 +432,11 @@ function AuthPage({ mode = "login", onLogin }) {
               <GitHubMark />
               <span>{connectingProvider === "github" ? "Connecting to GitHub..." : "Continue with GitHub"}</span>
             </button>
+            {connectingProvider && oauthIsTakingLonger && (
+              <p className="auth-oauth-status" role="status">
+                BragStack is waking up. This can take about a minute on the current low-cost server.
+              </p>
+            )}
           </div>
 
           <p className="auth-switch">

--- a/frontend/src/InterviewReferenceLayout.css
+++ b/frontend/src/InterviewReferenceLayout.css
@@ -236,9 +236,33 @@
   .interview-room-header .interview-end-button svg{margin:0;}
   .interview-room-grid{border-radius:0 0 18px 18px;}
   .interview-video-stage{aspect-ratio:4/3!important;min-height:0!important;}
-  .candidate-video-tile{right:12px!important;width:112px!important;max-width:30%!important;}
-  .interview-video-stage .video-controls{bottom:12px!important;gap:6px!important;}
-  .interview-video-stage .video-controls button{padding:7px 8px!important;}
+  .candidate-video-tile{
+    right:12px!important;
+    top:12px!important;
+    bottom:auto!important;
+    width:112px!important;
+    max-width:32%!important;
+    transform:none!important;
+  }
+  .interview-video-stage .video-controls{
+    left:12px!important;
+    right:12px!important;
+    bottom:12px!important;
+    width:auto!important;
+    transform:none!important;
+    display:grid!important;
+    grid-template-columns:minmax(0,1fr) minmax(0,1fr)!important;
+    gap:6px!important;
+  }
+  .interview-video-stage .video-controls button{
+    width:100%!important;
+    min-width:0!important;
+    padding:7px 6px!important;
+    overflow:hidden;
+    white-space:nowrap!important;
+    font-size:clamp(.66rem,3vw,.75rem)!important;
+  }
+  .interview-video-stage .video-controls button svg{flex:0 0 auto;}
   .aj-avatar-monogram{width:88px!important;height:88px!important;font-size:1.4rem!important;}
   .interview-answer-panel{padding:17px 16px 20px!important;}
   .answer-form textarea{min-height:88px!important;}


### PR DESCRIPTION
Closes #219

## What changed
- move the candidate self-view to the upper-right on phone layouts
- anchor camera/replay controls into an equal-width two-column row
- contain labels within their buttons at narrow widths
- explain Render cold-start waits after four seconds during OAuth
- add the unreleased changelog entry

## Verification
- `npm run build` ✅
- `npm run lint` ✅ (0 errors; existing warnings only)
- `npm run test:layout` could not execute locally because Chrome/Chromium is not installed; Frontend CI will run the browser guard on the exact PR head