### PR TITLE
Fix landing-page feature preview on mobile

### DIFF
--- a/frontend/src/LandingPageMobileFix.css
+++ b/frontend/src/LandingPageMobileFix.css
@@ -1,0 +1,65 @@
+/* Mobile-only safeguards for the marketing feature preview.
+ * Keep the BragStack desktop branding intact while preventing narrow iPhone
+ * layouts from forcing the evidence-state cards into unreadable columns.
+ */
+@media (max-width: 720px) {
+  .landing-feature-section {
+    padding: 1.25rem;
+    gap: 1.75rem;
+  }
+
+  .feature-dashboard-preview {
+    width: 100%;
+    min-width: 0;
+    padding: 0.65rem;
+  }
+
+  .feature-preview-header {
+    padding: 0;
+    grid-template-columns: 1fr;
+    gap: 0.65rem;
+  }
+
+  .feature-preview-header > div {
+    min-width: 0;
+    padding: 0.9rem;
+  }
+
+  .feature-preview-header strong {
+    display: block;
+    font-size: clamp(1.2rem, 6vw, 1.55rem);
+    line-height: 1.15;
+    overflow-wrap: anywhere;
+  }
+
+  .feature-preview-entry {
+    min-width: 0;
+    margin-top: 0.65rem;
+    padding: 1rem;
+  }
+
+  .feature-preview-entry h3 {
+    font-size: 1.2rem;
+    line-height: 1.25;
+  }
+
+  .feature-preview-entry p {
+    font-size: 0.95rem;
+    line-height: 1.6;
+  }
+
+  .feature-preview-tags {
+    max-width: 100%;
+  }
+}
+
+@media (max-width: 390px) {
+  .landing-feature-section {
+    width: calc(100% - 0.75rem);
+    padding: 1rem;
+  }
+
+  .feature-dashboard-preview {
+    padding: 0.5rem;
+  }
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -5,6 +5,7 @@ import "./index.css";
 import "./ReferencePolish.css";
 import "./MarketingFooterOrder.css";
 import "./ResponsiveLayoutGuard.css";
+import "./LandingPageMobileFix.css";
 import RootContent from "./RootContent.jsx";
 import { installInterviewBrowserPreflight } from "./interviewBrowserPreflight.js";
 


### PR DESCRIPTION
## Summary
- preserve the existing BragStack branding and desktop marketing layout
- stack the Evidence State / Visibility cards on narrow screens instead of squeezing them into two columns
- reduce mobile feature-section and preview padding
- constrain typography and wrapping inside the Impact Receipt preview
- add a narrow-screen safeguard for <=390px devices

## Why
The production marketing page currently renders the feature preview poorly on iPhone-width screens: the two status cards become extremely narrow and their large text wraps into oversized vertical blocks. This patch is intentionally CSS-only and mobile-scoped.

## Validation requested
- Frontend CI / lint / build
- responsive/browser audit at iPhone widths
- confirm desktop marketing branding/layout is unchanged