### PR TITLE
Instrument BragStack lifecycle events in PostHog

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,13 @@ JWT_SECRET=replace-with-a-long-random-secret
 ACCESS_TOKEN_EXPIRE_MINUTES=1440
 FRONTEND_URL=http://localhost:5173
 
+# Privacy-safe product analytics
+# Project tokens are write-only identifiers, but keep production configuration in the host.
+POSTHOG_PROJECT_API_KEY=replace-with-posthog-project-token
+POSTHOG_HOST=https://us.i.posthog.com
+VITE_POSTHOG_KEY=replace-with-posthog-project-token
+VITE_POSTHOG_HOST=https://us.i.posthog.com
+
 # API abuse protection
 RATE_LIMIT_ENABLED=true
 RATE_LIMIT_FAIL_OPEN=true

--- a/backend/app/auth_routes.py
+++ b/backend/app/auth_routes.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel, EmailStr, Field, field_validator
 from app.auth import create_access_token, get_current_user, hash_password, serialize_user, verify_password
 from app.database import users_collection
 from app.email_templates import build_email_verification_html, build_password_reset_html
+from app.product_analytics import EVENT_USER_SIGNED_UP, capture_product_event
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 FRONTEND_URL = os.getenv("FRONTEND_URL", "http://localhost:5173").rstrip("/")
@@ -151,6 +152,12 @@ async def register_user(payload: RegisterRequest):
     }
     result = users_collection.insert_one(doc)
     user = users_collection.find_one({"_id": result.inserted_id})
+    capture_product_event(
+        str(result.inserted_id),
+        EVENT_USER_SIGNED_UP,
+        source="web",
+        current_plan="free",
+    )
     raw, _ = _issue_verification_token(user)
     try:
         await _send_verification_email(email, f"{FRONTEND_URL}/login#verify_token={raw}")

--- a/backend/app/billing_routes.py
+++ b/backend/app/billing_routes.py
@@ -13,6 +13,7 @@ from pymongo.errors import DuplicateKeyError
 from app.auth import get_current_user
 from app.database import stripe_webhook_events_collection, users_collection
 from app.plans import get_plan_for_user
+from app.product_analytics import EVENT_PLAN_UPGRADED, capture_product_event
 
 router = APIRouter(prefix="/billing", tags=["billing"])
 
@@ -369,9 +370,13 @@ async def stripe_webhook(request: Request):
     obj = ((event.get("data") or {}).get("object") or {})
 
     try:
+        upgraded_user_id = None
+        upgraded_subscription_id = None
         if event_type == "checkout.session.completed":
             user_id = obj.get("client_reference_id") or (obj.get("metadata") or {}).get("user_id")
             if user_id:
+                prior_user = users_collection.find_one({"_id": ObjectId(str(user_id))}) if ObjectId.is_valid(str(user_id)) else None
+                was_pro = bool(prior_user and get_plan_for_user(prior_user) == "pro")
                 _set_subscription_state(
                     str(user_id),
                     plan="pro",
@@ -380,10 +385,15 @@ async def stripe_webhook(request: Request):
                     subscription_id=obj.get("subscription"),
                     stripe_event_created=event_created,
                 )
+                if not was_pro:
+                    upgraded_user_id = str(user_id)
+                    upgraded_subscription_id = obj.get("subscription")
 
         elif event_type in {"customer.subscription.created", "customer.subscription.updated"}:
             user_id = _user_id_from_subscription(obj)
             if user_id:
+                prior_user = users_collection.find_one({"_id": ObjectId(user_id)}) if ObjectId.is_valid(user_id) else None
+                was_pro = bool(prior_user and get_plan_for_user(prior_user) == "pro")
                 stripe_status = str(obj.get("status") or "unknown")
                 paid = stripe_status in {"active", "trialing"}
                 _set_subscription_state(
@@ -396,6 +406,9 @@ async def stripe_webhook(request: Request):
                     current_period_end=obj.get("current_period_end"),
                     stripe_event_created=event_created,
                 )
