### PR TITLE
Track core BragStack funnel events in GA4

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -58,6 +58,10 @@ jobs:
         if: github.event_name != 'pull_request' || steps.changes.outputs.run_frontend == 'true'
         run: npm ci
 
+      - name: Test analytics events and UTM attribution
+        if: github.event_name != 'pull_request' || steps.changes.outputs.run_frontend == 'true'
+        run: npm run test:analytics
+
       - name: Verify Aisha source and real-browser render
         if: github.event_name != 'pull_request' || steps.changes.outputs.run_frontend == 'true'
         run: node scripts/verify-aisha-source.mjs

--- a/docs/ga4-attribution.md
+++ b/docs/ga4-attribution.md
@@ -1,0 +1,47 @@
+# GA4 attribution setup
+
+BragStack sends privacy-minimized campaign attribution on core funnel events. The code captures current-session `utm_*` values and preserves original acquisition values as `first_utm_*` event parameters.
+
+## Core tracked events
+
+- `sign_up`
+- `accomplishment_created`
+- `impact_receipt_created`
+
+## Register first-touch attribution in GA4
+
+In Google Analytics, open **Admin → Data display → Custom definitions → Custom dimensions → Create custom dimension**.
+
+Create each item below with **Scope = Event**.
+
+| Dimension name | Event parameter | Description |
+| --- | --- | --- |
+| First UTM Source | `first_utm_source` | Original campaign source that first brought the visitor to BragStack. |
+| First UTM Medium | `first_utm_medium` | Original campaign medium. |
+| First UTM Campaign | `first_utm_campaign` | Original campaign name. |
+| First UTM Campaign ID | `first_utm_id` | Original campaign ID, when supplied. |
+| First UTM Source Platform | `first_utm_source_platform` | Original source platform, when supplied. |
+| First UTM Term | `first_utm_term` | Original campaign term, when supplied. |
+| First UTM Content | `first_utm_content` | Original campaign content variant, when supplied. |
+| First UTM Creative Format | `first_utm_creative_format` | Original creative format, when supplied. |
+| First UTM Marketing Tactic | `first_utm_marketing_tactic` | Original marketing tactic, when supplied. |
+
+Do not rename the **Event parameter** values. The display names can be changed later in GA4, but the parameter mapping is the contract with the frontend instrumentation.
+
+## Recommended campaign convention
+
+Example LinkedIn founder-launch URL:
+
+```text
+https://usebragstack.com/?utm_source=linkedin&utm_medium=organic_social&utm_campaign=beta_launch&utm_content=founder_post
+```
+
+Use stable lowercase values where possible so reporting does not fragment (`linkedin` vs `LinkedIn`, `organic_social` vs `social-organic`).
+
+## Privacy guardrails
+
+BragStack only reads the explicit UTM allowlist. It does not intentionally send email addresses, names, accomplishment text, evidence content, or arbitrary query-string values to GA4. Keep campaign tags free of personal information.
+
+## Reporting
+
+After GA4 has collected the parameters and the custom dimensions have been registered, allow approximately 24–48 hours for them to become available in reports and explorations.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
+    "test:analytics": "node --test src/analytics.test.js",
     "test:interview": "node --test src/interviewEngine*.test.js",
     "test:resume": "node --test src/resumeStructured.test.js src/dashboardTags.test.js",
     "test:seo": "node scripts/verify-search-appearance.mjs",

