### PR TITLE
Remove register page navbar

### DIFF
--- a/frontend/src/PublicAuthHeader.css
+++ b/frontend/src/PublicAuthHeader.css
@@ -50,12 +50,24 @@
   transform: translateY(-1px);
 }
 
-.public-auth-actions {
+.public-auth-actions,
+.public-auth-register-actions {
   display: flex;
   align-items: center;
   justify-content: flex-end;
   gap: 0.65rem;
   flex: 0 0 auto;
+}
+
+.public-auth-register-actions {
+  position: absolute;
+  top: 1rem;
+  right: 1.25rem;
+  z-index: 50;
+}
+
+.public-auth-register-actions a {
+  text-decoration: none;
 }
 
 .public-auth-button {
@@ -100,7 +112,8 @@
   background: rgba(23, 34, 57, 0.86);
 }
 
-.public-auth-header a:focus-visible {
+.public-auth-header a:focus-visible,
+.public-auth-register-actions a:focus-visible {
   outline: 3px solid rgba(166, 220, 255, 0.34);
   outline-offset: 3px;
 }
@@ -126,6 +139,11 @@
     min-height: 38px;
     padding: 0.5rem 0.78rem;
     font-size: 0.78rem;
+  }
+
+  .public-auth-register-actions {
+    top: 0.75rem;
+    right: 0.75rem;
   }
 }
 
@@ -160,7 +178,8 @@
     background: rgba(15, 23, 42, 0.46);
   }
 
-  .public-auth-actions {
+  .public-auth-actions,
+  .public-auth-register-actions {
     gap: 0.45rem;
   }
 

--- a/frontend/src/PublicAuthHeader.jsx
+++ b/frontend/src/PublicAuthHeader.jsx
@@ -7,25 +7,28 @@ export default function PublicAuthHeader() {
 
   if (!isRegister && !isLogin) return null;
 
-  const cta = isRegister
-    ? { href: "/", label: "Return" }
-    : { href: "/register", label: "Start free" };
+  if (isRegister) {
+    return (
+      <div className="public-auth-register-actions" aria-label="Registration shortcuts">
+        <a className="public-auth-button public-auth-button-secondary" href="/docs">Docs</a>
+        <a className="public-auth-button public-auth-button-primary" href="/">Return</a>
+      </div>
+    );
+  }
 
   return (
     <header className="public-auth-header" aria-label="BragStack public navigation">
       <a className="public-auth-brand" href="/">BragStack</a>
 
-      {!isRegister && (
-        <nav className="public-auth-links" aria-label="Public site navigation">
-          <a href="/#how-it-works">How it works</a>
-          <a href="/#product">Product</a>
-          <a href="/#pricing">Pricing</a>
-        </nav>
-      )}
+      <nav className="public-auth-links" aria-label="Public site navigation">
+        <a href="/#how-it-works">How it works</a>
+        <a href="/#product">Product</a>
+        <a href="/#pricing">Pricing</a>
+      </nav>
 
       <div className="public-auth-actions">
         <a className="public-auth-button public-auth-button-secondary" href="/docs">Docs</a>
-        <a className="public-auth-button public-auth-button-primary" href={cta.href}>{cta.label}</a>
+        <a className="public-auth-button public-auth-button-primary" href="/register">Start free</a>
       </div>
     </header>
   );


### PR DESCRIPTION
## Summary
- remove the full navbar/header chrome from `/register`
- remove the BragStack wordmark from the top bar on the registration page
- keep only the `Docs` and `Return` actions
- float those two actions cleanly at the top-right with no surrounding navbar container
- keep the `/login` page header unchanged

This is specifically to make the registration page feel cleaner and less visually heavy.