+                if paid and not was_pro:
+                    upgraded_user_id = user_id
+                    upgraded_subscription_id = obj.get("id")
 
         elif event_type == "customer.subscription.deleted":
             user_id = _user_id_from_subscription(obj)
@@ -434,6 +447,17 @@ async def stripe_webhook(request: Request):
                     subscription_id=obj.get("subscription"),
                     stripe_event_created=event_created,
                 )
+
+        if upgraded_user_id:
+            capture_product_event(
+                upgraded_user_id,
+                EVENT_PLAN_UPGRADED,
+                source="stripe_webhook",
+                current_plan="pro",
+                stripe_event_id=event_id,
+                stripe_event_type=event_type,
+                subscription_id=upgraded_subscription_id,
+            )
 
         _mark_stripe_event_processed(event_id)
     except Exception:

--- a/backend/app/impact_receipt_routes.py
+++ b/backend/app/impact_receipt_routes.py
@@ -11,6 +11,7 @@ from app.models import (
     ImpactReceiptResponse,
     ImpactReceiptUpdate,
 )
+from app.product_analytics import EVENT_IMPACT_RECEIPT_CREATED, capture_product_event
 
 
 router = APIRouter(
@@ -203,6 +204,15 @@ def create_impact_receipt(
     )
 
     insert_result = impact_receipts_collection.insert_one(receipt_document)
+    capture_product_event(
+        str(current_user["_id"]),
+        EVENT_IMPACT_RECEIPT_CREATED,
+        source="web",
+        current_plan=current_user.get("plan", "free"),
+        impact_receipt_id=str(insert_result.inserted_id),
+        is_public=receipt_document["is_public"],
+        schema_version=receipt_document["schema_version"],
+    )
     created_receipt = impact_receipts_collection.find_one(
         {"_id": insert_result.inserted_id}
     )
@@ -314,6 +324,16 @@ def create_impact_receipt_from_entry(
     )
 
     insert_result = impact_receipts_collection.insert_one(receipt_document)
+    capture_product_event(
+        user_id,
+        EVENT_IMPACT_RECEIPT_CREATED,
+        source="web",
+        current_plan=current_user.get("plan", "free"),
+        impact_receipt_id=str(insert_result.inserted_id),
+        source_brag_id=entry_id,
+        is_public=receipt_document["is_public"],
+        schema_version=receipt_document["schema_version"],
+    )
 
     created_receipt = impact_receipts_collection.find_one(
         {"_id": insert_result.inserted_id}

--- a/backend/app/oauth_routes.py
+++ b/backend/app/oauth_routes.py
@@ -10,6 +10,7 @@ from fastapi.responses import RedirectResponse
 
 from app.auth import create_access_token
 from app.database import users_collection
+from app.product_analytics import EVENT_USER_SIGNED_UP, capture_product_event
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 
@@ -115,6 +116,12 @@ def _find_or_create_oauth_user(
         "created_at": datetime.now(timezone.utc).isoformat(),
     }
     result = users_collection.insert_one(user_doc)
+    capture_product_event(
+        str(result.inserted_id),
+        EVENT_USER_SIGNED_UP,
+        source="web",
+        current_plan="free",
+    )
     return users_collection.find_one({"_id": result.inserted_id})
 
 

--- a/backend/app/product_analytics.py
+++ b/backend/app/product_analytics.py
@@ -1,0 +1,66 @@
+"""Privacy-safe, best-effort product analytics.
+
+Product behavior must never fail because analytics is unavailable. The PostHog
+client batches delivery in the background, while this module keeps the event
+contract and allowed properties in one reviewable place.
+"""
+
+from functools import lru_cache
+import logging
+import os
+
+
+logger = logging.getLogger(__name__)
+
+EVENT_USER_SIGNED_UP = "user_signed_up"
+EVENT_BRAG_CREATED = "brag_created"
+EVENT_IMPACT_RECEIPT_CREATED = "impact_receipt_created"
+EVENT_PLAN_UPGRADED = "plan_upgraded"
+
+_ALLOWED_PROPERTIES = {
+    "source",
+    "current_plan",
+    "brag_id",
+    "impact_receipt_id",
+    "source_brag_id",
+    "is_public",
+    "schema_version",
+    "stripe_event_id",
+    "stripe_event_type",
+    "subscription_id",
+}
+
+
+@lru_cache(maxsize=1)
+def _client():
+    api_key = os.getenv("POSTHOG_PROJECT_API_KEY", "").strip()
+    if not api_key:
+        return None
+
+    from posthog import Posthog
+
+    return Posthog(
+        api_key,
+        host=os.getenv("POSTHOG_HOST", "https://us.i.posthog.com").rstrip("/"),
+    )
+
+
+def capture_product_event(distinct_id: str, event: str, **properties) -> None:
+    """Queue an allow-listed lifecycle event without affecting the request."""
+    client = _client()
+    if client is None:
+        return
+
+    safe_properties = {
+        key: value
+        for key, value in properties.items()
+        if key in _ALLOWED_PROPERTIES and value is not None
+    }
+    try:
+        client.capture(
+            event,
+            distinct_id=str(distinct_id),
+            properties=safe_properties,
+        )
+    except Exception:
+        logger.warning("PostHog capture failed for %s", event, exc_info=True)

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -7,6 +7,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from app.auth import get_current_user
 from app.database import entries_collection
 from app.models import BragEntryCreate
+from app.product_analytics import EVENT_BRAG_CREATED, capture_product_event
 
 router = APIRouter(prefix="/entries", tags=["entries"])
 public_router = APIRouter(prefix="/public", tags=["public"])
@@ -79,6 +80,15 @@ def create_entry(
     document["user_id"] = get_user_id(current_user)
 
     result = entries_collection.insert_one(document)
+
+    capture_product_event(
+        get_user_id(current_user),
+        EVENT_BRAG_CREATED,
+        source="web",
+        current_plan=current_user.get("plan", "free"),
+        brag_id=str(result.inserted_id),
+        is_public=bool(document.get("is_public", False)),
+    )
 
     created_entry = entries_collection.find_one({"_id": result.inserted_id})
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -14,3 +14,4 @@ reportlab==4.4.3
 pypdf==6.15.0
 PyMuPDF>=1.24,<2
 python-docx==1.2.0
+posthog>=7,<8

--- a/backend/tests/test_product_analytics.py
+++ b/backend/tests/test_product_analytics.py
@@ -1,0 +1,45 @@
+import asyncio
+
+from bson import ObjectId
+import mongomock
+
+import app.auth_routes as auth_routes
+import app.impact_receipt_routes as receipt_routes
+import app.routes as entry_routes
+from app.models import BragEntryCreate
+
+
+def test_signup_capture_uses_internal_id_and_privacy_safe_properties(monkeypatch):
+    users = mongomock.MongoClient().db.users
+    captured = []
+    monkeypatch.setattr(auth_routes, "users_collection", users)
+    monkeypatch.setattr(auth_routes, "capture_product_event", lambda *args, **kwargs: captured.append((args, kwargs)))
+    monkeypatch.setattr(auth_routes, "hash_password", lambda value: "hash")
+
+    payload = auth_routes.RegisterRequest(name="Tee", email="tee@example.com", password="password1")
+    async def ignore_email(email, url):
+        return None
+    monkeypatch.setattr(auth_routes, "_send_verification_email", ignore_email)
+
+    asyncio.run(auth_routes.register_user(payload))
+
+    args, properties = captured[0]
+    created = users.find_one({"email": "tee@example.com"})
+    assert args == (str(created["_id"]), auth_routes.EVENT_USER_SIGNED_UP)
+    assert "email" not in properties
+    assert properties == {"source": "web", "current_plan": "free"}
+
+
+def test_entry_capture_happens_after_insert(monkeypatch):
+    entries = mongomock.MongoClient().db.entries
+    captured = []
+    monkeypatch.setattr(entry_routes, "entries_collection", entries)
+    monkeypatch.setattr(entry_routes, "capture_product_event", lambda *args, **kwargs: captured.append((args, kwargs)))
+    user = {"_id": ObjectId(), "plan": "free"}
+    payload = BragEntryCreate(title="Fixed deploy", category="Reliability", entry_date="2026-08-28", entry_type="Current Job", situation="Failure", action="Diagnosed it", impact="Restored service", lesson="Add alert", tags=["Docker"], is_public=False)
+
+    created = entry_routes.create_entry(payload, user)
+
+    assert captured[0][0][1] == entry_routes.EVENT_BRAG_CREATED
+    assert captured[0][1]["brag_id"] == created["id"]
+    assert "title" not in captured[0][1]

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "axios": "^1.16.1",
         "lucide-react": "^1.16.0",
+        "posthog-js": "^1.264.1",
         "react": "^19.2.6",
         "react-dom": "^19.2.6"
       },
@@ -519,6 +520,31 @@
         "url": "https://github.com/sponsors/Boshen"
       }
     },
