### PR TITLE
docs: record API startup performance remediation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This changelog tracks **merged, shipped repository changes only**. Open or draft
 
 ## [Unreleased]
 
+### Changed
+- Reduced avoidable API startup work by lazy-loading PyMuPDF, pypdf, and python-docx only when matching resume uploads are processed, while preserving PDF/DOCX/TXT import behavior and guarding the lazy-loading boundary with regression tests. (#250)
+
 ### Fixed
 - Kept the mobile Practice Interview camera and replay controls inside equal-width buttons, moved the self-view clear of the controls, and added honest progress feedback while the low-cost Render API wakes for OAuth sign-in. (#219)
 


### PR DESCRIPTION
Records merged PR #250 in the repository's notable changelog.

## What changed
- add the #250 resume-parser lazy-loading remediation under Unreleased → Changed
- keep the entry focused on user/reliability impact rather than implementation trivia
- preserve the detailed event-level record in the BragStack Drive changelog

## Merge gate
Merge only if Backend CI, Frontend CI, Security CI, and all other required checks are green on this exact PR head, the PR remains current/mergeable, and repository rules permit it.