### PR TITLE
feat(ai): add evidence-grounded AI foundation and licensing gate

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,10 @@ JWT_SECRET=replace-with-a-long-random-secret
 ACCESS_TOKEN_EXPIRE_MINUTES=1440
 FRONTEND_URL=http://localhost:5173
 
+# Experimental AI evidence assistance
+# Default off. Enable only for reviewed internal/experimental flows after licensing + eval gates pass.
+BRAGSTACK_EXPERIMENTAL_AI=false
+
 # API abuse protection
 RATE_LIMIT_ENABLED=true
 RATE_LIMIT_FAIL_OPEN=true

--- a/backend/app/ai/__init__.py
+++ b/backend/app/ai/__init__.py
@@ -1,0 +1,20 @@
+"""BragStack AI evidence-assistance foundation.
+
+AI output is suggestion state only. Domain evidence remains user-controlled and
+must be traceable to source evidence IDs.
+"""
+
+from .contracts import AIProvider, AISuggestion, EvidenceContext, InferenceRequest
+from .guards import GroundingViolation, validate_grounded_suggestion
+from .licensing import ModelLicenseRecord, ProductionLicenseGate
+
+__all__ = [
+    "AIProvider",
+    "AISuggestion",
+    "EvidenceContext",
+    "GroundingViolation",
+    "InferenceRequest",
+    "ModelLicenseRecord",
+    "ProductionLicenseGate",
+    "validate_grounded_suggestion",
+]

--- a/backend/app/ai/contracts.py
+++ b/backend/app/ai/contracts.py
@@ -1,0 +1,73 @@
+"""Provider-neutral contracts for evidence-grounded AI assistance."""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+SuggestionKind = Literal[
+    "evidence_extraction",
+    "evidence_quality",
+    "impact_receipt",
+    "career_writing",
+    "skill_classification",
+    "semantic_search",
+]
+
+
+@dataclass(frozen=True)
+class EvidenceContext:
+    """User-selected evidence made available to an AI task.
+
+    Raw content is intentionally carried beside stable evidence IDs so every
+    generated suggestion can preserve provenance without making AI output part
+    of the durable evidence record.
+    """
+
+    evidence_ids: tuple[str, ...]
+    content: str
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class InferenceRequest:
+    """Versioned request passed to an AI provider implementation."""
+
+    task: SuggestionKind
+    evidence: tuple[EvidenceContext, ...]
+    prompt_version: str
+    schema_version: str
+    instructions: str = ""
+
+
+@dataclass(frozen=True)
+class AISuggestion:
+    """Unaccepted AI draft with explicit provenance and reproducibility data."""
+
+    task: SuggestionKind
+    payload: dict[str, Any]
+    source_evidence_ids: tuple[str, ...]
+    provider: str
+    model_id: str
+    model_revision: str
+    prompt_version: str
+    schema_version: str
+    accepted: bool = False
+
+
+class AIProvider(ABC):
+    """Vendor-neutral inference adapter.
+
+    Provider implementations may be local or hosted, but callers interact only
+    with this contract and must validate returned suggestions before surfacing
+    them to users.
+    """
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Return a stable provider identifier."""
+
+    @abstractmethod
+    def suggest(self, request: InferenceRequest) -> AISuggestion:
+        """Return an evidence-grounded draft for a validated request."""

--- a/backend/app/ai/contracts.py
+++ b/backend/app/ai/contracts.py
@@ -17,11 +17,16 @@ SuggestionKind = Literal[
 
 @dataclass(frozen=True)
 class EvidenceContext:
-    """User-selected evidence made available to an AI task.
+    """Represent user-selected evidence made available to an AI task.
 
     Raw content is intentionally carried beside stable evidence IDs so every
     generated suggestion can preserve provenance without making AI output part
     of the durable evidence record.
+
+    Attributes:
+        evidence_ids: Stable identifiers for the evidence supplied to inference.
+        content: User-controlled evidence text available to the AI task.
+        metadata: Optional structured metadata associated with the evidence.
     """
 
     evidence_ids: tuple[str, ...]
@@ -31,7 +36,15 @@ class EvidenceContext:
 
 @dataclass(frozen=True)
 class InferenceRequest:
-    """Versioned request passed to an AI provider implementation."""
+    """Represent a versioned request passed to an AI provider implementation.
+
+    Attributes:
+        task: Supported evidence-assistance task to perform.
+        evidence: User-selected evidence contexts available to the task.
+        prompt_version: Version identifier for the task prompt.
+        schema_version: Version identifier for the expected structured output.
+        instructions: Optional task-specific instructions that do not replace evidence.
+    """
 
     task: SuggestionKind
     evidence: tuple[EvidenceContext, ...]
