### PR TITLE
Add dynamic public header to register and login

### DIFF
--- a/frontend/src/PublicAuthHeader.css
+++ b/frontend/src/PublicAuthHeader.css
@@ -1,0 +1,170 @@
+.public-auth-header {
+  position: sticky;
+  top: 16px;
+  z-index: 50;
+  width: min(1180px, calc(100% - 2rem));
+  margin: 1rem auto 0;
+  padding: 0.8rem 0.9rem 0.8rem 1.2rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: 18px;
+  background: rgba(7, 11, 20, 0.82);
+  box-shadow: 0 18px 50px rgba(0, 0, 0, 0.24);
+  backdrop-filter: blur(18px);
+}
+
+.public-auth-header a {
+  text-decoration: none;
+}
+
+.public-auth-brand {
+  flex: 0 0 auto;
+  color: #f8fafc;
+  font-size: 0.92rem;
+  font-weight: 900;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.public-auth-links {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 2rem;
+  min-width: 0;
+}
+
+.public-auth-links a {
+  color: #a7b4c9;
+  font-size: 0.9rem;
+  font-weight: 700;
+  transition: color 160ms ease, transform 160ms ease;
+}
+
+.public-auth-links a:hover,
+.public-auth-links a:focus-visible {
+  color: #f8fafc;
+  transform: translateY(-1px);
+}
+
+.public-auth-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.65rem;
+  flex: 0 0 auto;
+}
+
+.public-auth-button {
+  min-height: 40px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.55rem 1rem;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 900;
+  transition: transform 160ms ease, box-shadow 160ms ease, border-color 160ms ease, background 160ms ease;
+}
+
+.public-auth-button:hover,
+.public-auth-button:focus-visible {
+  transform: translateY(-2px);
+}
+
+.public-auth-button-primary {
+  color: #08101d;
+  background: linear-gradient(120deg, #a6dcff, #ad91ff);
+  box-shadow: 0 14px 35px rgba(124, 154, 255, 0.2);
+}
+
+.public-auth-button-primary:hover,
+.public-auth-button-primary:focus-visible {
+  box-shadow: 0 18px 42px rgba(124, 154, 255, 0.3);
+}
+
+.public-auth-button-secondary {
+  color: #f8fafc;
+  border-color: rgba(148, 163, 184, 0.18);
+  background: rgba(15, 23, 42, 0.6);
+  box-shadow: none;
+}
+
+.public-auth-button-secondary:hover,
+.public-auth-button-secondary:focus-visible {
+  border-color: rgba(166, 220, 255, 0.4);
+  background: rgba(23, 34, 57, 0.86);
+}
+
+.public-auth-header a:focus-visible {
+  outline: 3px solid rgba(166, 220, 255, 0.34);
+  outline-offset: 3px;
+}
+
+@media (max-width: 820px) {
+  .public-auth-header {
+    width: min(100% - 1rem, 720px);
+    top: 8px;
+    margin-top: 0.5rem;
+    padding: 0.65rem 0.7rem 0.65rem 0.85rem;
+    border-radius: 16px;
+  }
+
+  .public-auth-links {
+    gap: 1rem;
+  }
+
+  .public-auth-links a {
+    font-size: 0.78rem;
+  }
+
+  .public-auth-button {
+    min-height: 38px;
+    padding: 0.5rem 0.78rem;
+    font-size: 0.78rem;
+  }
+}
+
+@media (max-width: 640px) {
+  .public-auth-header {
+    position: relative;
+    top: 0;
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 0.6rem;
+  }
+
+  .public-auth-links {
+    grid-column: 1 / -1;
+    grid-row: 2;
+    justify-content: flex-start;
+    gap: 0.75rem;
+    overflow-x: auto;
+    padding: 0.1rem 0 0.15rem;
+    scrollbar-width: none;
+  }
+
+  .public-auth-links::-webkit-scrollbar {
+    display: none;
+  }
+
+  .public-auth-links a {
+    flex: 0 0 auto;
+    padding: 0.35rem 0.55rem;
+    border-radius: 999px;
+    border: 1px solid rgba(148, 163, 184, 0.14);
+    background: rgba(15, 23, 42, 0.46);
+  }
+
+  .public-auth-actions {
+    gap: 0.45rem;
+  }
+
+  .public-auth-button {
+    padding-inline: 0.68rem;
+  }
+}

--- a/frontend/src/PublicAuthHeader.jsx
+++ b/frontend/src/PublicAuthHeader.jsx
@@ -1,0 +1,30 @@
+import "./PublicAuthHeader.css";
+
+export default function PublicAuthHeader() {
+  const path = window.location.pathname.replace(/\/$/, "") || "/";
+  const isRegister = path === "/register";
+  const isLogin = path === "/login";
+
+  if (!isRegister && !isLogin) return null;
+
+  const cta = isRegister
+    ? { href: "/login", label: "Log in" }
+    : { href: "/register", label: "Start free" };
+
+  return (
+    <header className="public-auth-header" aria-label="BragStack public navigation">
+      <a className="public-auth-brand" href="/">BragStack</a>
+
+      <nav className="public-auth-links" aria-label="Public site navigation">
+        <a href="/#how-it-works">How it works</a>
+        <a href="/#product">Product</a>
+        <a href="/#pricing">Pricing</a>
+      </nav>
+
+      <div className="public-auth-actions">
+        <a className="public-auth-button public-auth-button-secondary" href="/docs">Docs</a>
+        <a className="public-auth-button public-auth-button-primary" href={cta.href}>{cta.label}</a>
+      </div>
+    </header>
+  );
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -8,6 +8,7 @@ import "./ResponsiveLayoutGuard.css";
 import "./ImpactReceiptsResponsive.css";
 import "./VerifiedImpact.css";
 import "./ProfileUploadPolish.css";
+import PublicAuthHeader from "./PublicAuthHeader.jsx";
 import RootContent from "./RootContent.jsx";
 import { installInterviewBrowserPreflight } from "./interviewBrowserPreflight.js";
 
@@ -15,6 +16,7 @@ installInterviewBrowserPreflight();
 
 createRoot(document.getElementById("root")).render(
   <StrictMode>
+    <PublicAuthHeader />
     <RootContent />
   </StrictMode>,
 );


### PR DESCRIPTION
## What changed
- adds the public BragStack floating/glass header to `/register` and `/login`
- carries the same public navigation destinations: How it works, Product, Pricing
- adds a visible Docs button
- makes the auth CTA dynamic: `/register` shows Log in; `/login` shows Start free
- matches the homepage pill/gradient visual language
- includes responsive mobile behavior and keyboard focus states

## CI budget
Frontend-only change. Use the medium PR frontend validation only; do not run nightly/full validation for this UI polish change.