### PR TITLE
Fix Proof Portfolio Calendly migration regression

### DIFF
--- a/.github/workflows/security-ci.yml
+++ b/.github/workflows/security-ci.yml
@@ -41,4 +41,27 @@ jobs:
 
       - name: Audit frontend dependencies
         working-directory: frontend
-        run: npm audit --audit-level=high
+        run: |
+          for attempt in 1 2 3; do
+            set +e
+            audit_output="$(npm audit --audit-level=high 2>&1)"
+            audit_status=$?
+            set -e
+
+            printf '%s\n' "$audit_output"
+            if [ "$audit_status" -eq 0 ]; then
+              exit 0
+            fi
+
+            if printf '%s\n' "$audit_output" | grep -Eq '503 Service Unavailable|audit endpoint returned an error|ECONNRESET|ETIMEDOUT|EAI_AGAIN'; then
+              if [ "$attempt" -lt 3 ]; then
+                echo "npm audit service unavailable; retrying transient registry failure ($attempt/3)."
+                sleep 10
+                continue
+              fi
+            fi
+
+            exit "$audit_status"
+          done
+
+          exit 1

--- a/backend/app/profile_connection_routes.py
+++ b/backend/app/profile_connection_routes.py
@@ -30,6 +30,21 @@ PUBLIC_PROFILE_EVENT_TYPES = {
 }
 
 
+def _is_calendly_booking_url(value: str | None) -> bool:
+    """Return whether a URL is an HTTPS Calendly scheduling page."""
+    if not value:
+        return False
+    normalized = value.strip().rstrip("/")
+    parsed = urlparse(normalized)
+    hostname = (parsed.hostname or "").lower()
+    return bool(
+        parsed.scheme == "https"
+        and (hostname == "calendly.com" or hostname.endswith(".calendly.com"))
+        and parsed.path
+        and parsed.path != "/"
+    )
+
+
 class ProfileConnectionUpdate(BaseModel):
     """Represent user-controlled Open to Talk and public scheduling settings."""
 
@@ -60,14 +75,8 @@ class ProfileConnectionUpdate(BaseModel):
         normalized = value.strip().rstrip("/")
         if not normalized:
             return ""
-        parsed = urlparse(normalized)
-        hostname = (parsed.hostname or "").lower()
-        if parsed.scheme != "https" or not (
-            hostname == "calendly.com" or hostname.endswith(".calendly.com")
-        ):
-            raise ValueError("Calendly URL must be an https://calendly.com/... link")
-        if not parsed.path or parsed.path == "/":
-            raise ValueError("Calendly URL must include your scheduling page path")
+        if not _is_calendly_booking_url(normalized):
+            raise ValueError("Calendly URL must be an https://calendly.com/... scheduling link")
         return normalized
 
     @field_validator("open_to_talk_types")
@@ -110,13 +119,33 @@ class PublicProfileAnalyticsEvent(BaseModel):
 
 
 def serialize_connection_settings(user: dict, *, public: bool) -> dict:
-    """Serialize connection settings without leaking disabled contact data."""
+    """Serialize connection settings without leaking disabled contact data.
+
+    Legacy users stored Calendly in ``open_to_talk_url`` before dedicated
+    Calendly fields existed. When that legacy URL was already explicitly
+    public through Open to Talk, continue exposing it as the inline scheduler
+    until the user saves the new Calendly settings. An explicit
+    ``calendly_enabled`` value always wins, so disabling the new integration is
+    respected.
+    """
     open_to_talk_enabled = bool(user.get("open_to_talk", False))
-    calendly_enabled = bool(user.get("calendly_enabled", False))
+    open_to_talk_url = user.get("open_to_talk_url", "") or ""
+    stored_calendly_url = user.get("calendly_url", "") or ""
+
+    legacy_calendly_url = ""
+    if open_to_talk_enabled and _is_calendly_booking_url(open_to_talk_url):
+        legacy_calendly_url = open_to_talk_url.strip().rstrip("/")
+
+    if "calendly_enabled" in user:
+        calendly_enabled = bool(user.get("calendly_enabled", False))
+    else:
+        calendly_enabled = bool(legacy_calendly_url)
+
+    effective_calendly_url = stored_calendly_url or legacy_calendly_url
 
     return {
         "open_to_talk": open_to_talk_enabled,
-        "open_to_talk_url": user.get("open_to_talk_url", "")
+        "open_to_talk_url": open_to_talk_url
         if (open_to_talk_enabled or not public)
         else "",
         "open_to_talk_note": user.get("open_to_talk_note", "")
@@ -126,7 +155,7 @@ def serialize_connection_settings(user: dict, *, public: bool) -> dict:
         if (open_to_talk_enabled or not public)
         else [],
         "calendly_enabled": calendly_enabled,
-        "calendly_url": user.get("calendly_url", "")
+        "calendly_url": effective_calendly_url
         if (calendly_enabled or not public)
         else "",
     }