+    "node_modules/@posthog/browser-common": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@posthog/browser-common/-/browser-common-0.6.2.tgz",
+      "integrity": "sha512-AZRETXzMXoCqNLGftKN7wtyhI+Da8y3WSYLrVzCyd7CSA2pIas1OjT4wsO3ncvX+Ezg0FJw5iSr84VtyVUcZ0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/core": "^1.49.1",
+        "@posthog/types": "^1.407.1"
+      }
+    },
+    "node_modules/@posthog/core": {
+      "version": "1.49.2",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.49.2.tgz",
+      "integrity": "sha512-AXHDo/4nisUg7OPG1TQNgREK7n+chBQXLQyttp7bDTDsDg2k9lV06TmnpvuNbwJs53q9mP9hjezKEZu4fYadfg==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/types": "^1.407.1"
+      }
+    },
+    "node_modules/@posthog/types": {
+      "version": "1.407.1",
+      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.407.1.tgz",
+      "integrity": "sha512-WhbkXPC2rgylXqmxHqv70ffI3k+KxyR6s7DBIfr5NvIqHkxp6v0pk31D/jbz0DNVbzwkLjyll2pxr4FNbJiYzg==",
+      "license": "MIT"
+    },
     "node_modules/@rolldown/binding-android-arm-eabi": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm-eabi/-/binding-android-arm-eabi-1.2.5.tgz",
