### PR TITLE
Add proprietary no-copy license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,33 @@
+PROPRIETARY LICENSE
+
+Copyright (c) 2026 mergemaven11. All rights reserved.
+
+This repository and its contents, including source code, documentation, designs,
+assets, data models, and related materials (the "Software"), are proprietary.
+
+The Software is made publicly viewable solely for portfolio review, security
+review, and evaluation. No license or permission is granted to copy, reproduce,
+modify, adapt, merge, publish, distribute, sublicense, sell, commercially use,
+rehost, create derivative works from, or incorporate the Software into another
+product or service.
+
+Use of the Software or its contents to train, fine-tune, evaluate, or supply
+training data to an artificial intelligence or machine-learning system is also
+prohibited without prior written permission.
+
+You may clone and run the Software locally only for private evaluation, provided
+that you do not redistribute it, use it in production, or remove copyright and
+proprietary notices.
+
+Any permission beyond this limited evaluation right requires prior written
+authorization from the copyright holder. Contact the repository owner through
+GitHub to request permission.
+
+Third-party dependencies and separately identified third-party materials remain
+subject to their respective licenses.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO WARRANTIES OF MERCHANTABILITY, FITNESS FOR
+A PARTICULAR PURPOSE, AND NON-INFRINGEMENT. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY ARISING FROM OR IN
+CONNECTION WITH THE SOFTWARE OR ITS USE.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> **Proprietary software — copying prohibited.** This source is public for portfolio review and evaluation only. Copying, modification, redistribution, commercial use, rehosting, derivative works, and AI/ML training use are prohibited without prior written permission. See [LICENSE](LICENSE).
+
 # BragStack
 
 > **Your work deserves receipts. Capture what you did. Prove the impact. Build the packet.**

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -11,6 +11,6 @@ pytest
 httpx
 mongomock
 reportlab==4.4.3
-pypdf==6.15.0
+pypdf==6.16.1
 PyMuPDF>=1.24,<2
 python-docx==1.2.0

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -22,7 +22,8 @@
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.6.0",
-        "vite": "^8.0.12"
+        "vite": "^8.0.12",
+        "browserslist": "^4.28.7"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -955,9 +956,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "version": "4.28.7",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.7.tgz",
+      "integrity": "sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==",
       "dev": true,
       "funding": [
         {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,6 +30,7 @@
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.6.0",
-    "vite": "^8.0.12"
+    "vite": "^8.0.12",
+    "browserslist": "^4.28.7"
   }
 }


### PR DESCRIPTION
## Summary
- adds an All Rights Reserved proprietary license
- permits private local evaluation only
- prohibits copying, modification, redistribution, rehosting, commercial use, derivative works, and AI/ML training without written permission
- adds a prominent README notice

## Note
Public GitHub visibility does not make this open-source software. Third-party dependencies remain governed by their own licenses.