--- a/backend/tests/test_calendly_profile_integration.py
+++ b/backend/tests/test_calendly_profile_integration.py
@@ -101,3 +101,53 @@ def test_partial_connection_update_does_not_clear_calendly(connection_context):
     stored = users.find_one({"_id": user["_id"]})
     assert stored["calendly_enabled"] is True
     assert stored["calendly_url"] == calendly_url
+
+
+def test_legacy_open_to_talk_calendly_url_drives_inline_scheduler(connection_context):
+    """Existing public Calendly links continue to power the new portfolio embed."""
+    user, users = connection_context
+    legacy_url = "https://calendly.com/calendar-user/30min"
+    users.update_one(
+        {"_id": user["_id"]},
+        {
+            "$set": {
+                "open_to_talk": True,
+                "open_to_talk_url": legacy_url,
+                "open_to_talk_note": "Book a conversation.",
+            }
+        },
+    )
+
+    public_response = client.get(f"/public/brag/{user['public_slug']}/connection")
+
+    assert public_response.status_code == 200
+    payload = public_response.json()
+    assert payload["open_to_talk"] is True
+    assert payload["open_to_talk_url"] == legacy_url
+    assert payload["calendly_enabled"] is True
+    assert payload["calendly_url"] == legacy_url
+
+
+def test_explicit_calendly_disable_overrides_legacy_open_to_talk_url(connection_context):
+    """A user who explicitly disables Calendly must not be re-enabled by fallback."""
+    user, users = connection_context
+    legacy_url = "https://calendly.com/calendar-user/30min"
+    users.update_one(
+        {"_id": user["_id"]},
+        {
+            "$set": {
+                "open_to_talk": True,
+                "open_to_talk_url": legacy_url,
+                "calendly_enabled": False,
+            }
+        },
+    )
+
+    public_response = client.get(f"/public/brag/{user['public_slug']}/connection")
+
+    assert public_response.status_code == 200
+    payload = public_response.json()
+    assert payload["open_to_talk"] is True
+    assert payload["open_to_talk_url"] == legacy_url
+    assert payload["calendly_enabled"] is False
+    assert payload["calendly_url"] == ""

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,7 @@
     "test:analytics": "node --test src/analytics.test.js",
     "test:interview": "node --test src/interviewEngine*.test.js",
     "test:resume": "node --test src/resumeStructured.test.js src/dashboardTags.test.js",
-    "test:seo": "node scripts/verify-search-appearance.mjs",
+    "test:seo": "node --test src/proofPortfolioSource.test.js && node scripts/verify-search-appearance.mjs",
     "test:clicks": "node scripts/run-click-audit.mjs",
     "test:layout": "node scripts/audit-responsive-layout.mjs",
     "test:bundle": "node scripts/verify-bundle-budget.mjs",

--- a/frontend/src/proofPortfolioSource.test.js
+++ b/frontend/src/proofPortfolioSource.test.js
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+function read(relativePath) {
+  const url = new URL(relativePath, import.meta.url);
+  return fs.readFileSync(fileURLToPath(url), "utf8");
+}
+
+test("public brag route is the professional Proof Portfolio", () => {
+  const source = read("./PublicBragPage.jsx");
+  assert.match(source, /className="proof-profile proof-portfolio"/);
+  assert.match(source, />Proof Portfolio</);
+  assert.match(source, /Professional proof portfolio/);
+  assert.match(source, /Portfolio snapshot/);
+  assert.match(source, /Featured impact/);
+  assert.match(source, /Demonstrated skills/);
+  assert.match(source, /Selected work/);
+});
+
+test("Proof Portfolio mounts the inline Calendly scheduler", () => {
+  const source = read("./PublicBragPage.jsx");
+  const calendly = read("./CalendlyEmbed.jsx");
+  assert.match(source, /id="schedule"/);
+  assert.match(source, /connection\?\.calendly_enabled && connection\.calendly_url/);
+  assert.match(source, /<CalendlyEmbed url=\{connection\.calendly_url\}/);
+  assert.match(calendly, /Calendly\.initInlineWidget/);
+  assert.match(calendly, /parentElement/);
+});


### PR DESCRIPTION
## Fix
- Preserve existing public Calendly scheduling for users who stored their Calendly URL in the legacy Open to Talk field before dedicated Calendly settings existed.
- Only use the legacy fallback when Open to Talk was already public and the URL is a valid HTTPS Calendly scheduling page.
- Respect an explicit `calendly_enabled: false` so user choice always wins.

## Regression coverage
- Backend integration test proves legacy public Calendly data now drives the new inline scheduler payload.
- Backend test proves explicit Calendly disable overrides the fallback.
- Frontend source regression verifies `/brag/...` remains the professional Proof Portfolio and continues mounting `CalendlyEmbed` with Calendly's inline widget.
- Frontend change intentionally triggers the full browser/responsive/lint/build CI suite.

## Merge gate
Backend, Frontend browser/responsive/build, and Security CI must all pass before merge.