@@ -806,7 +832,7 @@
       "version": "19.2.15",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.15.tgz",
       "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -821,6 +847,13 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "6.0.2",
@@ -1041,6 +1074,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/core-js": {
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.50.0.tgz",
+      "integrity": "sha512-BRWgOLKkFeCgRudR6zrs8p9XJZcE14grzKMMssoYrk6krtuEZ7MTKPIY5RzOnqsEKIR9kst7wNzphttraT+Yqw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -1060,7 +1107,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -1104,6 +1151,15 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.14",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.14.tgz",
+      "integrity": "sha512-dVoH9z+MY+C9IilgGCk3YfFqjLi3fChm2OiKJMzh6axrJ5qwxqWaZamgmHrpv22CN/KdbZJuGEGgfQoL00LTdg==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/dunder-proto": {
@@ -1415,6 +1471,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.9.tgz",
+      "integrity": "sha512-zdxgIEddhfsyCaWpJ2SdXEP8ZMrKJ6+5jl4OupODcywU0IhRk6gdXuVGcPICyfx2H97hVK7xmJtRLPjkxAX8Vw==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -2312,6 +2374,54 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/posthog-js": {
+      "version": "1.422.4",
+      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.422.4.tgz",
+      "integrity": "sha512-D+Ea66uj763KXn0Qx2I1bmOhkh0eyOA22R+gI511GcHtgdHMws7JGEVaqv4c9ONSX8NlUDk3ex7rA2kOD6DDtQ==",
+      "license": "(Apache-2.0 AND MIT)",
+      "dependencies": {
+        "@posthog/browser-common": "^0.6.2",
+        "@posthog/core": "^1.49.2",
+        "@posthog/types": "^1.407.1",
+        "core-js": "^3.49.0",
+        "dompurify": "^3.4.13",
+        "fflate": "^0.4.8",
+        "preact": "^10.29.3",
+        "query-selector-shadow-dom": "^1.0.1",
+        "web-vitals": "^5.3.0",
+        "web-vitals-soft-navs": "npm:web-vitals@6.0.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8.0",
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.29.8",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.8.tgz",
+      "integrity": "sha512-ej2aVZ+vZ8WO7tvlQWRM9N63A0KzF9q4mWJfDUHgYaIofWY9hu74QdnQrjoPMmZi2/nZ5gN0bJCQF49xQqx09Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      },
+      "peerDependencies": {
+        "preact-render-to-string": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "preact-render-to-string": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -2340,6 +2450,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/query-selector-shadow-dom": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/query-selector-shadow-dom/-/query-selector-shadow-dom-1.0.1.tgz",
+      "integrity": "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==",
+      "license": "MIT"
     },
     "node_modules/react": {
       "version": "19.2.6",
@@ -2593,6 +2709,19 @@
           "optional": true
         }
       }
+    },
+    "node_modules/web-vitals": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.3.0.tgz",
+      "integrity": "sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/web-vitals-soft-navs": {
+      "name": "web-vitals",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-6.0.0.tgz",
+      "integrity": "sha512-Guaibvy/+uNtL6Bsu4jmMJGzuSl91oeRH5iO9pPRbYftnFUr3yqT1TUNX/OE4o9HexuEMU3Kb/Wg7iKhlffZUA==",
+      "license": "Apache-2.0"
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "axios": "^1.16.1",
     "lucide-react": "^1.16.0",
+    "posthog-js": "^1.264.1",
     "react": "^19.2.6",
     "react-dom": "^19.2.6"
   },

--- a/frontend/src/AppSidebar.jsx
+++ b/frontend/src/AppSidebar.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { BarChart3, BrainCircuit, FileCheck2, FileText, GraduationCap, Home, ListChecks, LogOut, Menu, ReceiptText, Settings, ShieldCheck, Sparkles, Target, TrendingUp, UserRound, Users, Video, X } from "lucide-react";
 import { getCurrentUser } from "./api";
+import { resetAnalyticsUser } from "./analytics.js";
 import "./AppShell.css";
 
 const WORKSPACE_ITEMS = [
@@ -23,7 +24,7 @@ function AppSidebar() {
   const [user, setUser] = useState(null); const [mobileOpen, setMobileOpen] = useState(false);
   const path = window.location.pathname; const search = window.location.search;
   useEffect(() => { let mounted = true; (async () => { try { const data = await getCurrentUser(); if (mounted) setUser(data); } catch (error) { if (error.response?.status === 401) { localStorage.removeItem("bragstack_token"); window.location.assign("/login"); } } })(); return () => { mounted = false; }; }, []);
-  function logout() { localStorage.removeItem("bragstack_token"); window.location.assign("/login"); }
+  function logout() { void resetAnalyticsUser(); localStorage.removeItem("bragstack_token"); window.location.assign("/login"); }
   function proToolIsActive(href) { const target = new URL(href, window.location.origin); return path === target.pathname && search === target.search; }
   const isPro = Boolean(user?.entitlements?.advanced_reports);
   const isCompanyUser = user?.email?.trim().toLowerCase().endsWith("@usebragstack.com") === true;

--- a/frontend/src/analytics.js
+++ b/frontend/src/analytics.js
@@ -1,4 +1,35 @@
 const GA_MEASUREMENT_ID = "G-MKGEER9N5C";
+let posthogClientPromise;
+
+async function getPostHogClient() {
+  const apiKey = import.meta.env.VITE_POSTHOG_KEY;
+  if (!apiKey) return window.posthog || null;
+  if (!posthogClientPromise) {
+    posthogClientPromise = import("posthog-js").then(({ default: posthog }) => {
+      if (!window.__bragstackPostHogInitialized) {
+        posthog.init(apiKey, {
+          api_host: import.meta.env.VITE_POSTHOG_HOST || "https://us.i.posthog.com",
+          person_profiles: "identified_only",
+          capture_pageview: true,
+        });
+        window.__bragstackPostHogInitialized = true;
+      }
+      return posthog;
+    });
+  }
+  return posthogClientPromise;
+}
+
+export async function identifyAnalyticsUser(user) {
+  if (!user?.id) return;
+  const posthog = await getPostHogClient();
+  posthog?.identify(String(user.id), { current_plan: user.plan || "free" });
+}
+
+export async function resetAnalyticsUser() {
+  const posthog = await getPostHogClient();
+  posthog?.reset();
+}
 
 export function initializeAnalytics() {
   if (typeof window === "undefined" || typeof document === "undefined") return;
@@ -18,6 +49,7 @@ export function initializeAnalytics() {
   script.src = `https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`;
   script.dataset.bragstackAnalytics = "true";
   document.head.appendChild(script);
+  void getPostHogClient();
 }
 
 export { GA_MEASUREMENT_ID };

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,6 +1,7 @@
 import axios from "axios";
 
 import { normalizeDashboardTags } from "./dashboardTags.js";
+import { identifyAnalyticsUser } from "./analytics.js";
 
 function getDefaultApiBaseUrl() {
   if (window.location.hostname.endsWith(".app.github.dev")) return "/api";
@@ -114,7 +115,11 @@ export async function loginUser(credentials) {
   const response = await api.post("/auth/login", formData, { headers: { "Content-Type": "application/x-www-form-urlencoded" } });
   return response.data;
 }
-export async function getCurrentUser() { const response = await api.get("/auth/me"); return response.data; }
+export async function getCurrentUser() {
+  const response = await api.get("/auth/me");
+  void identifyAnalyticsUser(response.data);
+  return response.data;
+}
 export async function updateCurrentUserProfile(profile) { const response = await api.patch("/auth/me/profile", profile); return response.data; }
 export async function getBillingStatus() { const response = await api.get("/billing/status"); return response.data; }
 export async function cancelSubscription() { const response = await api.post("/billing/cancel"); return response.data; }


### PR DESCRIPTION
## Summary
- add best-effort, server-authoritative lifecycle capture for `user_signed_up`, `brag_created`, `impact_receipt_created`, and `plan_upgraded`
- capture upgrades only from verified Stripe webhooks and only on a free-to-Pro transition
- identify authenticated browser users by stable internal ID after login/session restoration and reset identity on logout
- allow-list privacy-safe analytics properties and exclude email, profile, résumé, and receipt content
- cover password and OAuth signup paths, plus standalone and brag-derived Impact Receipts

## Configuration
- backend: `POSTHOG_PROJECT_API_KEY`, `POSTHOG_HOST`
- frontend: `VITE_POSTHOG_KEY`, `VITE_POSTHOG_HOST`

## Verification
- `python -m compileall -q backend/app`
- `JWT_SECRET=... python -m pytest -q backend/tests/test_product_analytics.py` (2 passed)
- `npm run build`
- `npm run lint` (0 errors; 6 pre-existing hook warnings)
- `git diff --check`

PostHog custom events will appear after the relevant real product actions occur; no synthetic production events were sent.