@@ -42,7 +55,19 @@ class InferenceRequest:
 
 @dataclass(frozen=True)
 class AISuggestion:
-    """Unaccepted AI draft with explicit provenance and reproducibility data."""
+    """Represent an unaccepted AI draft with provenance and reproducibility data.
+
+    Attributes:
+        task: Evidence-assistance task that produced the suggestion.
+        payload: Structured suggestion content returned by the provider.
+        source_evidence_ids: Evidence identifiers cited as support for the suggestion.
+        provider: Stable identifier for the inference provider.
+        model_id: Exact model identifier used for inference.
+        model_revision: Pinned model revision used for reproducibility.
+        prompt_version: Version identifier for the prompt used during inference.
+        schema_version: Version identifier for the structured output schema.
+        accepted: Whether the user explicitly accepted the suggestion.
+    """
 
     task: SuggestionKind
     payload: dict[str, Any]
@@ -56,7 +81,7 @@ class AISuggestion:
 
 
 class AIProvider(ABC):
-    """Vendor-neutral inference adapter.
+    """Define the vendor-neutral inference adapter contract.
 
     Provider implementations may be local or hosted, but callers interact only
     with this contract and must validate returned suggestions before surfacing
@@ -66,8 +91,19 @@ class AIProvider(ABC):
     @property
     @abstractmethod
     def name(self) -> str:
-        """Return a stable provider identifier."""
+        """Return the stable provider identifier.
+
+        Returns:
+            Stable provider name used in audit and provenance records.
+        """
 
     @abstractmethod
     def suggest(self, request: InferenceRequest) -> AISuggestion:
-        """Return an evidence-grounded draft for a validated request."""
+        """Return an evidence-grounded draft for a validated request.
+
+        Args:
+            request: Versioned inference request containing selected evidence.
+
+        Returns:
+            Unaccepted AI suggestion carrying model and evidence provenance.
+        """

--- a/backend/app/ai/feature_flags.py
+++ b/backend/app/ai/feature_flags.py
@@ -1,0 +1,15 @@
+"""Environment-backed kill switches for incremental AI rollout."""
+from __future__ import annotations
+
+import os
+
+_TRUE_VALUES = {"1", "true", "yes", "on"}
+
+
+def experimental_ai_enabled() -> bool:
+    """Return whether experimental AI assistance is explicitly enabled.
+
+    The default is intentionally off so deployment of this foundation cannot
+    accidentally make model-backed behavior customer-facing.
+    """
+    return os.getenv("BRAGSTACK_EXPERIMENTAL_AI", "false").strip().casefold() in _TRUE_VALUES

--- a/backend/app/ai/feature_flags.py
+++ b/backend/app/ai/feature_flags.py
@@ -11,5 +11,9 @@ def experimental_ai_enabled() -> bool:
 
     The default is intentionally off so deployment of this foundation cannot
     accidentally make model-backed behavior customer-facing.
