### PR TITLE
Fix shared Proof Portfolio links dropping theme

### DIFF
--- a/frontend/src/RootContent.jsx
+++ b/frontend/src/RootContent.jsx
@@ -66,6 +66,14 @@ function installInterviewSpeechGuard() {
 }
 
 function RouteFallback() { return <BragStackLoader message="Opening BragStack…" detail="Loading the tools you need." />; }
+function LegacyShareRedirect({ path }) {
+  useEffect(() => {
+    const parts = path.split("/").filter(Boolean);
+    const slug = parts[0] === "share" && parts[1] === "brag" ? parts[2] : "";
+    window.location.replace(slug ? `/brag/${slug}${window.location.search}` : "/");
+  }, [path]);
+  return <BragStackLoader message="Opening Proof Portfolio…" detail="Preserving the shared profile theme and public proof." />;
+}
 function ProRequired({ feature = "This feature" }) { return <main className="page"><section className="notice"><strong>BragStack Pro</strong><span>{feature} is available on Pro. Upgrade to unlock advanced career tools.</span><a className="btn primary" href="/upgrade">Upgrade to Pro</a></section></main>; }
 function ImpactReceiptsWithVerification() { return <><ImpactReceiptsPage /><ReceiptVerificationCenter /></>; }
 
@@ -128,7 +136,8 @@ function RootContent() {
   }, [path]);
 
   let content;
-  if (path === "/privacy" || path === "/terms") content = <LegalPages page={path === "/privacy" ? "privacy" : "terms"} />;
+  if (path.startsWith("/share/brag/")) content = <LegacyShareRedirect path={path} />;
+  else if (path === "/privacy" || path === "/terms") content = <LegalPages page={path === "/privacy" ? "privacy" : "terms"} />;
   else if (path === "/verify-receipt") content = <ReceiptVerificationPage />;
   else if (path === "/upgrade") content = <UpgradePage />;
   else if (path === "/docs") content = <DocsPage />;

--- a/frontend/src/proofPortfolioSource.test.js
+++ b/frontend/src/proofPortfolioSource.test.js
@@ -19,6 +19,13 @@ test("public brag route is the professional Proof Portfolio", () => {
   assert.match(source, /Selected work/);
 });
 
+test("legacy rich-share links redirect to the themed Proof Portfolio route", () => {
+  const source = read("./RootContent.jsx");
+  assert.match(source, /path\.startsWith\("\/share\/brag\/"\)/);
+  assert.match(source, /window\.location\.replace\(slug \? `\/brag\/\$\{slug\}\$\{window\.location\.search\}` : "\/"\)/);
+  assert.match(source, /Opening Proof Portfolio…/);
+});
+
 test("Proof Portfolio mounts the inline Calendly scheduler", () => {
   const source = read("./PublicBragPage.jsx");
   const calendly = read("./CalendlyEmbed.jsx");


### PR DESCRIPTION
## What changed
- adds a compatibility redirect for `/share/brag/{slug}` to the real `/brag/{slug}` Proof Portfolio route
- preserves the query string used for share-version cache busting
- prevents old shared links from falling through to the legacy dashboard/profile shell
- adds a regression test so shared links cannot silently regress back to the old profile

## Why
The production Render static site is serving `/share/brag/...` through the SPA fallback. That path was not recognized as a public Proof Portfolio route, so shared links rendered the old profile/dashboard and lost the saved theme.

## CI budget
Frontend-only fix. Run the required medium frontend gate only; backend/security should be skipped.