--- a/frontend/src/ImpactReceiptsResponsive.css
+++ b/frontend/src/ImpactReceiptsResponsive.css
@@ -1,0 +1,172 @@
+/* Impact Receipt display polish: keep Safari/tablet rendering intentional. */
+.receipt-card-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  flex: 0 0 auto;
+  background: transparent;
+}
+
+.receipt-card-actions > button {
+  appearance: none;
+  -webkit-appearance: none;
+  margin: 0;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(15, 23, 42, 0.92);
+  color: #dbeafe;
+  box-shadow: none;
+}
+
+.receipt-card-actions > button:not(.visibility-pill) {
+  width: 40px;
+  height: 40px;
+  padding: 0;
+  border-radius: 12px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.receipt-card-actions > button:not(.visibility-pill):hover,
+.receipt-card-actions > button:not(.visibility-pill):focus-visible {
+  border-color: rgba(125, 211, 252, 0.5);
+  background: rgba(30, 41, 59, 0.96);
+  outline: none;
+}
+
+.receipt-library-card > .receipt-signal-row > span {
+  max-width: 100%;
+  min-width: 0;
+  border-radius: 14px;
+  line-height: 1.4;
+  white-space: normal;
+  overflow-wrap: anywhere;
+}
+
+.receipt-chip-row > span {
+  max-width: 100%;
+  min-width: 0;
+  line-height: 1.35;
+  white-space: normal;
+  overflow-wrap: anywhere;
+}
+
+.receipt-evidence-list {
+  display: grid;
+  gap: 10px;
+  margin-top: 18px;
+}
+
+.receipt-evidence-heading {
+  color: #e2e8f0;
+  font-weight: 850;
+}
+
+.receipt-evidence-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  min-width: 0;
+  padding: 14px 16px;
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  border-radius: 16px;
+  background: rgba(2, 6, 23, 0.28);
+}
+
+.receipt-evidence-row > div:first-child {
+  display: grid;
+  gap: 6px;
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+.receipt-evidence-row > div:first-child > strong {
+  color: #f8fafc;
+  overflow-wrap: anywhere;
+}
+
+.receipt-evidence-row > div:first-child > span {
+  display: inline-flex;
+  width: max-content;
+  max-width: 100%;
+  padding: 4px 8px;
+  border-radius: 999px;
+  border: 1px solid rgba(125, 211, 252, 0.18);
+  background: rgba(14, 116, 144, 0.1);
+  color: #7dd3fc;
+  font-size: 0.72rem;
+  font-weight: 850;
+}
+
+.receipt-evidence-row p {
+  margin: 2px 0 0;
+  color: #cbd5e1;
+  line-height: 1.55;
+  overflow-wrap: anywhere;
+}
+
+.receipt-evidence-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 8px;
+  min-width: 0;
+}
+
+.receipt-evidence-actions a {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 36px;
+  min-height: 36px;
+  padding: 8px 10px;
+  border-radius: 10px;
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  background: rgba(30, 41, 59, 0.72);
+  color: #bae6fd;
+  text-decoration: none;
+  overflow-wrap: anywhere;
+}
+
+@media (max-width: 820px) {
+  .receipt-library-card-top {
+    gap: 16px;
+  }
+
+  .receipt-library-card-top > div:first-child {
+    min-width: 0;
+  }
+
+  .receipt-card-actions {
+    max-width: 180px;
+  }
+
+  .receipt-evidence-row {
+    flex-direction: column;
+  }
+
+  .receipt-evidence-actions {
+    justify-content: flex-start;
+    width: 100%;
+  }
+}
+
+@media (max-width: 560px) {
+  .receipt-library-card-top {
+    flex-direction: column;
+  }
+
+  .receipt-card-actions {
+    justify-content: flex-start;
+    max-width: none;
+    width: 100%;
+  }
+
+  .receipt-card-actions .visibility-pill {
+    margin-right: auto;
+  }
+}

--- a/frontend/src/analytics.js
+++ b/frontend/src/analytics.js
@@ -2,16 +2,19 @@ const GA_MEASUREMENT_ID = "G-MKGEER9N5C";
 
 const GA_NAME_PATTERN = /^[a-z][a-z0-9_]{0,39}$/;
 const UTM_FIELDS = [
+  "utm_id",
   "utm_source",
   "utm_medium",
   "utm_campaign",
-  "utm_id",
+  "utm_source_platform",
   "utm_term",
   "utm_content",
+  "utm_creative_format",
+  "utm_marketing_tactic",
 ];
 const FIRST_TOUCH_UTM_KEY = "bragstack_first_touch_utm";
 const SESSION_UTM_KEY = "bragstack_session_utm";