+
+    Returns:
+        True only when ``BRAGSTACK_EXPERIMENTAL_AI`` contains an explicit
+        truthy value recognized by the application.
     """
     return os.getenv("BRAGSTACK_EXPERIMENTAL_AI", "false").strip().casefold() in _TRUE_VALUES

--- a/backend/app/ai/guards.py
+++ b/backend/app/ai/guards.py
@@ -1,0 +1,100 @@
+"""Deterministic grounding guards for AI-generated career suggestions."""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any, Iterable
+
+from .contracts import AISuggestion, EvidenceContext
+
+_NUMERIC_RE = re.compile(r"(?<!\w)(?:[$£€]?\d+(?:[,.]\d+)*(?:%|x|\+)?)(?!\w)")
+_HIGH_RISK_TERMS = (
+    "verified",
+    "certified",
+    "confirmed by",
+    "credential",
+    "licensed",
+    "promoted",
+    "increased",
+    "decreased",
+    "reduced",
+    "saved",
+    "revenue",
+)
+
+
+@dataclass(frozen=True)
+class GroundingViolation:
+    """One deterministic reason a suggestion cannot be trusted as grounded."""
+
+    code: str
+    message: str
+    value: str | None = None
+
+
+def _flatten_strings(value: Any) -> Iterable[str]:
+    if isinstance(value, str):
+        yield value
+    elif isinstance(value, dict):
+        for child in value.values():
+            yield from _flatten_strings(child)
+    elif isinstance(value, (list, tuple, set)):
+        for child in value:
+            yield from _flatten_strings(child)
+
+
+def _normalized_corpus(evidence: Iterable[EvidenceContext]) -> str:
+    return "\n".join(item.content for item in evidence).casefold()
+
+
+def validate_grounded_suggestion(
+    suggestion: AISuggestion,
+    evidence: Iterable[EvidenceContext],
+) -> list[GroundingViolation]:
+    """Reject provenance gaps and unsupported high-risk factual specificity.
+
+    This guard is deliberately conservative. It does not attempt semantic fact
+    checking; it blocks obvious classes of unsupported claims before a model
+    output can be surfaced as a BragStack suggestion.
+    """
+    evidence_items = tuple(evidence)
+    known_ids = {evidence_id for item in evidence_items for evidence_id in item.evidence_ids}
+    violations: list[GroundingViolation] = []
+
+    if not suggestion.source_evidence_ids:
+        violations.append(
+            GroundingViolation("missing_provenance", "AI suggestions must cite at least one evidence ID.")
+        )
+    for source_id in suggestion.source_evidence_ids:
+        if source_id not in known_ids:
+            violations.append(
+                GroundingViolation(
+                    "unknown_evidence_id",
+                    "Suggestion references evidence that was not supplied to the task.",
+                    source_id,
+                )
+            )
+
+    corpus = _normalized_corpus(evidence_items)
+    for text in _flatten_strings(suggestion.payload):
+        for number in _NUMERIC_RE.findall(text):
+            if number.casefold() not in corpus:
+                violations.append(
+                    GroundingViolation(
+                        "unsupported_numeric_claim",
+                        "Numeric specificity must already exist in user-controlled evidence.",
+                        number,
+                    )
+                )
+        lowered = text.casefold()
+        for phrase in _HIGH_RISK_TERMS:
+            if phrase in lowered and phrase not in corpus:
+                violations.append(
+                    GroundingViolation(
+                        "unsupported_high_risk_language",
+                        "High-risk factual language must be supported by supplied evidence.",
+                        phrase,
+                    )
+                )
+
+    return violations

--- a/backend/app/ai/guards.py
+++ b/backend/app/ai/guards.py
@@ -25,7 +25,13 @@ _HIGH_RISK_TERMS = (
 
 @dataclass(frozen=True)
 class GroundingViolation:
-    """One deterministic reason a suggestion cannot be trusted as grounded."""
+    """Represent one deterministic reason a suggestion is not grounded.
+
+    Attributes:
+        code: Stable machine-readable violation identifier.
+        message: Human-readable explanation of the violation.
+        value: Optional unsupported value or phrase that triggered the violation.
+    """
 
     code: str
     message: str
@@ -33,6 +39,14 @@ class GroundingViolation:
 
 
 def _flatten_strings(value: Any) -> Iterable[str]:
+    """Yield every nested string contained in a structured value.
+
+    Args:
+        value: Arbitrarily nested structured value from an AI suggestion payload.
+
+    Yields:
+        String values discovered recursively in dictionaries and iterable containers.
+    """
     if isinstance(value, str):
         yield value
     elif isinstance(value, dict):
@@ -44,6 +58,14 @@ def _flatten_strings(value: Any) -> Iterable[str]:
 
 
 def _normalized_corpus(evidence: Iterable[EvidenceContext]) -> str:
+    """Build a case-insensitive corpus from supplied evidence text.
+
+    Args:
+        evidence: Evidence contexts supplied to the inference task.
+
+    Returns:
+        Newline-delimited case-folded evidence text for deterministic matching.
+    """
     return "\n".join(item.content for item in evidence).casefold()
 
 
@@ -56,6 +78,14 @@ def validate_grounded_suggestion(
     This guard is deliberately conservative. It does not attempt semantic fact
     checking; it blocks obvious classes of unsupported claims before a model
     output can be surfaced as a BragStack suggestion.
+
+    Args:
+        suggestion: Unaccepted AI suggestion to validate before it is surfaced.
+        evidence: User-controlled evidence supplied to the originating inference task.
+
+    Returns:
+        Deterministic grounding violations. An empty list means this guard found
+        no provenance, unsupported-number, or high-risk-language violations.
     """
     evidence_items = tuple(evidence)
     known_ids = {evidence_id for item in evidence_items for evidence_id in item.evidence_ids}

