### PR TITLE
perf: lazy-load resume document parsers

### DIFF
--- a/backend/app/resume_builder_routes.py
+++ b/backend/app/resume_builder_routes.py
@@ -3,12 +3,9 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from io import BytesIO
 
-import fitz
 from bson import ObjectId
-from docx import Document
 from fastapi import APIRouter, Depends, File, HTTPException, UploadFile, status
 from pydantic import BaseModel, Field
-from pypdf import PdfReader
 
 from app.auth import get_current_user
 from app.database import impact_receipts_collection, resume_documents_collection
@@ -120,8 +117,10 @@ def _server_readiness(bullets: list[ResumeBulletPayload]) -> dict:
 
 def _extract_pdf_text_pymupdf(data: bytes) -> str:
     """Primary born-digital PDF extraction with block geometry and stable reading-order sorting."""
+    import pymupdf
+
     lines: list[str] = []
-    with fitz.open(stream=data, filetype="pdf") as document:
+    with pymupdf.open(stream=data, filetype="pdf") as document:
         if document.page_count > MAX_RESUME_PAGES:
             raise HTTPException(status_code=400, detail=f"Resume PDFs can contain up to {MAX_RESUME_PAGES} pages")
         for page in document:
@@ -137,6 +136,8 @@ def _extract_pdf_text_pymupdf(data: bytes) -> str:
 
 
 def _extract_pdf_text_pypdf(data: bytes) -> str:
+    from pypdf import PdfReader
+
     reader = PdfReader(BytesIO(data))
     if len(reader.pages) > MAX_RESUME_PAGES:
         raise HTTPException(status_code=400, detail=f"Resume PDFs can contain up to {MAX_RESUME_PAGES} pages")
@@ -174,6 +175,8 @@ def _extract_uploaded_text(filename: str, content_type: str, data: bytes) -> str
     if content_type == "application/pdf" or suffix == ".pdf":
         return _extract_pdf_text(data)
     if content_type == "application/vnd.openxmlformats-officedocument.wordprocessingml.document" or suffix == ".docx":
+        from docx import Document
+
         document = Document(BytesIO(data))
         paragraphs = [paragraph.text for paragraph in document.paragraphs]
         table_rows = [" | ".join(cell.text for cell in row.cells) for table in document.tables for row in table.rows]

--- a/backend/tests/test_resume_parser_lazy_imports.py
+++ b/backend/tests/test_resume_parser_lazy_imports.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from app import resume_builder_routes as routes
+
+
+HEAVY_RESUME_MODULES = {"fitz", "pymupdf", "pypdf", "docx"}
+
+
+def _top_level_import_roots(source: str) -> set[str]:
+    tree = ast.parse(source)
+    imported: set[str] = set()
+    for node in tree.body:
+        if isinstance(node, ast.Import):
+            imported.update(alias.name.split(".", 1)[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported.add(node.module.split(".", 1)[0])
+    return imported
+
+
+def test_resume_route_defers_heavy_document_parser_imports_until_upload_processing():
+    source = Path(routes.__file__).read_text(encoding="utf-8")
+
+    assert HEAVY_RESUME_MODULES.isdisjoint(_top_level_import_roots(source))
+    assert "import pymupdf" in source
+    assert "from pypdf import PdfReader" in source
+    assert "from docx import Document" in source
+    assert "import fitz" not in source
+
+
+def test_plain_text_resume_import_does_not_require_document_parser_libraries():
+    text = routes._extract_uploaded_text("resume.txt", "text/plain", b"Platform engineer with Python and Docker experience")
+
+    assert text == "Platform engineer with Python and Docker experience"


### PR DESCRIPTION
Addresses the remaining parser-startup work in #211.

## What changed
- remove PyMuPDF, pypdf, and python-docx from `resume_builder_routes` module-level imports
- lazy-load each parser only when the corresponding PDF/DOCX upload path is actually used
- switch PyMuPDF usage from the legacy `fitz` import name to the supported `pymupdf` module name
- keep TXT resume imports dependency-light
- add regression coverage that rejects future top-level heavy parser imports

## Why
PR #212 already removed synchronous persistent observability writes from the response path. Current `main` still imports all resume document parser libraries during API startup even for unrelated routes, adding avoidable cold-start/module-load work.

## Merge gate
Merge only if Backend CI, Frontend CI, Security CI, and all other required checks are green on this exact PR head, the PR remains current/mergeable, and repository rules permit it.