-const MAX_ATTRIBUTION_VALUE_LENGTH = 120;
+const MAX_ATTRIBUTION_VALUE_LENGTH = 100;
 
 export const ANALYTICS_EVENTS = Object.freeze({
   SIGN_UP: "sign_up",

--- a/frontend/src/analytics.js
+++ b/frontend/src/analytics.js
@@ -1,7 +1,92 @@
 const GA_MEASUREMENT_ID = "G-MKGEER9N5C";
 
+const GA_NAME_PATTERN = /^[a-z][a-z0-9_]{0,39}$/;
+const UTM_FIELDS = [
+  "utm_source",
+  "utm_medium",
+  "utm_campaign",
+  "utm_id",
+  "utm_term",
+  "utm_content",
+];
+const FIRST_TOUCH_UTM_KEY = "bragstack_first_touch_utm";
+const SESSION_UTM_KEY = "bragstack_session_utm";
+const MAX_ATTRIBUTION_VALUE_LENGTH = 120;
+
+export const ANALYTICS_EVENTS = Object.freeze({
+  SIGN_UP: "sign_up",
+  ACCOMPLISHMENT_CREATED: "accomplishment_created",
+  IMPACT_RECEIPT_CREATED: "impact_receipt_created",
+});
+
+function safeStorageRead(storage, key) {
+  try {
+    const rawValue = storage?.getItem(key);
+    return rawValue ? JSON.parse(rawValue) : {};
+  } catch {
+    return {};
+  }
+}
+
+function safeStorageWrite(storage, key, value) {
+  try {
+    storage?.setItem(key, JSON.stringify(value));
+  } catch {
+    // Analytics must never break a product flow when browser storage is blocked.
+  }
+}
+
+function readUtmParametersFromUrl() {
+  if (typeof window === "undefined") return {};
+
+  const params = new URLSearchParams(window.location.search);
+  return Object.fromEntries(
+    UTM_FIELDS.flatMap((field) => {
+      const value = params.get(field)?.trim().slice(0, MAX_ATTRIBUTION_VALUE_LENGTH);
+      return value ? [[field, value]] : [];
+    }),
+  );
+}
+
+export function captureCampaignAttribution() {
+  if (typeof window === "undefined") return {};
+
+  const incomingUtm = readUtmParametersFromUrl();
+  if (!Object.keys(incomingUtm).length) {
+    return safeStorageRead(window.sessionStorage, SESSION_UTM_KEY);
+  }
+
+  safeStorageWrite(window.sessionStorage, SESSION_UTM_KEY, incomingUtm);
+
+  const existingFirstTouch = safeStorageRead(window.localStorage, FIRST_TOUCH_UTM_KEY);
+  if (!Object.keys(existingFirstTouch).length) {
+    safeStorageWrite(window.localStorage, FIRST_TOUCH_UTM_KEY, incomingUtm);
+  }
+
+  return incomingUtm;
+}
+
+export function getCampaignEventParameters() {
+  if (typeof window === "undefined") return {};
+
+  const sessionUtm = captureCampaignAttribution();
+  const firstTouchUtm = safeStorageRead(window.localStorage, FIRST_TOUCH_UTM_KEY);
+
+  return {
+    ...sessionUtm,
+    ...Object.fromEntries(
+      Object.entries(firstTouchUtm).map(([key, value]) => [
+        `first_${key}`,
+        value,
+      ]),
+    ),
+  };
+}
+
 export function initializeAnalytics() {
   if (typeof window === "undefined" || typeof document === "undefined") return;
+
+  captureCampaignAttribution();
   if (window.__bragstackGaInitialized) return;
 
   window.__bragstackGaInitialized = true;
@@ -18,6 +103,33 @@ export function initializeAnalytics() {
   script.src = `https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`;
   script.dataset.bragstackAnalytics = "true";
   document.head.appendChild(script);
+}
+
+function sanitizeEventParameters(parameters = {}) {
+  return Object.fromEntries(
+    Object.entries(parameters).filter(([key, value]) => {
+      if (!GA_NAME_PATTERN.test(key)) return false;
+      if (value === null || value === undefined || value === "") return false;
+      return ["string", "number", "boolean"].includes(typeof value);
+    }),
+  );
+}
+
+export function trackAnalyticsEvent(eventName, parameters = {}) {
+  if (typeof window === "undefined" || !GA_NAME_PATTERN.test(eventName)) return false;
+
+  initializeAnalytics();
+  if (typeof window.gtag !== "function") return false;
+
+  window.gtag(
+    "event",
+    eventName,
+    sanitizeEventParameters({
+      ...getCampaignEventParameters(),
+      ...parameters,
+    }),
+  );
+  return true;
 }
 
 export { GA_MEASUREMENT_ID };

--- a/frontend/src/analytics.test.js
+++ b/frontend/src/analytics.test.js
@@ -1,26 +1,138 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import { GA_MEASUREMENT_ID, initializeAnalytics } from "./analytics.js";
+import assert from "node:assert/strict";
+import { beforeEach, describe, it } from "node:test";
 
-describe("initializeAnalytics", () => {
+import {
+  ANALYTICS_EVENTS,
+  GA_MEASUREMENT_ID,
+  captureCampaignAttribution,
+  getCampaignEventParameters,
+  initializeAnalytics,
+  trackAnalyticsEvent,
+} from "./analytics.js";
+
+class MemoryStorage {
+  constructor() {
+    this.values = new Map();
+  }
+
+  clear() {
+    this.values.clear();
+  }
+
+  getItem(key) {
+    return this.values.has(key) ? this.values.get(key) : null;
+  }
+
+  setItem(key, value) {
+    this.values.set(key, String(value));
+  }
+}
+
+function setUrl(path) {
+  globalThis.window.location = new URL(path, "https://usebragstack.com");
+}
+
+function installBrowserFakes() {
+  const scripts = [];
+  globalThis.window = {
+    location: new URL("https://usebragstack.com/"),
+    localStorage: new MemoryStorage(),
+    sessionStorage: new MemoryStorage(),
+  };
+  globalThis.document = {
+    createElement() {
+      return { async: false, src: "", dataset: {} };
+    },
+    head: {
+      appendChild(node) {
+        scripts.push(node);
+        return node;
+      },
+      querySelector(selector) {
+        if (selector !== "script[data-bragstack-analytics]") return null;
+        return scripts.find((node) => node.dataset?.bragstackAnalytics === "true") ?? null;
+      },
+      querySelectorAll(selector) {
+        if (selector !== "script[data-bragstack-analytics]") return [];
+        return scripts.filter((node) => node.dataset?.bragstackAnalytics === "true");
+      },
+    },
+  };
+}
+
+describe("BragStack analytics", () => {
   beforeEach(() => {
-    delete window.__bragstackGaInitialized;
-    delete window.dataLayer;
-    delete window.gtag;
-    document.head.querySelectorAll("script[data-bragstack-analytics]").forEach((node) => node.remove());
+    installBrowserFakes();
   });
 
   it("loads the BragStack GA4 tag and configures the measurement ID once", () => {
-    const appendSpy = vi.spyOn(document.head, "appendChild");
-
     initializeAnalytics();
     initializeAnalytics();
 
     const script = document.head.querySelector("script[data-bragstack-analytics]");
-    expect(script).not.toBeNull();
-    expect(script.src).toContain(`googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`);
-    expect(window.dataLayer.some((entry) => entry[0] === "config" && entry[1] === GA_MEASUREMENT_ID)).toBe(true);
-    expect(appendSpy).toHaveBeenCalledTimes(1);
+    assert.ok(script);
+    assert.match(script.src, new RegExp(`googletagmanager\\.com/gtag/js\\?id=${GA_MEASUREMENT_ID}`));
+    assert.equal(
+      window.dataLayer.filter((entry) => entry[0] === "config" && entry[1] === GA_MEASUREMENT_ID).length,
+      1,
+    );
+    assert.equal(document.head.querySelectorAll("script[data-bragstack-analytics]").length, 1);
+  });
 
-    appendSpy.mockRestore();
+  it("captures session and first-touch UTM attribution without storing unrelated query parameters", () => {
+    setUrl(
+      "/?utm_source=linkedin&utm_medium=social&utm_campaign=founder_launch&utm_content=profile&email=private@example.com",
+    );
+
+    const captured = captureCampaignAttribution();
+    const parameters = getCampaignEventParameters();
+
+    assert.deepEqual(captured, {
+      utm_source: "linkedin",
+      utm_medium: "social",
+      utm_campaign: "founder_launch",
+      utm_content: "profile",
+    });
+    assert.equal(parameters.utm_source, "linkedin");
+    assert.equal(parameters.utm_medium, "social");
+    assert.equal(parameters.utm_campaign, "founder_launch");
+    assert.equal(parameters.first_utm_source, "linkedin");
+    assert.equal(parameters.first_utm_medium, "social");
+    assert.equal(parameters.first_utm_campaign, "founder_launch");
+    assert.doesNotMatch(JSON.stringify(parameters), /private@example\.com/);
+  });
+
+  it("keeps first-touch attribution while allowing a later campaign to become the active session campaign", () => {
+    setUrl("/?utm_source=linkedin&utm_campaign=launch");
+    captureCampaignAttribution();
+
+    window.sessionStorage.clear();
+    setUrl("/?utm_source=newsletter&utm_campaign=return_visit");
+    captureCampaignAttribution();
+
+    const parameters = getCampaignEventParameters();
+    assert.equal(parameters.utm_source, "newsletter");
+    assert.equal(parameters.utm_campaign, "return_visit");
+    assert.equal(parameters.first_utm_source, "linkedin");
+    assert.equal(parameters.first_utm_campaign, "launch");
+  });
+
+  it("enriches successful product events with UTM attribution", () => {
+    setUrl("/register?utm_source=linkedin&utm_medium=social&utm_campaign=beta");
+
+    const tracked = trackAnalyticsEvent(ANALYTICS_EVENTS.SIGN_UP, {
+      method: "email_password",
+    });
+
+    assert.equal(tracked, true);
+    const event = window.dataLayer.find(
+      (entry) => entry[0] === "event" && entry[1] === ANALYTICS_EVENTS.SIGN_UP,
+    );
+    assert.ok(event);
+    assert.equal(event[2].method, "email_password");
+    assert.equal(event[2].utm_source, "linkedin");
+    assert.equal(event[2].utm_medium, "social");
+    assert.equal(event[2].utm_campaign, "beta");
+    assert.equal(event[2].first_utm_source, "linkedin");
   });
 });

--- a/frontend/src/analytics.test.js
+++ b/frontend/src/analytics.test.js
@@ -79,9 +79,9 @@ describe("BragStack analytics", () => {
     assert.equal(document.head.querySelectorAll("script[data-bragstack-analytics]").length, 1);
   });
 
-  it("captures session and first-touch UTM attribution without storing unrelated query parameters", () => {
+  it("captures approved UTM attribution without storing unrelated query parameters", () => {
     setUrl(
-      "/?utm_source=linkedin&utm_medium=social&utm_campaign=founder_launch&utm_content=profile&email=private@example.com",
+      "/?utm_source=linkedin&utm_medium=paid_social&utm_campaign=founder_launch&utm_source_platform=linkedin_ads&utm_content=profile&utm_creative_format=video&utm_marketing_tactic=prospecting&email=private@example.com",
     );
 
     const captured = captureCampaignAttribution();
@@ -89,17 +89,27 @@ describe("BragStack analytics", () => {
 
     assert.deepEqual(captured, {
       utm_source: "linkedin",
-      utm_medium: "social",
+      utm_medium: "paid_social",
       utm_campaign: "founder_launch",
+      utm_source_platform: "linkedin_ads",
       utm_content: "profile",
+      utm_creative_format: "video",
+      utm_marketing_tactic: "prospecting",
     });
     assert.equal(parameters.utm_source, "linkedin");
-    assert.equal(parameters.utm_medium, "social");
-    assert.equal(parameters.utm_campaign, "founder_launch");
+    assert.equal(parameters.utm_source_platform, "linkedin_ads");
     assert.equal(parameters.first_utm_source, "linkedin");
-    assert.equal(parameters.first_utm_medium, "social");
-    assert.equal(parameters.first_utm_campaign, "founder_launch");
+    assert.equal(parameters.first_utm_source_platform, "linkedin_ads");
     assert.doesNotMatch(JSON.stringify(parameters), /private@example\.com/);
+  });
+
+  it("caps UTM values at the GA4 event-parameter value limit", () => {
+    const oversizedCampaign = "x".repeat(150);
+    setUrl(`/?utm_source=linkedin&utm_campaign=${oversizedCampaign}`);
+
+    const captured = captureCampaignAttribution();
+
+    assert.equal(captured.utm_campaign.length, 100);
   });
 
   it("keeps first-touch attribution while allowing a later campaign to become the active session campaign", () => {

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,5 +1,6 @@
 import axios from "axios";
 
+import { ANALYTICS_EVENTS, trackAnalyticsEvent } from "./analytics.js";
 import { normalizeDashboardTags } from "./dashboardTags.js";
 
 function getDefaultApiBaseUrl() {
@@ -104,6 +105,25 @@ api.interceptors.request.use((config) => {
   const token = localStorage.getItem("bragstack_token");
   if (token) config.headers.Authorization = `Bearer ${token}`;
   return config;
+});
+
+api.interceptors.response.use((response) => {
+  const method = String(response.config?.method || "").toLowerCase();
+  const url = String(response.config?.url || "").split("?")[0];
+
+  if (method !== "post") return response;
+
+  if (url === "/auth/register") {
+    trackAnalyticsEvent(ANALYTICS_EVENTS.SIGN_UP, { method: "email_password" });
+  } else if (url === "/entries") {
+    trackAnalyticsEvent(ANALYTICS_EVENTS.ACCOMPLISHMENT_CREATED);
+  } else if (url === "/impact-receipts") {
+    trackAnalyticsEvent(ANALYTICS_EVENTS.IMPACT_RECEIPT_CREATED, { creation_source: "manual" });
+  } else if (url.startsWith("/impact-receipts/from-entry/")) {
+    trackAnalyticsEvent(ANALYTICS_EVENTS.IMPACT_RECEIPT_CREATED, { creation_source: "accomplishment" });
+  }
+
+  return response;
 });
 
 export async function registerUser(user) { const response = await api.post("/auth/register", user); return response.data; }

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -5,6 +5,7 @@ import "./index.css";
 import "./ReferencePolish.css";
 import "./MarketingFooterOrder.css";
 import "./ResponsiveLayoutGuard.css";
+import "./ImpactReceiptsResponsive.css";
 import RootContent from "./RootContent.jsx";
 import { installInterviewBrowserPreflight } from "./interviewBrowserPreflight.js";
 


### PR DESCRIPTION
## What this adds
- Adds a reusable GA4 event helper on top of BragStack's existing `G-MKGEER9N5C` analytics bootstrap.
- Emits GA4 `sign_up` only after successful registration.
- Emits `accomplishment_created` only after a successful `POST /entries`.
- Emits `impact_receipt_created` after successful receipt creation, with a safe `creation_source` value (`manual` or `accomplishment`).
- Centralizes write-event tracking in the Axios success interceptor so future UI surfaces using the same API client inherit the instrumentation.
- Captures Google's current UTM set: `utm_id`, `utm_source`, `utm_medium`, `utm_campaign`, `utm_source_platform`, `utm_term`, `utm_content`, `utm_creative_format`, and `utm_marketing_tactic`.
- Persists active-session UTM attribution through navigation/auth flows and preserves separate first-touch UTM attribution across later sessions.
- Enriches the three core funnel events with the active campaign and first-touch campaign values.
- Caps UTM values at GA4's 100-character standard event-parameter value limit.
- Documents the nine `first_utm_*` GA4 custom dimensions to register under Admin → Data display → Custom definitions.
- Fixes the Impact Receipt tablet/mobile display regression shown on iPad: Safari-default edit/delete controls, evidence metadata collisions, evidence-action layout, and long metric/skill pill overflow.

## Privacy
No email, name, accomplishment title, description, result, evidence, skills, full query string, or other user-written content is sent to GA4. Only the explicit UTM allowlist is read from campaign URLs; unrelated query parameters are discarded. Event/parameter names are validated and parameters are restricted to primitive values. Campaign tags should never contain personal information.

## Expected GA4 events
- `sign_up` (`method=email_password` + UTM attribution when present)
- `accomplishment_created` (+ UTM attribution when present)
- `impact_receipt_created` (`creation_source=manual|accomplishment` + UTM attribution when present)

## UTM behavior
A visit such as `/?utm_source=linkedin&utm_medium=paid_social&utm_campaign=beta` keeps those values through signup and later product events in the same session. `first_utm_*` parameters preserve the user's original acquisition campaign while a later campaign can become the current `utm_*` session attribution.

## Validation
Frontend CI explicitly runs `npm run test:analytics`. Analytics tests cover tag initialization, UTM allowlisting, GA4 value limits, session attribution, first-touch persistence, privacy filtering, and event enrichment. The normal browser click/layout checks, lint, build, bundle validation, Backend CI, Security CI, and branch protections remain required before merge.