--- a/backend/app/ai/licensing.py
+++ b/backend/app/ai/licensing.py
@@ -1,0 +1,57 @@
+"""Production licensing gate for candidate AI models and runtimes."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+_PERMISSIVE_LICENSES = {"apache-2.0", "mit", "bsd-2-clause", "bsd-3-clause"}
+
+
+@dataclass(frozen=True)
+class ModelLicenseRecord:
+    """Auditable model licensing and deployment metadata."""
+
+    model_id: str
+    revision: str
+    source_url: str
+    license_id: str
+    license_url: str
+    commercial_use: bool
+    modification: bool
+    redistribution: bool
+    attribution_notice: str
+    runtime: str
+    hardware_envelope: str
+    intended_task: str
+    evaluation_status: str = "not_evaluated"
+    known_limitations: str = ""
+
+
+class ProductionLicenseGate:
+    """Fail closed unless model weights have clear permissive commercial terms."""
+
+    @staticmethod
+    def violations(record: ModelLicenseRecord) -> list[str]:
+        """Return every reason the model is not eligible for production use."""
+        problems: list[str] = []
+        if record.license_id.casefold() not in _PERMISSIVE_LICENSES:
+            problems.append("license_not_allowlisted")
+        if not record.commercial_use:
+            problems.append("commercial_use_not_confirmed")
+        if not record.modification:
+            problems.append("modification_not_confirmed")
+        if not record.redistribution:
+            problems.append("redistribution_not_confirmed")
+        if not record.revision.strip():
+            problems.append("revision_missing")
+        if not record.source_url.startswith("https://"):
+            problems.append("source_url_missing_or_insecure")
+        if not record.license_url.startswith("https://"):
+            problems.append("license_url_missing_or_insecure")
+        if not record.intended_task.strip():
+            problems.append("intended_task_missing")
+        return problems
+
+    @classmethod
+    def allows_production(cls, record: ModelLicenseRecord) -> bool:
+        """Return true only when all licensing metadata passes the gate."""
+        return not cls.violations(record)

--- a/backend/app/ai/licensing.py
+++ b/backend/app/ai/licensing.py
@@ -8,7 +8,24 @@ _PERMISSIVE_LICENSES = {"apache-2.0", "mit", "bsd-2-clause", "bsd-3-clause"}
 
 @dataclass(frozen=True)
 class ModelLicenseRecord:
-    """Auditable model licensing and deployment metadata."""
+    """Represent auditable model licensing and deployment metadata.
+
+    Attributes:
+        model_id: Exact upstream model identifier.
+        revision: Immutable reviewed model revision or commit identifier.
+        source_url: Permanent HTTPS source for the model or model card.
+        license_id: Normalized SPDX-style license identifier.
+        license_url: Permanent HTTPS URL for the reviewed license text.
+        commercial_use: Whether commercial use is explicitly permitted.
+        modification: Whether modification is explicitly permitted.
+        redistribution: Whether redistribution is explicitly permitted.
+        attribution_notice: Required attribution or notice text, when applicable.
+        runtime: Runtime selected or proposed for model execution.
+        hardware_envelope: Documented CPU, GPU, memory, or platform expectations.
+        intended_task: BragStack task for which the model is being evaluated.
+        evaluation_status: Current BragStack-specific evaluation state.
+        known_limitations: Known model, runtime, or task limitations.
+    """
 
     model_id: str
     revision: str
@@ -31,7 +48,15 @@ class ProductionLicenseGate:
 
     @staticmethod
     def violations(record: ModelLicenseRecord) -> list[str]:
-        """Return every reason the model is not eligible for production use."""
+        """Return every reason a model record is not license-eligible for production.
+
+        Args:
+            record: Auditable model-license record to evaluate.
+
+        Returns:
+            Stable violation identifiers. An empty list means the licensing
+            metadata satisfies this gate; it does not imply quality approval.
+        """
         problems: list[str] = []
         if record.license_id.casefold() not in _PERMISSIVE_LICENSES:
             problems.append("license_not_allowlisted")
@@ -53,5 +78,13 @@ class ProductionLicenseGate:
 
     @classmethod
     def allows_production(cls, record: ModelLicenseRecord) -> bool:
-        """Return true only when all licensing metadata passes the gate."""
+        """Return whether the record passes the production licensing gate.
+
+        Args:
+            record: Auditable model-license record to evaluate.
+
+        Returns:
+            True only when no licensing metadata violations are present. This
+            result does not replace BragStack's separate model-evaluation gate.
+        """
         return not cls.violations(record)

--- a/backend/tests/test_ai_foundation.py
+++ b/backend/tests/test_ai_foundation.py
@@ -6,6 +6,15 @@ from app.ai.licensing import ModelLicenseRecord, ProductionLicenseGate
 
 
 def _suggestion(payload, source_ids=("ev-1",)):
+    """Build a deterministic AI suggestion fixture.
+
+    Args:
+        payload: Structured payload to place in the test suggestion.
+        source_ids: Evidence identifiers cited by the suggestion.
+
+    Returns:
+        AI suggestion populated with deterministic test provenance metadata.
+    """
     return AISuggestion(
         task="impact_receipt",
         payload=payload,
@@ -19,10 +28,19 @@ def _suggestion(payload, source_ids=("ev-1",)):
 
 
 def _evidence(text="Reduced build time by 30% for the release pipeline."):
+    """Build a deterministic evidence-context fixture.
+
+    Args:
+        text: User-controlled evidence text supplied to the grounding guard.
+
+    Returns:
+        Single evidence context wrapped in a tuple for validator input.
+    """
     return (EvidenceContext(evidence_ids=("ev-1",), content=text),)
 
 
 def test_grounded_numeric_claim_is_allowed():
+    """Verify numeric claims already present in evidence pass the guard."""
     violations = validate_grounded_suggestion(
         _suggestion({"result": "Reduced build time by 30%."}),
         _evidence(),
@@ -31,6 +49,7 @@ def test_grounded_numeric_claim_is_allowed():
 
 
 def test_new_numeric_claim_is_rejected():
+    """Verify invented numeric specificity is rejected."""
     violations = validate_grounded_suggestion(
         _suggestion({"result": "Reduced build time by 55%."}),
         _evidence(),
@@ -39,6 +58,7 @@ def test_new_numeric_claim_is_rejected():
 
 
 def test_unknown_provenance_id_is_rejected():
+    """Verify suggestions cannot cite evidence absent from the request."""
     violations = validate_grounded_suggestion(
         _suggestion({"result": "Improved the release pipeline."}, source_ids=("ev-missing",)),
         _evidence(),
@@ -47,6 +67,7 @@ def test_unknown_provenance_id_is_rejected():
 
 
 def test_missing_provenance_is_rejected():
+    """Verify every AI suggestion must cite at least one evidence identifier."""
     violations = validate_grounded_suggestion(
         _suggestion({"result": "Improved the release pipeline."}, source_ids=()),
         _evidence(),
@@ -55,6 +76,7 @@ def test_missing_provenance_is_rejected():
 
 
 def test_unsupported_verification_language_is_rejected():
+    """Verify unsupported verification language is rejected."""
     violations = validate_grounded_suggestion(
         _suggestion({"evidence": "Result was verified by leadership."}),
         _evidence(),
@@ -63,6 +85,7 @@ def test_unsupported_verification_language_is_rejected():
 
 
 def test_supported_high_risk_language_is_allowed():
+    """Verify high-risk wording passes when directly supported by evidence."""
     evidence = _evidence("Leadership verified the release-pipeline result.")
     violations = validate_grounded_suggestion(
         _suggestion({"evidence": "Leadership verified the release-pipeline result."}),
@@ -72,6 +95,7 @@ def test_supported_high_risk_language_is_allowed():
 
 
 def test_permissive_complete_model_record_passes_license_gate():
+    """Verify a complete permissive commercial-use record passes licensing."""
     record = ModelLicenseRecord(
         model_id="example/model",
         revision="deadbeef",
@@ -90,6 +114,7 @@ def test_permissive_complete_model_record_passes_license_gate():
 
 
 def test_license_gate_fails_closed_for_noncommercial_or_unpinned_model():
+    """Verify unclear commercial rights and missing revisions fail closed."""
     record = ModelLicenseRecord(
         model_id="example/research-only",
         revision="",
@@ -111,10 +136,12 @@ def test_license_gate_fails_closed_for_noncommercial_or_unpinned_model():
 
 
 def test_experimental_ai_is_disabled_by_default(monkeypatch):
+    """Verify experimental AI remains disabled when no flag is configured."""
     monkeypatch.delenv("BRAGSTACK_EXPERIMENTAL_AI", raising=False)
     assert experimental_ai_enabled() is False
 
 
 def test_experimental_ai_requires_explicit_opt_in(monkeypatch):
+    """Verify experimental AI activates only after explicit environment opt-in."""
     monkeypatch.setenv("BRAGSTACK_EXPERIMENTAL_AI", "true")
     assert experimental_ai_enabled() is True

--- a/backend/tests/test_ai_foundation.py
+++ b/backend/tests/test_ai_foundation.py
@@ -1,5 +1,6 @@
 """Regression tests for BragStack's AI evidence-assistance safety foundation."""
 from app.ai.contracts import AISuggestion, EvidenceContext
