### PR TITLE
docs: add proprietary no-copy notice

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,0 +1,13 @@
+# Proprietary Source Notice
+
+**Publicly visible does not mean open source.**
+
+Do not copy, reproduce, redistribute, republish, rebrand, modify, deploy, host, sell, sublicense, create derivative works from, or incorporate this repository or its contents into another product or service without prior written permission from the copyright holder.
+
+This repository is made available for portfolio review, product transparency, security review, demonstration, and authorized collaboration only.
+
+Use of the source code, documentation, designs, assets, data models, product copy, or other materials for AI/ML training, fine-tuning, evaluation datasets, competing products, or commercial offerings is prohibited without prior written permission.
+
+Third-party dependencies and separately identified third-party materials remain subject to their own licenses.
+
+See `LICENSE` for the complete terms.


### PR DESCRIPTION
## Summary

- adds a prominent `NOTICE.md` stating that public visibility does not mean open source
- prohibits copying, redistribution, rebranding, modification, deployment, derivative works, competing-product reuse, and AI/ML training use without permission
- points visitors to the existing proprietary `LICENSE`

## Why

BragStack is publicly visible for portfolio/product transparency, but the source remains proprietary. This makes that status unmistakable to repository visitors.