### PR TITLE
Fix mobile marketing preview layout and add landing regression guard

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,7 @@
     "test:resume": "node --test src/resumeStructured.test.js src/dashboardTags.test.js",
     "test:seo": "node scripts/verify-search-appearance.mjs",
     "test:clicks": "node scripts/run-click-audit.mjs",
-    "test:layout": "node scripts/audit-responsive-layout.mjs",
+    "test:layout": "node scripts/audit-responsive-layout.mjs && node scripts/audit-marketing-responsive.mjs",
     "test:bundle": "node scripts/verify-bundle-budget.mjs",
     "preview": "vite preview"
   },

--- a/frontend/scripts/audit-marketing-responsive.mjs
+++ b/frontend/scripts/audit-marketing-responsive.mjs
@@ -1,0 +1,222 @@
+import assert from "node:assert/strict";
+import { spawn, spawnSync } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { createServer } from "vite";
+
+const HOST = "127.0.0.1";
+const APP_PORT = 41742;
+const DEBUG_PORT = 9225;
+const BASE_URL = `http://${HOST}:${APP_PORT}`;
+const SCREENSHOT_DIR = path.join(process.cwd(), "artifacts", "marketing-layout");
+const VIEWPORTS = [
+  { name: "phone-360", width: 360, height: 800 },
+  { name: "phone-390", width: 390, height: 844 },
+  { name: "phone-430", width: 430, height: 932 },
+];
+
+function findChrome() {
+  return ["google-chrome", "chromium", "chromium-browser"]
+    .find((name) => spawnSync("which", [name], { encoding: "utf8" }).status === 0);
+}
+
+async function waitFor(fn, timeoutMs = 10000) {
+  const started = Date.now();
+  let lastError;
+  while (Date.now() - started < timeoutMs) {
+    try {
+      const result = await fn();
+      if (result) return result;
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw lastError || new Error(`Timed out after ${timeoutMs}ms`);
+}
+
+async function findPageTarget() {
+  return waitFor(async () => {
+    const response = await fetch(`http://${HOST}:${DEBUG_PORT}/json/list`);
+    if (!response.ok) return null;
+    const targets = await response.json();
+    return targets.find((target) => target.type === "page" && target.webSocketDebuggerUrl) || null;
+  }, 5000);
+}
+
+class CDP {
+  constructor(wsUrl) {
+    this.ws = new WebSocket(wsUrl);
+    this.nextId = 1;
+    this.pending = new Map();
+  }
+
+  async open() {
+    await new Promise((resolve, reject) => {
+      this.ws.addEventListener("open", resolve, { once: true });
+      this.ws.addEventListener("error", reject, { once: true });
+    });
+    this.ws.addEventListener("message", (event) => {
+      const message = JSON.parse(event.data);
+      if (!message.id || !this.pending.has(message.id)) return;
+      const { resolve, reject } = this.pending.get(message.id);
+      this.pending.delete(message.id);
+      if (message.error) reject(new Error(message.error.message));
+      else resolve(message.result);
+    });
+  }
+
+  send(method, params = {}) {
+    const id = this.nextId++;
+    return new Promise((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+      this.ws.send(JSON.stringify({ id, method, params }));
+    });
+  }
+
+  close() {
+    try { this.ws.close(); } catch { /* ignore */ }
+  }
+}
+
+async function evaluate(cdp, expression) {
+  const result = await cdp.send("Runtime.evaluate", {
+    expression,
+    awaitPromise: true,
+    returnByValue: true,
+  });
+  if (result.exceptionDetails) throw new Error(result.exceptionDetails.text || "Browser evaluation failed");
+  return result.result?.value;
+}
+
+async function setViewport(cdp, viewport) {
+  await cdp.send("Emulation.setDeviceMetricsOverride", {
+    width: viewport.width,
+    height: viewport.height,
+    deviceScaleFactor: 1,
+    mobile: false,
+  });
+}
+
+async function captureFailure(cdp, viewport) {
+  await fs.mkdir(SCREENSHOT_DIR, { recursive: true });
+  const result = await cdp.send("Page.captureScreenshot", { format: "png", fromSurface: true, captureBeyondViewport: true });
+  const filename = `landing-${viewport.name}.png`;
+  await fs.writeFile(path.join(SCREENSHOT_DIR, filename), Buffer.from(result.data, "base64"));
+  return filename;
+}
+
+function assertInside(rect, viewportWidth, label) {
+  assert.ok(rect, `${label} is missing`);
+  assert.ok(rect.left >= -1, `${label} starts outside viewport: ${rect.left}`);
+  assert.ok(rect.right <= viewportWidth + 1, `${label} exceeds viewport: ${rect.right} > ${viewportWidth}`);
+}
+
+const chrome = findChrome();
+assert.ok(chrome, "Chrome/Chromium is required for marketing responsive CI");
+
+const server = await createServer({ root: process.cwd(), logLevel: "error", server: { host: HOST, port: APP_PORT, strictPort: true } });
+const userDataDir = await fs.mkdtemp(path.join(os.tmpdir(), "bragstack-marketing-layout-"));
+let browser;
+let cdp;
+const failures = [];
+
+try {
+  await fs.rm(SCREENSHOT_DIR, { recursive: true, force: true });
+  await server.listen();
+  browser = spawn(chrome, [
+    "--headless=new",
+    "--no-sandbox",
+    "--disable-gpu",
+    "--disable-dev-shm-usage",
+    `--remote-debugging-port=${DEBUG_PORT}`,
+    `--user-data-dir=${userDataDir}`,
+    "about:blank",
+  ], { stdio: ["ignore", "ignore", "pipe"] });
+
+  const target = await findPageTarget();
+  cdp = new CDP(target.webSocketDebuggerUrl);
+  await cdp.open();
+  await Promise.all([cdp.send("Page.enable"), cdp.send("Runtime.enable")]);
+
+  for (const viewport of VIEWPORTS) {
+    const label = `/ @ ${viewport.width}x${viewport.height}`;
+    try {
+      await setViewport(cdp, viewport);
+      await cdp.send("Page.navigate", { url: BASE_URL });
+      await waitFor(async () => evaluate(cdp, `Boolean(document.querySelector(".feature-dashboard-preview"))`), 12000);
+      await new Promise((resolve) => setTimeout(resolve, 150));
+
+      const layout = await evaluate(cdp, `(() => {
+        const rect = (selector) => {
+          const element = document.querySelector(selector);
+          if (!element) return null;
+          const value = element.getBoundingClientRect();
+          return { left: value.left, right: value.right, width: value.width };
+        };
+        const header = document.querySelector(".feature-preview-header");
+        const cards = [...document.querySelectorAll(".feature-preview-header > div")].map((element) => {
+          const value = element.getBoundingClientRect();
+          const strong = element.querySelector("strong");
+          return {
+            left: value.left,
+            right: value.right,
+            width: value.width,
+            fontSize: strong ? Number.parseFloat(getComputedStyle(strong).fontSize) : 0,
+          };
+        });
+        const headerRect = header?.getBoundingClientRect();
+        const offenders = [...document.querySelectorAll(".landing-feature-section *")]
+          .filter((element) => {
+            const style = getComputedStyle(element);
+            if (style.display === "none" || style.visibility === "hidden") return false;
+            const value = element.getBoundingClientRect();
+            return value.right > window.innerWidth + 1 || value.left < -1;
+          })
+          .slice(0, 10)
+          .map((element) => element.className || element.tagName);
+        return {
+          viewportWidth: window.innerWidth,
+          documentWidth: Math.max(document.documentElement.scrollWidth, document.body.scrollWidth),
+          section: rect(".landing-feature-section"),
+          preview: rect(".feature-dashboard-preview"),
+          entry: rect(".feature-preview-entry"),
+          headerWidth: headerRect?.width || 0,
+          cards,
+          offenders,
+        };
+      })()`);
+
+      assert.ok(layout.documentWidth <= layout.viewportWidth + 1, `${label} has horizontal document overflow`);
+      assertInside(layout.section, layout.viewportWidth, `${label} feature section`);
+      assertInside(layout.preview, layout.viewportWidth, `${label} dashboard preview`);
+      assertInside(layout.entry, layout.viewportWidth, `${label} receipt preview`);
+      assert.equal(layout.cards.length, 2, `${label} should render two summary cards`);
+      layout.cards.forEach((card, index) => {
+        assertInside(card, layout.viewportWidth, `${label} summary card ${index + 1}`);
+        assert.ok(card.width >= layout.headerWidth * 0.85, `${label} summary card ${index + 1} is still squeezed into a multi-column phone layout`);
+        assert.ok(card.fontSize <= 24.5, `${label} summary card ${index + 1} text is too large for mobile: ${card.fontSize}px`);
+      });
+      assert.equal(layout.offenders.length, 0, `${label} contains clipped marketing elements: ${JSON.stringify(layout.offenders)}`);
+      console.log(`MARKETING RESPONSIVE PASS ${label}`);
+    } catch (error) {
+      let screenshot = "";
+      try { screenshot = await captureFailure(cdp, viewport); } catch { /* best effort */ }
+      failures.push(`${label}: ${error.message}${screenshot ? ` [screenshot: ${screenshot}]` : ""}`);
+    }
+  }
+
+  if (failures.length) {
+    console.error("\nMARKETING RESPONSIVE FAILURES");
+    failures.forEach((failure) => console.error(`- ${failure}`));
+    process.exitCode = 1;
+  } else {
+    console.log(`\nMarketing responsive guard passed ${VIEWPORTS.length} phone widths.`);
+  }
+} finally {
+  cdp?.close();
+  if (browser && browser.exitCode === null && browser.signalCode === null) browser.kill("SIGKILL");
+  await server.close();
+  await fs.rm(userDataDir, { recursive: true, force: true, maxRetries: 8, retryDelay: 150 });
+}

--- a/frontend/src/LandingPageMobileGuard.css
+++ b/frontend/src/LandingPageMobileGuard.css
@@ -1,33 +1,35 @@
 /* Mobile guardrails for the public BragStack marketing page.
    Keep the existing brand system intact while preventing preview cards from
-   becoming cramped or unreadable on narrow phones. */
+   becoming cramped or unreadable on narrow phones. The .landing-page prefix
+   intentionally gives these narrow-screen rules higher specificity than the
+   lazy-loaded landing-page stylesheet. */
 
 @media (max-width: 720px) {
-  .landing-feature-section {
+  .landing-page .landing-feature-section {
     padding: 1.25rem;
     gap: 2rem;
     border-radius: 24px;
   }
 
-  .feature-dashboard-preview {
+  .landing-page .feature-dashboard-preview {
     width: 100%;
     min-width: 0;
     padding: 0.75rem;
     border-radius: 20px;
   }
 
-  .feature-preview-header {
+  .landing-page .feature-preview-header {
     padding: 0.25rem;
     grid-template-columns: 1fr;
     gap: 0.65rem;
   }
 
-  .feature-preview-header > div {
+  .landing-page .feature-preview-header > div {
     min-width: 0;
     padding: 0.9rem 1rem;
   }
 
-  .feature-preview-header strong {
+  .landing-page .feature-preview-header strong {
     display: block;
     font-size: clamp(1.25rem, 6vw, 1.5rem);
     line-height: 1.15;
@@ -35,42 +37,42 @@
     overflow-wrap: anywhere;
   }
 
-  .feature-preview-entry {
+  .landing-page .feature-preview-entry {
     min-width: 0;
     padding: 1rem;
   }
 
-  .feature-preview-entry h3 {
+  .landing-page .feature-preview-entry h3 {
     font-size: 1.15rem;
     line-height: 1.3;
     overflow-wrap: anywhere;
   }
 
-  .feature-preview-entry p {
+  .landing-page .feature-preview-entry p {
     font-size: 0.95rem;
     line-height: 1.55;
   }
 
-  .feature-preview-tags {
+  .landing-page .feature-preview-tags {
     gap: 0.35rem;
   }
 }
 
 @media (max-width: 420px) {
-  .landing-feature-section {
+  .landing-page .landing-feature-section {
     padding: 1rem;
   }
 
-  .feature-dashboard-preview {
+  .landing-page .feature-dashboard-preview {
     padding: 0.6rem;
   }
 
-  .feature-preview-header > div,
-  .feature-preview-entry {
+  .landing-page .feature-preview-header > div,
+  .landing-page .feature-preview-entry {
     padding: 0.85rem;
   }
 
-  .feature-preview-entry > div:first-child {
+  .landing-page .feature-preview-entry > div:first-child {
     gap: 0.5rem;
   }
 }

--- a/frontend/src/LandingPageMobileGuard.css
+++ b/frontend/src/LandingPageMobileGuard.css
@@ -1,0 +1,76 @@
+/* Mobile guardrails for the public BragStack marketing page.
+   Keep the existing brand system intact while preventing preview cards from
+   becoming cramped or unreadable on narrow phones. */
+
+@media (max-width: 720px) {
+  .landing-feature-section {
+    padding: 1.25rem;
+    gap: 2rem;
+    border-radius: 24px;
+  }
+
+  .feature-dashboard-preview {
+    width: 100%;
+    min-width: 0;
+    padding: 0.75rem;
+    border-radius: 20px;
+  }
+
+  .feature-preview-header {
+    padding: 0.25rem;
+    grid-template-columns: 1fr;
+    gap: 0.65rem;
+  }
+
+  .feature-preview-header > div {
+    min-width: 0;
+    padding: 0.9rem 1rem;
+  }
+
+  .feature-preview-header strong {
+    display: block;
+    font-size: clamp(1.25rem, 6vw, 1.5rem);
+    line-height: 1.15;
+    letter-spacing: -0.025em;
+    overflow-wrap: anywhere;
+  }
+
+  .feature-preview-entry {
+    min-width: 0;
+    padding: 1rem;
+  }
+
+  .feature-preview-entry h3 {
+    font-size: 1.15rem;
+    line-height: 1.3;
+    overflow-wrap: anywhere;
+  }
+
+  .feature-preview-entry p {
+    font-size: 0.95rem;
+    line-height: 1.55;
+  }
+
+  .feature-preview-tags {
+    gap: 0.35rem;
+  }
+}
+
+@media (max-width: 420px) {
+  .landing-feature-section {
+    padding: 1rem;
+  }
+
+  .feature-dashboard-preview {
+    padding: 0.6rem;
+  }
+
+  .feature-preview-header > div,
+  .feature-preview-entry {
+    padding: 0.85rem;
+  }
+
+  .feature-preview-entry > div:first-child {
+    gap: 0.5rem;
+  }
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -5,6 +5,7 @@ import "./index.css";
 import "./ReferencePolish.css";
 import "./MarketingFooterOrder.css";
 import "./ResponsiveLayoutGuard.css";
+import "./LandingPageMobileGuard.css";
 import RootContent from "./RootContent.jsx";
 import { installInterviewBrowserPreflight } from "./interviewBrowserPreflight.js";
 


### PR DESCRIPTION
## What changed
- keeps the existing BragStack branding and new evidence-layer marketing copy intact
- adds narrow-phone overrides for the marketing feature preview shown in the reported iPhone screenshot
- stacks Evidence state / Visibility summary cards vertically on phones instead of squeezing them into two narrow columns
- reduces summary-card typography and preview padding at phone breakpoints
- keeps the Impact Receipt preview readable without overflow or extreme wrapping
- adds a dedicated public landing-page responsive browser audit at 360px, 390px, and 430px
- wires the marketing audit into `npm run test:layout` so `/` is covered alongside authenticated app routes

## Why
The existing responsive CI only exercised authenticated app routes, so the public marketing page could pass CI while the feature preview became visually broken at phone widths.

## Validation gate
Merge only with Frontend CI, Backend CI, and Security CI green on this exact head. Frontend CI must pass both the existing authenticated responsive audit and the new public marketing responsive audit.