+from app.ai.feature_flags import experimental_ai_enabled
 from app.ai.guards import validate_grounded_suggestion
 from app.ai.licensing import ModelLicenseRecord, ProductionLicenseGate
 
@@ -107,3 +108,13 @@ def test_license_gate_fails_closed_for_noncommercial_or_unpinned_model():
     assert "license_not_allowlisted" in violations
     assert "commercial_use_not_confirmed" in violations
     assert "revision_missing" in violations
+
+
+def test_experimental_ai_is_disabled_by_default(monkeypatch):
+    monkeypatch.delenv("BRAGSTACK_EXPERIMENTAL_AI", raising=False)
+    assert experimental_ai_enabled() is False
+
+
+def test_experimental_ai_requires_explicit_opt_in(monkeypatch):
+    monkeypatch.setenv("BRAGSTACK_EXPERIMENTAL_AI", "true")
+    assert experimental_ai_enabled() is True

--- a/backend/tests/test_ai_foundation.py
+++ b/backend/tests/test_ai_foundation.py
@@ -1,0 +1,109 @@
+"""Regression tests for BragStack's AI evidence-assistance safety foundation."""
+from app.ai.contracts import AISuggestion, EvidenceContext
+from app.ai.guards import validate_grounded_suggestion
+from app.ai.licensing import ModelLicenseRecord, ProductionLicenseGate
+
+
+def _suggestion(payload, source_ids=("ev-1",)):
+    return AISuggestion(
+        task="impact_receipt",
+        payload=payload,
+        source_evidence_ids=source_ids,
+        provider="test",
+        model_id="test-model",
+        model_revision="abc123",
+        prompt_version="receipt-v1",
+        schema_version="receipt-v1",
+    )
+
+
+def _evidence(text="Reduced build time by 30% for the release pipeline."):
+    return (EvidenceContext(evidence_ids=("ev-1",), content=text),)
+
+
+def test_grounded_numeric_claim_is_allowed():
+    violations = validate_grounded_suggestion(
+        _suggestion({"result": "Reduced build time by 30%."}),
+        _evidence(),
+    )
+    assert violations == []
+
+
+def test_new_numeric_claim_is_rejected():
+    violations = validate_grounded_suggestion(
+        _suggestion({"result": "Reduced build time by 55%."}),
+        _evidence(),
+    )
+    assert "unsupported_numeric_claim" in {item.code for item in violations}
+
+
+def test_unknown_provenance_id_is_rejected():
+    violations = validate_grounded_suggestion(
+        _suggestion({"result": "Improved the release pipeline."}, source_ids=("ev-missing",)),
+        _evidence(),
+    )
+    assert "unknown_evidence_id" in {item.code for item in violations}
+
+
+def test_missing_provenance_is_rejected():
+    violations = validate_grounded_suggestion(
+        _suggestion({"result": "Improved the release pipeline."}, source_ids=()),
+        _evidence(),
+    )
+    assert "missing_provenance" in {item.code for item in violations}
+
+
+def test_unsupported_verification_language_is_rejected():
+    violations = validate_grounded_suggestion(
+        _suggestion({"evidence": "Result was verified by leadership."}),
+        _evidence(),
+    )
+    assert "unsupported_high_risk_language" in {item.code for item in violations}
+
+
+def test_supported_high_risk_language_is_allowed():
+    evidence = _evidence("Leadership verified the release-pipeline result.")
+    violations = validate_grounded_suggestion(
+        _suggestion({"evidence": "Leadership verified the release-pipeline result."}),
+        evidence,
+    )
+    assert violations == []
+
+
+def test_permissive_complete_model_record_passes_license_gate():
+    record = ModelLicenseRecord(
+        model_id="example/model",
+        revision="deadbeef",
+        source_url="https://example.com/model",
+        license_id="apache-2.0",
+        license_url="https://www.apache.org/licenses/LICENSE-2.0",
+        commercial_use=True,
+        modification=True,
+        redistribution=True,
+        attribution_notice="Preserve Apache-2.0 notices.",
+        runtime="local",
+        hardware_envelope="CPU or GPU; benchmark before release",
+        intended_task="evidence extraction",
+    )
+    assert ProductionLicenseGate.allows_production(record)
+
+
+def test_license_gate_fails_closed_for_noncommercial_or_unpinned_model():
+    record = ModelLicenseRecord(
+        model_id="example/research-only",
+        revision="",
+        source_url="https://example.com/model",
+        license_id="research-only",
+        license_url="https://example.com/license",
+        commercial_use=False,
+        modification=False,
+        redistribution=False,
+        attribution_notice="",
+        runtime="local",
+        hardware_envelope="unknown",
+        intended_task="evidence extraction",
+    )
+    violations = ProductionLicenseGate.violations(record)
+    assert "license_not_allowlisted" in violations
+    assert "commercial_use_not_confirmed" in violations
+    assert "revision_missing" in violations

