### PR TITLE
Fix live landing page messaging and preserve BragStack branding

### DIFF
--- a/frontend/public/production-patches.js
+++ b/frontend/public/production-patches.js
@@ -9,7 +9,7 @@
   const BILLING_EMAIL = "billing@usebragstack.com";
 
   const routeMeta = {
-    "/": ["BragStack | Resume Accomplishments, Career Portfolio & Job Search Proof", "Capture work accomplishments and turn them into evidence-backed resume bullets, career portfolios, interview stories, performance reviews, promotion packets, and job-search proof."],
+    "/": ["BragStack | Turn Your Work Into Career Proof", "BragStack helps professionals capture wins, attach evidence, create Impact Receipts, build Proof Profiles and Professional Packets, and selectively share career proof when it matters."],
     "/docs": ["BragStack Docs | Career Proof, Billing, Privacy & Product Help", "Customer documentation for BragStack accounts, Impact Receipts, reports, public proof profiles, privacy, billing, and BragStack Pro."],
     "/resume-accomplishments": ["Resume Accomplishments & Achievement Tracker | BragStack", "Track work accomplishments, measurable impact, and evidence so you can build stronger resume bullets from real career proof."],
     "/career-portfolio": ["Career Portfolio & Professional Proof Profile | BragStack", "Build a professional career portfolio from selected accomplishments, skills, evidence, and measurable impact while keeping your account private by default."],
@@ -56,7 +56,7 @@
     const nav = root.querySelector?.(".landing-nav") || document.querySelector(".landing-nav");
     if (!nav || nav.dataset.brandPatched === "true") return;
     const logo = nav.querySelector(".landing-logo");
-    if (logo) { logo.textContent = ""; logo.setAttribute("aria-label", "BragStack home"); }
+    if (logo) { logo.textContent = "BragStack"; logo.setAttribute("aria-label", "BragStack home"); }
     const actions = nav.querySelector(".landing-nav-actions");
     if (actions) {
       if (!actions.querySelector('a[href="/docs"]')) {

--- a/frontend/src/LandingPage.jsx
+++ b/frontend/src/LandingPage.jsx
@@ -157,15 +157,16 @@ function LandingPage() {
 
       <section className="landing-hero">
         <div className="landing-hero-copy">
-          <div className="landing-eyebrow"><ShieldCheck size={15} />The evidence layer for professional growth</div>
-          <h1>Turn your work into<span> career proof.</span></h1>
+          <div className="landing-eyebrow"><ShieldCheck size={15} />NEW BRAGSTACK · CAREER EVIDENCE, NOT JUST CLAIMS</div>
+          <h1>Your work deserves<span> receipts.</span></h1>
           <p className="landing-hero-description">
-            BragStack gives you an employee-owned record of what you did, what you contributed, what changed, and what supports the claim — so your best work is ready for reviews, promotions, interviews, résumés, selective sharing, and the opportunities that follow.
+            BragStack helps you capture wins, attach evidence, and turn important work into Impact Receipts. Reuse that proof for performance reviews, promotions, résumés, interviews, and a selective public Proof Profile.
           </p>
           <div className="landing-hero-actions">
-            <a className="landing-btn" href="/register">Build my evidence record <ArrowRight size={18} /></a>
-            <a className="landing-btn landing-btn-secondary" href="#how-it-works">See how proof travels</a>
+            <a className="landing-btn" href="/register">Start my BragStack <ArrowRight size={18} /></a>
+            <a className="landing-btn landing-btn-secondary" href="#product">See what&apos;s new</a>
           </div>
+          <p className="landing-trust-line">Impact Receipts <span>•</span> Proof Profiles <span>•</span> Professional Packets <span>•</span> Open to Talk</p>
           <p className="landing-trust-line">Private by default <span>•</span> Evidence-backed <span>•</span> You choose what becomes public</p>
         </div>
 
@@ -209,7 +210,7 @@ function LandingPage() {
       </section>
 
       <section className="landing-use-cases" id="product">
-        <div className="landing-section-heading"><p>THE EVIDENCE SYSTEM</p><h2>One record. Multiple career outcomes.</h2><span>Impact Receipts are the core primitive; profiles, packets, analytics, and conversations are ways to use the evidence you control.</span></div>
+        <div className="landing-section-heading"><p>WHAT&apos;S NEW IN BRAGSTACK</p><h2>One place for your career evidence.</h2><span>Impact Receipts are the core. Proof Profiles, Professional Packets, Career Analytics, and Open to Talk help you use that evidence when it matters.</span></div>
         <div className="use-case-grid">{productDetails.map(({ icon: Icon, ...item }) => <article className="use-case-card" id={item.id} key={item.id}><div className="use-case-icon"><Icon size={21} /></div><h3>{item.title}</h3><p>{item.description}</p></article>)}</div>
       </section>
 


### PR DESCRIPTION
## What changed
- keeps the BragStack wordmark visible in the production navbar instead of clearing it
- makes the first fold explicitly announce the new BragStack positioning
- leads with `Your work deserves receipts.`
- plainly names Impact Receipts, Proof Profiles, Professional Packets, and Open to Talk above the fold
- relabels the product section as `WHAT'S NEW IN BRAGSTACK`
- updates production runtime title/description from the older résumé/portfolio positioning to the evidence-layer product story

## Why
The production domain was still presenting BragStack like the older marketing site even though the new evidence-layer source had deployed. The production patch also removed the visible BragStack wordmark. This keeps the existing visual brand while making the current product understandable immediately.

## Validation
- Frontend CI: real Chrome click-path audit
- responsive phone/tablet/desktop checks
- lint + production build
- production bundle budgets
- verify Render deploy after merge

No backend behavior changes.