### PR TITLE
Fix Aisha interview targeting, language coaching, and audio teardown

### DIFF
--- a/frontend/src/AnimatedInterviewerAvatar.jsx
+++ b/frontend/src/AnimatedInterviewerAvatar.jsx
@@ -10,13 +10,14 @@ const STATE_COPY = {
 
 export default function AnimatedInterviewerAvatar({ state = "idle", name = "Aisha Jordan" }) {
   const safeState = STATE_COPY[state] ? state : "idle";
+  const displayName = name === "AJ" ? "Aisha Jordan" : name;
 
   return (
     <div
       className={`aisha-avatar-shell state-${safeState}`}
       data-avatar-engine="bragstack-static-aj-v1"
       data-interviewer-state={safeState}
-      aria-label={`${name}, BragStack Interviewer — ${STATE_COPY[safeState]}`}
+      aria-label={`${displayName}, BragStack Interviewer — ${STATE_COPY[safeState]}`}
     >
       <div className="aj-avatar-content">
         <div className="aj-avatar-monogram" aria-hidden="true">AJ</div>

--- a/frontend/src/AnimatedInterviewerAvatar.jsx
+++ b/frontend/src/AnimatedInterviewerAvatar.jsx
@@ -8,7 +8,7 @@ const STATE_COPY = {
   encouraging: "Preparing next step",
 };
 
-export default function AnimatedInterviewerAvatar({ state = "idle", name = "AJ" }) {
+export default function AnimatedInterviewerAvatar({ state = "idle", name = "Aisha Jordan" }) {
   const safeState = STATE_COPY[state] ? state : "idle";
 
   return (
@@ -21,7 +21,7 @@ export default function AnimatedInterviewerAvatar({ state = "idle", name = "AJ" 
       <div className="aj-avatar-content">
         <div className="aj-avatar-monogram" aria-hidden="true">AJ</div>
         <div className="aj-avatar-identity">
-          <span>BragStack Interviewer</span>
+          <span>Aisha Jordan · BragStack Interviewer</span>
         </div>
         <div className={`aj-avatar-state state-${safeState}`} aria-live="polite">
           <span className="aj-avatar-state-dot" aria-hidden="true" />

--- a/frontend/src/InterviewPracticeExperience.jsx
+++ b/frontend/src/InterviewPracticeExperience.jsx
@@ -11,6 +11,130 @@ import "./InterviewHandoffBridge.css";
 
 const RESUME_CONTEXT_KEY = "bragstack_resume_interview_context_v1";
 const MEDIA_PRIMED_KEY = "bragstack_interview_media_primed_v1";
+const INTERVIEW_PATH = "/app/interview-practice";
+const INTERVIEWER_NAME = "Aisha Jordan";
+
+function isInterviewPath() {
+  return (window.location.pathname.replace(/\/$/, "") || "/") === INTERVIEW_PATH;
+}
+
+function brandInterviewerCopy(value = "") {
+  return String(value).replace(/\bAJ\b/g, INTERVIEWER_NAME);
+}
+
+function brandInterviewDom(root = document) {
+  const candidates = [];
+  if (root?.matches?.(".interview-practice-page")) candidates.push(root);
+  root?.querySelectorAll?.(".interview-practice-page").forEach((node) => candidates.push(node));
+  if (root === document) document.querySelectorAll(".interview-practice-page").forEach((node) => candidates.push(node));
+
+  [...new Set(candidates)].forEach((container) => {
+    const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT);
+    let node = walker.nextNode();
+    while (node) {
+      const current = node.nodeValue || "";
+      const next = brandInterviewerCopy(current);
+      if (next !== current) node.nodeValue = next;
+      node = walker.nextNode();
+    }
+  });
+}
+
+function InterviewRuntimeSafetyBridge() {
+  useEffect(() => {
+    const synth = window.speechSynthesis;
+    const previousSpeak = synth?.speak;
+    const originalPushState = window.history.pushState;
+    const originalReplaceState = window.history.replaceState;
+
+    const stopInterviewSpeech = () => {
+      window.__bragstackInterviewActive = false;
+      try { synth?.cancel?.(); } catch { /* ignore */ }
+    };
+
+    if (synth?.speak) {
+      const brandedSpeak = function brandedSpeak(utterance) {
+        if (!isInterviewPath() || !window.__bragstackInterviewActive) {
+          try { synth.cancel?.(); } catch { /* ignore */ }
+          return;
+        }
+        try {
+          if (utterance?.text) utterance.text = brandInterviewerCopy(utterance.text);
+        } catch {
+          // Browser speech objects can expose read-only text in some implementations.
+        }
+        previousSpeak.call(synth, utterance);
+      };
+      synth.speak = brandedSpeak;
+    }
+
+    const stopForAnchorNavigation = (event) => {
+      const anchor = event.target.closest?.("a[href]");
+      if (!anchor) return;
+      const rawHref = anchor.getAttribute("href") || "";
+      if (!rawHref || rawHref.startsWith("#") || rawHref.startsWith("mailto:") || rawHref.startsWith("tel:") || anchor.target === "_blank") return;
+      const destination = new URL(anchor.href, window.location.href);
+      if ((destination.pathname.replace(/\/$/, "") || "/") !== INTERVIEW_PATH) stopInterviewSpeech();
+    };
+
+    const stopForHistoryNavigation = (method, args) => {
+      const target = args[2];
+      if (target === undefined || target === null) return;
+      try {
+        const destination = new URL(String(target), window.location.href);
+        if ((destination.pathname.replace(/\/$/, "") || "/") !== INTERVIEW_PATH) stopInterviewSpeech();
+      } catch {
+        stopInterviewSpeech();
+      }
+    };
+
+    window.history.pushState = function pushState(...args) {
+      stopForHistoryNavigation("pushState", args);
+      return originalPushState.apply(this, args);
+    };
+    window.history.replaceState = function replaceState(...args) {
+      stopForHistoryNavigation("replaceState", args);
+      return originalReplaceState.apply(this, args);
+    };
+
+    const stopForRouteEvent = () => stopInterviewSpeech();
+    const keepActiveWhileHere = () => {
+      if (isInterviewPath()) window.__bragstackInterviewActive = true;
+      else stopInterviewSpeech();
+    };
+
+    document.addEventListener("click", stopForAnchorNavigation, true);
+    window.addEventListener("pagehide", stopForRouteEvent);
+    window.addEventListener("beforeunload", stopForRouteEvent);
+    window.addEventListener("popstate", stopForRouteEvent);
+    window.addEventListener("bragstack:interview-teardown", stopForRouteEvent);
+
+    brandInterviewDom(document);
+    const observer = new MutationObserver((mutations) => {
+      mutations.forEach((mutation) => mutation.addedNodes.forEach((node) => {
+        if (node.nodeType === Node.ELEMENT_NODE) brandInterviewDom(node);
+      }));
+    });
+    observer.observe(document.body, { childList: true, subtree: true });
+    const routeInterval = window.setInterval(keepActiveWhileHere, 120);
+
+    return () => {
+      observer.disconnect();
+      window.clearInterval(routeInterval);
+      document.removeEventListener("click", stopForAnchorNavigation, true);
+      window.removeEventListener("pagehide", stopForRouteEvent);
+      window.removeEventListener("beforeunload", stopForRouteEvent);
+      window.removeEventListener("popstate", stopForRouteEvent);
+      window.removeEventListener("bragstack:interview-teardown", stopForRouteEvent);
+      if (synth?.speak && previousSpeak && synth.speak !== previousSpeak) synth.speak = previousSpeak;
+      if (window.history.pushState !== originalPushState) window.history.pushState = originalPushState;
+      if (window.history.replaceState !== originalReplaceState) window.history.replaceState = originalReplaceState;
+      stopInterviewSpeech();
+    };
+  }, []);
+
+  return null;
+}
 
 function setControlledValue(element, value) {
   if (!element || value === undefined || value === null) return;
@@ -154,10 +278,15 @@ function InterviewExitGuard() {
   }, [active]);
 
   const requestEnd = () => setPendingHref(`${window.location.origin}/app`);
-  const keepInterview = () => setPendingHref("");
+  const keepInterview = () => {
+    window.__bragstackInterviewActive = true;
+    setPendingHref("");
+  };
   const confirmEnd = () => {
     bypassRef.current = true;
+    window.__bragstackInterviewActive = false;
     window.speechSynthesis?.cancel?.();
+    window.dispatchEvent(new CustomEvent("bragstack:interview-teardown"));
     window.location.assign(pendingHref || "/app");
   };
 
@@ -182,5 +311,5 @@ function InterviewExitGuard() {
 }
 
 export default function InterviewPracticeExperience() {
-  return <><ResumeInterviewHandoff /><InterviewMediaPermissionBridge /><InterviewPracticePage /><InterviewExitGuard /></>;
+  return <><InterviewRuntimeSafetyBridge /><ResumeInterviewHandoff /><InterviewMediaPermissionBridge /><InterviewPracticePage /><InterviewExitGuard /></>;
 }

--- a/frontend/src/interviewEngine.guardrails.test.js
+++ b/frontend/src/interviewEngine.guardrails.test.js
@@ -1,26 +1,43 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { analyzeAnswer, summarizeInterview } from "./interviewEngine.js";
+import { analyzeAnswer, buildInterviewPlan, summarizeInterview } from "./interviewEngine.js";
 
-test("critical interview language triggers an immediate failed answer", () => {
-  const analysis = analyzeAnswer("I got frustrated and said fuck it, then we moved on.", {
+test("profanity creates coaching but does not fail the interview", () => {
+  const analysis = analyzeAnswer("I got frustrated and said shit, then I reset and resolved the issue.", {
     question: "Tell me about a difficult workplace situation.",
     competency: "communication",
   });
-  assert.equal(analysis.instantFail, true);
-  assert.equal(analysis.overallScore, 0);
-  assert.equal(analysis.overallLabel, "Interview failed");
-  assert.ok(analysis.warning?.terms.includes("fuck"));
-  assert.equal(analysis.followUp, null);
+  assert.equal(analysis.instantFail, false);
+  assert.notEqual(analysis.overallLabel, "Interview failed");
+  assert.ok(analysis.warning?.terms.includes("shit"));
+  assert.match(analysis.warning?.coaching || "", /keep going/i);
 });
 
-test("drug language is treated as a critical practice-interview warning", () => {
-  const analysis = analyzeAnswer("We were talking about drugs at work.", {
+test("ordinary drug terminology is not treated as an automatic professional-language failure", () => {
+  const analysis = analyzeAnswer("I reviewed the medication and drug interaction documentation with the clinical team and updated the process.", {
     question: "Tell me about a workplace challenge.",
     competency: "judgment",
+    roleTitle: "Clinical Software Engineer",
   });
-  assert.equal(analysis.instantFail, true);
-  assert.ok(analysis.warning?.terms.includes("drugs"));
+  assert.equal(analysis.instantFail, false);
+  assert.equal(analysis.warning, null);
+});
+
+test("job descriptions drive multiple interview questions", () => {
+  const plan = buildInterviewPlan({
+    roleTitle: "Software Engineer",
+    questionCount: 8,
+    jobDescription: `
+      Build and maintain Python APIs and distributed backend services.
+      Deploy containerized workloads with Docker and Kubernetes on AWS.
+      Design reliable PostgreSQL data models and troubleshoot production incidents.
+      Collaborate with product teams to deliver customer-facing software.
+    `,
+  });
+  const targeted = plan.questions.filter((question) => question.source === "job-description");
+  assert.ok(targeted.length >= 3);
+  assert.ok(targeted.some((question) => /python|api|backend|distributed/i.test(question.text)));
+  assert.ok(targeted.some((question) => /docker|kubernetes|aws/i.test(question.text)));
 });
 
 test("weak answers receive concrete improvements rather than only a needs-detail label", () => {
@@ -56,13 +73,13 @@ test("final summary includes stars, score, verdict, and recommendations", () => 
   assert.ok(summary.recommendations.length > 0);
 });
 
-test("one critical warning fails the overall practice interview", () => {
-  const analysis = analyzeAnswer("I said shit during the meeting.", {
+test("a language coaching note does not zero the overall interview", () => {
+  const analysis = analyzeAnswer("During a conflict I said shit, caught myself, communicated the issue clearly, and resolved it with the team.", {
     question: "Tell me about a conflict.",
     competency: "communication",
   });
-  const summary = summarizeInterview([{ answer: "bad", analysis }]);
-  assert.equal(summary.failed, true);
-  assert.equal(summary.overallScore, 0);
-  assert.equal(summary.stars, 1);
+  const summary = summarizeInterview([{ answer: "example", analysis }]);
+  assert.equal(summary.failed, false);
+  assert.ok(summary.overallScore > 0);
+  assert.ok(summary.warnings.length === 1);
 });

--- a/frontend/src/interviewEngine.js
+++ b/frontend/src/interviewEngine.js
@@ -2,18 +2,19 @@ import { CAREER_FAMILIES, CORE_QUESTIONS } from "./interviewKnowledgeBase.js";
 import { rankImpactReceipts, scoreMeaningAlignment } from "./careerIntelligence.js";
 
 const STOP_WORDS = new Set(["a", "an", "and", "are", "as", "at", "be", "for", "from", "how", "i", "in", "is", "it", "me", "my", "of", "on", "or", "that", "the", "this", "to", "was", "we", "were", "what", "when", "with", "you", "your"]);
+const JOB_DESCRIPTION_NOISE = new Set(["ability", "about", "across", "also", "applicant", "candidate", "company", "demonstrated", "environment", "excellent", "experience", "experienced", "including", "knowledge", "looking", "preferred", "qualified", "requirements", "required", "responsibilities", "responsibility", "role", "skills", "strong", "team", "teams", "using", "work", "working", "years"]);
 const ACTION_WORDS = ["analyzed", "automated", "built", "changed", "chose", "coached", "collaborated", "communicated", "configured", "coordinated", "created", "decided", "deployed", "designed", "diagnosed", "documented", "escalated", "facilitated", "fixed", "implemented", "improved", "introduced", "investigated", "isolated", "led", "mentored", "migrated", "monitored", "negotiated", "optimized", "organized", "owned", "partnered", "presented", "prioritized", "proposed", "recommended", "refactored", "repaired", "resolved", "reviewed", "selected", "tested", "trained", "taught", "updated", "validated", "verified", "wrote"];
 const RESULT_WORDS = ["achieved", "afterward", "allowed", "avoided", "completed", "delivered", "eliminated", "enabled", "faster", "grew", "helped", "higher", "improved", "increased", "launched", "lower", "met", "outcome", "prevented", "recovered", "reduced", "resolved", "result", "resulted", "saved", "shortened", "ultimately"];
 const CONTEXT_WORDS = ["campaign", "case", "client", "customer", "deadline", "during", "incident", "patient", "project", "quarter", "role", "shift", "student", "team", "when", "while"];
 const FILLERS = ["um", "uh", "erm", "you know", "kind of", "sort of", "basically", "literally", "i mean"];
+const RECEIPT_ROTATION_KEY = "bragstack_interview_receipt_rotation_v1";
 
-const INTERVIEW_FAIL_TERMS = [
-  { term: "drugs", pattern: /\bdrugs?\b/i, reason: "Drug-related language is inappropriate in a standard professional interview answer unless the role/question specifically requires clinical, legal, or policy terminology." },
-  { term: "fuck", pattern: /\bfuck(?:ing|ed|er|ers)?\b/i, reason: "Profanity can immediately damage professional credibility in an interview." },
-  { term: "shit", pattern: /\bshit(?:ty)?\b/i, reason: "Profanity can immediately damage professional credibility in an interview." },
-  { term: "bitch", pattern: /\bbitch(?:es|ing)?\b/i, reason: "Insulting or profane language is not appropriate for an interview." },
-  { term: "asshole", pattern: /\bassholes?\b/i, reason: "Insulting language is not appropriate for an interview." },
-  { term: "damn", pattern: /\bdamn(?:ed)?\b/i, reason: "Strong casual language can read as unprofessional in a formal interview." },
+const INTERVIEW_LANGUAGE_TERMS = [
+  { term: "fuck", pattern: /\bfuck(?:ing|ed|er|ers)?\b/i, reason: "Profanity can distract from an otherwise strong interview answer." },
+  { term: "shit", pattern: /\bshit(?:ty)?\b/i, reason: "Profanity can distract from an otherwise strong interview answer." },
+  { term: "bitch", pattern: /\bbitch(?:es|ing)?\b/i, reason: "Insulting or profane wording can undermine a professional answer." },
+  { term: "asshole", pattern: /\bassholes?\b/i, reason: "Insulting wording can undermine a professional answer." },
+  { term: "damn", pattern: /\bdamn(?:ed)?\b/i, reason: "Strong casual wording may be worth replacing in a formal interview." },
 ];
 
 function normalize(value = "") {
@@ -48,15 +49,16 @@ function formatRole(template, roleTitle) {
 }
 
 function professionalLanguageWarning(text) {
-  const matches = INTERVIEW_FAIL_TERMS.filter(({ pattern }) => pattern.test(text));
+  const matches = INTERVIEW_LANGUAGE_TERMS.filter(({ pattern }) => pattern.test(text));
   if (!matches.length) return null;
   return {
     triggered: true,
-    instantFail: true,
+    instantFail: false,
+    severity: "coaching",
     terms: matches.map(({ term }) => term),
-    title: "‼️ Interview failed: professional-language warning",
+    title: "Professional-language coaching note",
     message: matches[0].reason,
-    coaching: "In a real interview, replace emotional, profane, illegal-drug, or insulting wording with neutral professional language. Describe the situation factually and keep the focus on your judgment, actions, and results.",
+    coaching: "Keep going. In a real interview, replace profanity or insulting wording with neutral professional language and keep the focus on your judgment, actions, and results.",
   };
 }
 
@@ -71,6 +73,27 @@ export function inferCareerFamily(roleTitle = "", careerArea = "") {
   return bestFamily;
 }
 
+function safeReceiptRotationState() {
+  try {
+    return JSON.parse(globalThis.localStorage?.getItem(RECEIPT_ROTATION_KEY) || "{}") || {};
+  } catch {
+    return {};
+  }
+}
+
+function rememberReceiptQuestion(roleTitle, questionId) {
+  try {
+    if (!globalThis.localStorage || !questionId) return;
+    const state = safeReceiptRotationState();
+    const roleKey = normalize(roleTitle) || "general";
+    const recent = Array.isArray(state[roleKey]) ? state[roleKey] : [];
+    state[roleKey] = [questionId, ...recent.filter((id) => id !== questionId)].slice(0, 4);
+    globalThis.localStorage.setItem(RECEIPT_ROTATION_KEY, JSON.stringify(state));
+  } catch {
+    // Receipt rotation should never block interview planning.
+  }
+}
+
 function receiptQuestion(receipts = [], roleTitle = "", jobDescription = "") {
   const ranked = rankImpactReceipts(receipts, {
     roleTitle,
@@ -78,32 +101,95 @@ function receiptQuestion(receipts = [], roleTitle = "", jobDescription = "") {
     competency: "career_evidence",
     question: `What career evidence best supports a ${roleTitle || "target"} role?`,
   });
-  const best = ranked[0];
+  if (!ranked.length) return null;
+
+  const roleKey = normalize(roleTitle) || "general";
+  const recent = Array.isArray(safeReceiptRotationState()[roleKey]) ? safeReceiptRotationState()[roleKey] : [];
+  const candidates = ranked.map((item) => ({ ...item, questionId: `receipt-${item.receipt?.id || normalize(item.receipt?.accomplishment || item.receipt?.result || "personalized")}` }));
+  const best = candidates.find((item) => !recent.includes(item.questionId)) || candidates[0];
   if (!best) return null;
+
   const receipt = best.receipt;
   const accomplishment = String(receipt.accomplishment || receipt.result || receipt.contribution || "").trim();
   if (!accomplishment) return null;
+  rememberReceiptQuestion(roleTitle, best.questionId);
   return {
-    id: `receipt-${receipt.id || "personalized"}`,
+    id: best.questionId,
     competency: "career_evidence",
     source: "impact-receipt",
     evidenceScore: best.score,
-    text: `Your BragStack includes this accomplishment: “${accomplishment}” Walk me through the situation, what you personally owned, and the result that would matter to someone hiring a ${roleTitle || "candidate"}.`,
+    text: `Your BragStack includes this accomplishment: “${accomplishment}” Walk me through the part of that example that is most relevant to this ${roleTitle || "role"}: what you personally owned, the hardest decision or technical challenge, and the result that mattered.`,
   };
 }
 
-function jobDescriptionQuestion(jobDescription = "", roleTitle = "") {
-  const tokens = tokenize(jobDescription);
+function jobDescriptionKeywords(value = "") {
   const counts = new Map();
-  for (const token of tokens) counts.set(token, (counts.get(token) || 0) + 1);
-  const keywords = [...counts.entries()].sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0])).map(([word]) => word).filter((word) => word.length > 4).slice(0, 3);
-  if (!keywords.length) return null;
-  return {
-    id: "job-description",
+  for (const token of tokenize(value)) {
+    if (JOB_DESCRIPTION_NOISE.has(token) || /^\d+$/.test(token)) continue;
+    counts.set(token, (counts.get(token) || 0) + 1);
+  }
+  return [...counts.entries()]
+    .sort((a, b) => b[1] - a[1] || b[0].length - a[0].length || a[0].localeCompare(b[0]))
+    .map(([word]) => word);
+}
+
+function jobDescriptionPriorityGroups(jobDescription = "", maxGroups = 4) {
+  const raw = String(jobDescription || "").trim();
+  if (!raw) return [];
+  const segments = raw
+    .split(/\n+|(?<=[.!?])\s+/)
+    .map((segment) => segment.replace(/^[\s•*\-–—]+/, "").replace(/\s+/g, " ").trim())
+    .filter((segment) => segment.length >= 18);
+
+  const signal = /\b(build|design|develop|implement|maintain|operate|deploy|debug|troubleshoot|support|architect|lead|manage|own|deliver|secure|scale|optimize|automate|test|review|integrate|monitor|cloud|api|database|container|customer|linux|python|java|javascript|typescript|react|node|docker|kubernetes|aws|azure|gcp|sql)\w*\b/gi;
+  const groups = segments
+    .map((segment, index) => {
+      const keywords = jobDescriptionKeywords(segment).slice(0, 4);
+      const signalCount = (segment.match(signal) || []).length;
+      return { index, keywords, score: keywords.length + signalCount * 2 };
+    })
+    .filter((item) => item.keywords.length >= 2)
+    .sort((a, b) => b.score - a.score || a.index - b.index);
+
+  const uniqueGroups = [];
+  const used = new Set();
+  for (const group of groups) {
+    const key = group.keywords.slice(0, 3).join("|");
+    if (!key || used.has(key)) continue;
+    used.add(key);
+    uniqueGroups.push(group.keywords.slice(0, 3));
+    if (uniqueGroups.length >= maxGroups) break;
+  }
+
+  if (uniqueGroups.length < maxGroups) {
+    const globalKeywords = jobDescriptionKeywords(raw).slice(0, maxGroups * 3);
+    for (let index = 0; index < globalKeywords.length && uniqueGroups.length < maxGroups; index += 3) {
+      const group = globalKeywords.slice(index, index + 3);
+      const key = group.join("|");
+      if (group.length >= 2 && !used.has(key)) {
+        used.add(key);
+        uniqueGroups.push(group);
+      }
+    }
+  }
+  return uniqueGroups;
+}
+
+function jobDescriptionQuestions(jobDescription = "", roleTitle = "", count = 3) {
+  const groups = jobDescriptionPriorityGroups(jobDescription, count);
+  const variants = [
+    (role, priorities) => `The ${role} job description emphasizes ${priorities}. Tell me about a specific project where you used those skills together. What did you personally build, change, diagnose, or deliver, and what was the result?`,
+    (role, priorities) => `For this ${role} role, the posting calls out ${priorities}. Walk me through the hardest real example from your background that proves you can handle that part of the job.`,
+    (role, priorities) => `Imagine I am evaluating you specifically against ${priorities} for this ${role} position. Which accomplishment best proves your depth there, and what tradeoff or decision did you personally own?`,
+    (role, priorities) => `This ${role} posting repeatedly points to ${priorities}. Give me an example that shows how you applied those priorities in practice and how you knew your approach worked.`,
+  ];
+  return groups.map((keywords, index) => ({
+    id: `job-description-${index + 1}`,
     competency: "role_alignment",
     source: "job-description",
-    text: `This ${roleTitle || "role"} posting emphasizes ${keywords.join(", ")}. Tell me about a real example that best demonstrates your experience with one or more of those priorities.`,
-  };
+    jobKeywords: keywords,
+    text: variants[index % variants.length](roleTitle || "role", keywords.join(", ")),
+  }));
 }
 
 export function buildInterviewPlan({ roleTitle = "", careerArea = "", experienceLevel = "experienced", interviewType = "mixed", questionCount = 8, jobDescription = "", receipts = [] } = {}) {
@@ -114,10 +200,13 @@ export function buildInterviewPlan({ roleTitle = "", careerArea = "", experience
   const pool = [];
   const intro = CORE_QUESTIONS.find((question) => question.id === "intro-role");
   if (intro) pool.push({ ...intro, source: "core", text: formatRole(intro.text, role) });
+
+  const jdQuestionCount = jobDescription.trim() ? Math.min(4, Math.max(2, Math.ceil(desiredCount / 2))) : 0;
+  pool.push(...jobDescriptionQuestions(jobDescription, role, jdQuestionCount));
+
   const personalized = receiptQuestion(receipts, role, jobDescription);
   if (personalized) pool.push(personalized);
-  const jdQuestion = jobDescriptionQuestion(jobDescription, role);
-  if (jdQuestion) pool.push(jdQuestion);
+
   if (familyConfig) {
     familyConfig.roleQuestions.forEach((text, index) => pool.push({ id: `${family}-${index + 1}`, competency: familyConfig.competencies[index % familyConfig.competencies.length], source: "career-family", text: formatRole(text, role) }));
   } else {
@@ -285,13 +374,13 @@ export function analyzeAnswer(answer = "", { question = "", competency = "", rol
   const communicationScore = scoreCommunication({ wordCount, fillerCount, relevanceScore, structureScore, specificityScore, ownershipScore, impactScore, actionFound, resultFound });
   const wordsPerMinute = durationSeconds > 5 ? Math.round(wordCount / (durationSeconds / 60)) : null;
 
-  let dimensions = {
+  const dimensions = {
     relevance: dimension(relevanceScore, relevanceScore >= 80 ? `Your evidence directly supports ${meaning.competency.replaceAll("_", " ")}.` : relevanceScore >= 55 ? `Your example partly supports ${meaning.competency.replaceAll("_", " ")}, but the connection needs to be explicit.` : `This answer does not yet prove ${meaning.competency.replaceAll("_", " ")}.`, `State the exact behavior or decision that demonstrates ${meaning.competency.replaceAll("_", " ")}.`),
     structure: dimension(structureScore, structureScore >= 80 ? "The answer has a clear situation → action → result arc." : "One or more STAR pieces are missing or too vague to score strongly.", "Use one sentence for the situation, most of the answer on your action, and finish with the result."),
     ownership: dimension(ownershipScore, actionFound ? (ownershipScore >= 70 ? "Your personal contribution is clear and supported by evidence." : "A personal action is present, but it needs clearer ownership and evidence.") : firstPerson ? "You speak in first person, but the actual action is vague." : "It is unclear what you personally owned.", "Name the exact thing you decided, built, changed, diagnosed, communicated, or led."),
     specificity: dimension(specificityScore, specificityScore >= 70 ? "Concrete details make the story credible." : "The answer relies on broad statements instead of enough evidence.", "Add one or two real details: what system/process, what constraint, what decision, or who was affected."),
     impact: dimension(impactScore, resultFound ? (impactScore >= 70 ? "The answer shows what changed because of your work." : "You mention an outcome, but the causal impact is still weak or broad.") : "The answer stops before showing what changed.", resultFound ? "Make the result explicitly follow from your action and add truthful scale when known." : "Finish with the business, customer, team, quality, time, risk, or cost outcome."),
-    communication: dimension(communicationScore, communicationScore >= 70 ? "The answer is direct, organized, and supported by enough evidence." : wordCount < 20 ? "The answer is too short to communicate enough interview-grade evidence." : "The answer may be readable, but it is not yet organized around enough relevant evidence.", fillerCount > 5 ? "Pause instead of filling silence, then deliver the next evidence point." : "Keep the answer focused on the exact competency, your action, and the result."),
+    communication: dimension(warning ? Math.min(communicationScore, 70) : communicationScore, warning ? warning.message : communicationScore >= 70 ? "The answer is direct, organized, and supported by enough evidence." : wordCount < 20 ? "The answer is too short to communicate enough interview-grade evidence." : "The answer may be readable, but it is not yet organized around enough relevant evidence.", warning ? warning.coaching : fillerCount > 5 ? "Pause instead of filling silence, then deliver the next evidence point." : "Keep the answer focused on the exact competency, your action, and the result."),
   };
 
   let missingDimension = null;
@@ -300,30 +389,26 @@ export function analyzeAnswer(answer = "", { question = "", competency = "", rol
   else if (!resultFound) missingDimension = "result";
   else if (!specific) missingDimension = "specificity";
   else if (!quantified) missingDimension = "quantification";
-  const followUp = warning ? null : buildFollowUp({ missingDimension, competency: meaning.competency, question });
+  const followUp = buildFollowUp({ missingDimension, competency: meaning.competency, question });
 
   const scores = Object.values(dimensions).map((item) => item.score);
   let overallScore = Math.round(scores.reduce((sum, score) => sum + score, 0) / scores.length);
   overallScore = applyAnswerEvidenceGate(overallScore, { wordCount, relevanceScore, actionFound, resultFound });
 
-  if (warning?.instantFail) {
-    overallScore = 0;
-    dimensions = Object.fromEntries(Object.entries(dimensions).map(([name, value]) => [name, { ...value, score: 0, label: "Critical" }]));
-  }
-
   const detailed = actionableFeedback({ meaning, wordCount, contextFound, actionFound, resultFound, quantified, specific, fillerCount });
+  if (warning && !detailed.improvements.includes(warning.coaching)) detailed.improvements.unshift(warning.coaching);
   return {
     overallScore,
-    overallLabel: warning ? "Interview failed" : labelFor(overallScore),
+    overallLabel: labelFor(overallScore),
     dimensions,
     meaning,
     warning,
-    instantFail: Boolean(warning?.instantFail),
+    instantFail: false,
     signals: { wordCount, fillerCount, wordsPerMinute, contextFound, actionFound, resultFound, quantified, competency: meaning.competency, conceptCoverage: meaning.conceptCoverage, causalEvidence, concreteExample: meaning.concreteExample },
     missingDimension,
     followUp,
     strengths: detailed.strengths,
-    improvements: detailed.improvements,
+    improvements: detailed.improvements.slice(0, 5),
     coaching: warning?.coaching || detailed.improvements[0] || `Keep the evidence tied to ${meaning.competency.replaceAll("_", " ")}.`,
   };
 }
@@ -337,7 +422,7 @@ function starRating(score) {
 }
 
 function sessionVerdict(overallScore, failed) {
-  if (failed) return "Interview failed because of a critical professional-language red flag.";
+  if (failed) return "Interview stopped because of a critical safety issue.";
   if (overallScore >= 80) return "Interview-ready with a few refinements.";
   if (overallScore >= 65) return "Promising, but several answers still need sharper evidence.";
   if (overallScore >= 50) return "Not interview-ready yet; too many answers need stronger evidence, ownership, or results.";
@@ -367,7 +452,8 @@ export function summarizeInterview(responses = []) {
   const quantMissing = scored.filter((response) => response.analysis.signals.resultFound && !response.analysis.signals.quantified).length;
   const weakMeaning = scored.filter((response) => (response.analysis.meaning?.score || 0) < 55).length;
   const patterns = [];
-  if (failed) patterns.push("A professional-language red flag caused an instant practice-interview fail. Fix that first before judging the rest of the session.");
+  if (failed) patterns.push("A critical safety issue stopped the practice interview.");
+  if (warnings.length) patterns.push(`${warnings.length} answer${warnings.length === 1 ? "" : "s"} included wording Aisha Jordan would coach you to make more professional; the interview continued.`);
   if (weakMeaning) patterns.push(`${weakMeaning} of ${scored.length} answers did not strongly prove the competency being tested.`);
   if (resultMissing) patterns.push(`${resultMissing} of ${scored.length} answers did not clearly state what changed as a result of your work.`);
   if (actionMissing) patterns.push(`${actionMissing} of ${scored.length} answers did not make your personal action specific enough.`);
@@ -396,7 +482,7 @@ export function summarizeInterview(responses = []) {
 
   return {
     overallScore,
-    overallLabel: failed ? "Interview failed" : labelFor(overallScore),
+    overallLabel: failed ? "Interview stopped" : labelFor(overallScore),
     stars: failed ? 1 : starRating(overallScore),
     failed,
     warnings,


### PR DESCRIPTION
## Why
The production interview experience had four user-visible problems:

1. The same Impact Receipt (for example the PocketTerm accomplishment) could be asked repeatedly instead of rotating career proof.
2. Pasted job descriptions were not driving enough of the interview questions.
3. A single profanity such as `shit` could instantly fail the entire practice interview.
4. Spoken interviewer audio could continue after the user navigated away from the interview.
5. The interviewer had drifted back to the short `AJ` label instead of the requested **Aisha Jordan** identity.

## Changes
- prioritize multiple job-description-derived questions when a description is provided
- derive separate priority groups from job-description bullets/sentences instead of one generic frequency-based question
- rotate personalized Impact Receipt questions so the same accomplishment is not selected every session when alternatives exist
- keep career-proof personalization behind the role/job-description targeting rather than letting one receipt dominate the interview
- change profanity from an instant-fail rule to a coaching warning; the answer/interview continues and communication feedback explains how to rephrase professionally
- remove ordinary `drug` terminology from the profanity failure logic so clinical/legal/policy language is not falsely treated as misconduct
- add navigation/audio teardown safeguards for links, browser history navigation, page hide/unload, and BragStack interview teardown events
- prevent speech synthesis from speaking after the route is no longer `/app/interview-practice`
- restore visible/spoken interviewer branding to **Aisha Jordan** while retaining the existing AJ monogram asset marker
- update interview guardrail tests and add job-description targeting coverage

## Expected behavior
- An 8-question interview with a pasted job description should contain several questions explicitly tied to that description.
- Career proof can still personalize the interview, but a single accomplishment should not be the same repeated default when multiple receipts exist.
- Saying `shit` produces a professional-language coaching note, not an automatic failed interview.
- Leaving the interview should silence Aisha immediately and prevent queued speech from continuing on another page.
- The UI and spoken copy present the interviewer as **Aisha Jordan**.