--- a/docs/AI_MODEL_REGISTRY.md
+++ b/docs/AI_MODEL_REGISTRY.md
@@ -1,0 +1,51 @@
+# BragStack AI model registry
+
+Status: foundation only. No model listed here is customer-facing by inclusion alone.
+
+BragStack's production gate is deliberately stricter than "the runtime is open source." Model weights, exact revision, source, license, commercial-use rights, modification rights, redistribution rights, notices, task fit, and evaluation status must all be recorded independently.
+
+## Candidate: HuggingFaceTB/SmolLM2-1.7B-Instruct
+
+- Intended BragStack tasks: experimental evidence extraction, evidence-quality suggestions, grounded drafting.
+- Exact revision reviewed: `31b70e2e869a7173562077fd711b654946d38674`.
+- Upstream model: `HuggingFaceTB/SmolLM2-1.7B-Instruct`.
+- Model card: https://huggingface.co/HuggingFaceTB/SmolLM2-1.7B-Instruct
+- Reviewed revision: https://huggingface.co/HuggingFaceTB/SmolLM2-1.7B-Instruct/tree/31b70e2e869a7173562077fd711b654946d38674
+- Declared license: Apache-2.0.
+- License text: https://www.apache.org/licenses/LICENSE-2.0
+- Commercial use: allowed by Apache-2.0, subject to preserving required notices and complying with applicable law.
+- Modification: allowed by Apache-2.0.
+- Redistribution: allowed by Apache-2.0, subject to license/notice requirements.
+- Attribution/notice: preserve the Apache-2.0 license and applicable notices when redistribution triggers those obligations.
+- Runtime options noted upstream: Transformers, Transformers.js, vLLM, SGLang, Docker Model Runner.
+- Hardware envelope: 1.7B parameters; benchmark CPU/RAM/GPU latency and memory before any release. No production hardware claim is approved yet.
+- Evaluation status: **NOT EVALUATED FOR BRAGSTACK**.
+- Known limitations for our use: small-model factual/structured-output reliability must be measured; prompt injection and unsupported-claim behavior remain release blockers until the evaluation gate passes.
+- Production status: **LICENSE-ELIGIBLE CANDIDATE, NOT APPROVED FOR CUSTOMER-FACING USE**.
+
+## Candidate: sentence-transformers/all-MiniLM-L6-v2
+
+- Intended BragStack task: future private semantic evidence search / retrieval.
+- Exact revision reviewed: `1110a243fdf4706b3f48f1d95db1a4f5529b4d41`.
+- Upstream model: `sentence-transformers/all-MiniLM-L6-v2`.
+- Model card: https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2
+- Reviewed revision: https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/tree/1110a243fdf4706b3f48f1d95db1a4f5529b4d41
+- Declared license: Apache-2.0.
+- License text: https://www.apache.org/licenses/LICENSE-2.0
+- Commercial use: allowed by Apache-2.0, subject to preserving required notices and complying with applicable law.
+- Modification: allowed by Apache-2.0.
+- Redistribution: allowed by Apache-2.0, subject to license/notice requirements.
+- Attribution/notice: preserve the Apache-2.0 license and applicable notices when redistribution triggers those obligations.
+- Runtime: sentence-transformers / Transformers; ONNX and OpenVINO artifacts are published upstream.
+- Hardware envelope: compact 384-dimensional embedding model; benchmark throughput, memory, retrieval quality, and local-device suitability before release.
+- Evaluation status: **NOT EVALUATED FOR BRAGSTACK**.
+- Known limitations for our use: semantic similarity is not evidence verification; retrieval results must never be represented as factual confirmation.
+- Production status: **LICENSE-ELIGIBLE CANDIDATE, NOT APPROVED FOR CUSTOMER-FACING USE**.
+
+## Rejected-by-default categories
+
+Do not ship a model when any of the following applies: research-only terms, noncommercial terms, ambiguous or missing weight license, incompatible redistribution terms, missing immutable revision, unclear provenance, gated terms that have not been reviewed, or a model that has not passed the BragStack task-specific evaluation threshold.
+
+## Release checklist
+
+Before moving a registry entry to approved: verify the exact immutable revision again; preserve required notices; record runtime license separately; run the versioned evaluation set; measure unsupported-claim and numeric-hallucination rates; verify evidence-reference correctness and schema validity; run privacy/redaction and prompt-injection fixtures; record latency/memory on supported hardware; document limitations; and verify the feature-flag kill switch.


### PR DESCRIPTION
## Summary

Introduces the P0 AI/ML foundation described in `ROADMAP.md` without making model inference customer-facing.

This PR establishes the contracts and deterministic safety gates BragStack needs before experimental evidence extraction or drafting can ship.

## What changed

- Added a provider-neutral `AIProvider` abstraction so domain logic is not coupled to any inference vendor or runtime.
- Added immutable, versioned inference request and AI suggestion contracts carrying:
  - evidence IDs,
  - provider/model identity,
  - immutable model revision,
  - prompt version,
  - schema version,
  - acceptance state.
- Added deterministic grounding validation that rejects:
  - missing provenance,
  - unknown evidence IDs,
  - unsupported numeric claims,
  - unsupported high-risk factual language such as verification/credential/outcome assertions.
- Added a fail-closed production model licensing gate requiring:
  - an allowlisted permissive license,
  - confirmed commercial-use rights,
  - confirmed modification rights,
  - confirmed redistribution rights,
  - immutable revision,
  - HTTPS source/license references,
  - explicit intended task.
- Added `BRAGSTACK_EXPERIMENTAL_AI=false` as a default-off kill switch.
- Added `docs/AI_MODEL_REGISTRY.md` with reviewed, pinned model candidates and explicit release status.

## Commercial-use model review

### HuggingFaceTB/SmolLM2-1.7B-Instruct

- Reviewed revision: `31b70e2e869a7173562077fd711b654946d38674`
- Declared license: Apache-2.0
- Candidate use: evidence extraction, evidence-quality suggestions, grounded drafting
- Status: **license-eligible candidate; NOT approved for customer-facing use**

### sentence-transformers/all-MiniLM-L6-v2

- Reviewed revision: `1110a243fdf4706b3f48f1d95db1a4f5529b4d41`
- Declared license: Apache-2.0
- Candidate use: future private semantic evidence search
- Status: **license-eligible candidate; NOT approved for customer-facing use**

Model-weight licensing is treated independently from runtime/library licensing. A permissive runtime cannot cause restricted weights to pass the gate.

## Tests

Adds `backend/tests/test_ai_foundation.py` covering:

- grounded numeric claims pass,
- invented numeric specificity fails,
- unknown evidence provenance fails,
- missing provenance fails,
- unsupported verification language fails,
- supported high-risk language passes,
- permissive complete licensing records pass,
- noncommercial/unpinned models fail closed,
- experimental AI is disabled by default,
- explicit environment opt-in enables the experimental flag.

## Safety / privacy posture

- AI remains assistive suggestion state, never source-of-truth evidence.
- No endpoint in this PR invokes a model.
- No user evidence is sent to a hosted provider.
- No training/feedback pipeline is introduced.
- Feature flag defaults off.
- Unsupported factual specificity is blocked deterministically before later UI exposure.

## Why this is P0

The roadmap explicitly requires architecture, provenance, licensing/evaluation gates, feature flags, and rollback before customer-facing AI. This PR builds that foundation first so P1 experiments can happen without weakening BragStack's core promise: **AI can help organize the receipts; it cannot invent them.**

## Follow-up

1. Add the versioned evaluation harness + cross-profession fixtures.
2. Add prompt-injection/privacy fixtures.
3. Implement a local provider adapter behind `BRAGSTACK_EXPERIMENTAL_AI`.
4. Run SmolLM2 against extraction/quality fixtures and document thresholds/results.
5. Only after thresholds pass, add an authenticated experimental evidence-assistance endpoint that stores output as suggestion state with provenance.