### PR TITLE
Add substantive public information pages

### DIFF
--- a/frontend/public/production-patches.js
+++ b/frontend/public/production-patches.js
@@ -11,6 +11,15 @@
   const routeMeta = {
     "/": ["BragStack | Turn Your Work Into Career Proof", "BragStack helps professionals capture wins, attach evidence, create Impact Receipts, build Proof Profiles and Professional Packets, and selectively share career proof when it matters."],
     "/docs": ["BragStack Docs | Career Proof, Billing, Privacy & Product Help", "Customer documentation for BragStack accounts, Impact Receipts, reports, public proof profiles, privacy, billing, and BragStack Pro."],
+    "/how-it-works": ["How BragStack Works | Capture, Prove & Reuse Career Evidence", "See how BragStack helps you capture accomplishments, create Impact Receipts, reuse evidence for career moments, share selectively, and keep private work private."],
+    "/use-cases": ["BragStack Use Cases | Reviews, Promotions, Resumes & Interviews", "Explore BragStack use cases for performance reviews, promotions, resumes, interviews, career changes, freelancers, founders, and adults in education."],
+    "/contact": ["Contact BragStack | Support, Privacy, Security & Billing", "Contact BragStack for product support, privacy requests, security concerns, billing questions, general questions, or legal correspondence."],
+    "/team": ["BragStack for Teams | Coming Soon", "Learn about the planned BragStack Team direction for evidence-backed reviews, employee-controlled sharing, bounded analytics, and organization workflows without surveillance."],
+    "/enterprise": ["BragStack Enterprise | Governance Roadmap for Career Evidence", "Learn about BragStack's early enterprise direction for identity, governance, retention, admin policy controls, integrations, and employee-controlled evidence boundaries."],
+    "/security": ["BragStack Security | Private-by-Default Career Evidence", "Read BragStack's security approach, private-by-default model, confidential-work guidance, payment handling, and instructions for reporting a security concern."],
+    "/privacy": ["Privacy Policy | BragStack", "Read the BragStack Privacy Policy, including information collection, career evidence, sharing, AI-assisted features, retention, security, and privacy choices."],
+    "/terms": ["Terms and Conditions | BragStack", "Read the terms governing BragStack accounts, user content, acceptable use, subscriptions, AI-assisted career content, confidentiality, and service use."],
+    "/nda-safety": ["NDA & Confidential Work Guidance | BragStack", "Learn how to document professional accomplishments in BragStack without overriding NDAs, employer policies, client agreements, or confidentiality obligations."],
     "/resume-accomplishments": ["Resume Accomplishments & Achievement Tracker | BragStack", "Track work accomplishments, measurable impact, and evidence so you can build stronger resume bullets from real career proof."],
     "/career-portfolio": ["Career Portfolio & Professional Proof Profile | BragStack", "Build a professional career portfolio from selected accomplishments, skills, evidence, and measurable impact while keeping your account private by default."],
     "/performance-reviews": ["Performance Review Accomplishment Tracker | BragStack", "Capture wins throughout the year and turn documented impact into performance-review material without rebuilding months of work from memory."],
@@ -79,18 +88,46 @@
     nav.dataset.brandPatched = "true";
   }
 
+  function ensureFooterLink(column, label, href) {
+    if (!column) return;
+    const normalized = label.trim().toLowerCase();
+    let link = Array.from(column.querySelectorAll("a")).find((item) => item.textContent?.trim().toLowerCase() === normalized);
+    if (!link) {
+      link = document.createElement("a");
+      link.textContent = label;
+      column.appendChild(link);
+    }
+    link.setAttribute("href", href);
+  }
+
   function ensureDarkFooterLinks(root = document) {
     const footer = root.querySelector?.(".mega-footer") || document.querySelector(".mega-footer");
-    if (!footer || footer.dataset.legalLinksPatched === "true") return;
+    if (!footer) return;
     const columns = footer.querySelector(".mega-footer-columns");
     if (!columns) return;
-    const resources = Array.from(columns.children).find((column) => column.querySelector("h3")?.textContent?.trim().toLowerCase() === "resources");
+
+    const byHeading = (heading) => Array.from(columns.children).find((column) => column.querySelector("h3")?.textContent?.trim().toLowerCase() === heading);
+    const resources = byHeading("resources");
+    const company = byHeading("company");
+
     if (resources) {
       const docsPlaceholder = Array.from(resources.children).find((item) => item.textContent?.trim().toLowerCase().startsWith("docs"));
-      if (docsPlaceholder) { const docs = document.createElement("a"); docs.href = "/docs"; docs.textContent = "Docs"; docsPlaceholder.replaceWith(docs); }
-      if (!resources.querySelector('a[href="/nda-safety"]')) { const nda = document.createElement("a"); nda.href = "/nda-safety"; nda.textContent = "NDA & confidential work"; resources.appendChild(nda); }
+      if (docsPlaceholder && docsPlaceholder.tagName !== "A") { const docs = document.createElement("a"); docs.href = "/docs"; docs.textContent = "Docs"; docsPlaceholder.replaceWith(docs); }
+      ensureFooterLink(resources, "How it works", "/how-it-works");
+      ensureFooterLink(resources, "Use cases", "/use-cases");
+      ensureFooterLink(resources, "Sign in", "/login");
+      ensureFooterLink(resources, "Create account", "/register");
+      ensureFooterLink(resources, "NDA & confidential work", "/nda-safety");
     }
-    if (!Array.from(columns.children).some((column) => column.querySelector("h3")?.textContent?.trim().toLowerCase() === "legal")) {
+
+    if (company) {
+      ensureFooterLink(company, "Contact", "/contact");
+      ensureFooterLink(company, "Team waitlist", "/team");
+      ensureFooterLink(company, "Enterprise", "/enterprise");
+      ensureFooterLink(company, "Trust & privacy", "/security");
+    }
+
+    if (!byHeading("legal")) {
       const legal = document.createElement("div");
       legal.innerHTML = '<h3>Legal</h3><a href="/privacy">Privacy Policy</a><a href="/terms">Terms & Conditions</a><a href="/nda-safety">Confidentiality guidance</a>';
       columns.appendChild(legal);
@@ -110,10 +147,23 @@
     return CONTACT_EMAIL;
   }
 
+  function patchNamedPublicLink(link, text) {
+    const routes = {
+      "how it works": "/how-it-works",
+      "use cases": "/use-cases",
+      "contact": "/contact",
+      "team waitlist": "/team",
+      "enterprise": "/enterprise",
+      "trust & privacy": "/security",
+    };
+    if (routes[text]) link.setAttribute("href", routes[text]);
+  }
+
   function patchLinks(root = document) {
     root.querySelectorAll?.("a[href]").forEach((link) => {
       const href = link.getAttribute("href") || "";
       const text = (link.textContent || "").trim().toLowerCase();
+      patchNamedPublicLink(link, text);
       if (href.toLowerCase().startsWith(`mailto:${PERSONAL_EMAIL.toLowerCase()}`)) {
         const query = href.includes("?") ? href.slice(href.indexOf("?")) : "";
         const roleEmail = roleEmailForLink(link);

--- a/frontend/public/sitemap.xml
+++ b/frontend/public/sitemap.xml
@@ -5,10 +5,14 @@
   <url><loc>https://usebragstack.com/interview-preparation</loc><changefreq>weekly</changefreq><priority>0.95</priority></url>
   <url><loc>https://usebragstack.com/pricing</loc><changefreq>weekly</changefreq><priority>0.9</priority></url>
   <url><loc>https://usebragstack.com/docs</loc><changefreq>weekly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://usebragstack.com/how-it-works</loc><changefreq>weekly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://usebragstack.com/use-cases</loc><changefreq>weekly</changefreq><priority>0.85</priority></url>
   <url><loc>https://usebragstack.com/security</loc><changefreq>monthly</changefreq><priority>0.75</priority></url>
+  <url><loc>https://usebragstack.com/contact</loc><changefreq>monthly</changefreq><priority>0.55</priority></url>
+  <url><loc>https://usebragstack.com/team</loc><changefreq>monthly</changefreq><priority>0.6</priority></url>
+  <url><loc>https://usebragstack.com/enterprise</loc><changefreq>monthly</changefreq><priority>0.6</priority></url>
   <url><loc>https://usebragstack.com/login</loc><changefreq>monthly</changefreq><priority>0.85</priority></url>
   <url><loc>https://usebragstack.com/register</loc><changefreq>monthly</changefreq><priority>0.85</priority></url>
-  <url><loc>https://usebragstack.com/how-it-works</loc><changefreq>weekly</changefreq><priority>0.9</priority></url>
   <url><loc>https://usebragstack.com/impact-receipts</loc><changefreq>weekly</changefreq><priority>0.9</priority></url>
   <url><loc>https://usebragstack.com/performance-reviews</loc><changefreq>weekly</changefreq><priority>0.9</priority></url>
   <url><loc>https://usebragstack.com/career-portfolio</loc><changefreq>weekly</changefreq><priority>0.9</priority></url>

--- a/frontend/src/PublicInfoPages.css
+++ b/frontend/src/PublicInfoPages.css
@@ -1,0 +1,535 @@
+:root {
+  --public-bg: #070b14;
+  --public-panel: rgba(15, 23, 42, 0.78);
+  --public-panel-soft: rgba(15, 23, 42, 0.52);
+  --public-border: rgba(148, 163, 184, 0.18);
+  --public-text: #f8fafc;
+  --public-muted: #aebbd0;
+  --public-blue: #5ea0ff;
+  --public-blue-strong: #7db3ff;
+  --public-green: #72d7a5;
+}
+
+body:has(.public-info-topbar) {
+  margin: 0;
+  background: var(--public-bg);
+  color: var(--public-text);
+}
+
+.public-info-topbar,
+.public-info-hero,
+.public-info-section,
+.public-info-intro-grid,
+.public-info-warning,
+.public-info-footer {
+  box-sizing: border-box;
+}
+
+.public-info-topbar {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 2rem;
+  width: 100%;
+  padding: 1rem clamp(1.2rem, 4vw, 4rem);
+  border-bottom: 1px solid var(--public-border);
+  background: rgba(7, 11, 20, 0.9);
+  backdrop-filter: blur(18px);
+}
+
+.public-info-brand {
+  display: inline-flex;
+  align-items: center;
+  gap: .65rem;
+  color: var(--public-text);
+  text-decoration: none;
+  font-size: 1.05rem;
+}
+
+.public-info-brand img {
+  width: 30px;
+  height: 30px;
+  object-fit: contain;
+}
+
+.public-info-topbar nav {
+  display: flex;
+  align-items: center;
+  gap: 1.2rem;
+  flex-wrap: wrap;
+}
+
+.public-info-topbar nav a,
+.public-info-footer a {
+  color: var(--public-muted);
+  text-decoration: none;
+}
+
+.public-info-topbar nav a:hover,
+.public-info-footer a:hover {
+  color: var(--public-text);
+}
+
+.public-info-hero {
+  width: min(1180px, calc(100% - 2.4rem));
+  margin: 0 auto;
+  padding: clamp(4rem, 8vw, 7.5rem) 0 clamp(3rem, 6vw, 5.4rem);
+  display: grid;
+  grid-template-columns: minmax(0, 1.35fr) minmax(280px, .65fr);
+  align-items: center;
+  gap: clamp(2rem, 5vw, 5rem);
+}
+
+.public-info-kicker,
+.public-info-status {
+  display: inline-flex;
+  align-items: center;
+  gap: .45rem;
+  font-size: .78rem;
+  font-weight: 850;
+  letter-spacing: .12em;
+}
+
+.public-info-kicker {
+  color: var(--public-blue-strong);
+}
+
+.public-info-status {
+  margin-left: .75rem;
+  padding: .42rem .65rem;
+  border: 1px solid rgba(114, 215, 165, .32);
+  border-radius: 999px;
+  color: var(--public-green);
+  background: rgba(114, 215, 165, .08);
+}
+
+.public-info-hero h1 {
+  max-width: 880px;
+  margin: 1rem 0 1.15rem;
+  font-size: clamp(2.55rem, 6vw, 5.4rem);
+  line-height: .98;
+  letter-spacing: -.045em;
+}
+
+.public-info-hero > div > p {
+  max-width: 840px;
+  margin: 0;
+  color: var(--public-muted);
+  font-size: clamp(1rem, 2vw, 1.18rem);
+  line-height: 1.75;
+}
+
+.public-info-actions {
+  display: flex;
+  gap: .8rem;
+  margin-top: 1.65rem;
+  flex-wrap: wrap;
+}
+
+.public-info-primary,
+.public-info-secondary {
+  display: inline-flex;
+  align-items: center;
+  gap: .45rem;
+  min-height: 46px;
+  padding: .8rem 1rem;
+  border-radius: .8rem;
+  text-decoration: none;
+  font-weight: 800;
+}
+
+.public-info-primary {
+  background: var(--public-blue);
+  color: #06101d;
+}
+
+.public-info-secondary {
+  border: 1px solid var(--public-border);
+  color: var(--public-text);
+  background: rgba(255, 255, 255, .025);
+}
+
+.public-info-principles {
+  display: grid;
+  gap: .8rem;
+  padding: 1.6rem;
+  border: 1px solid var(--public-border);
+  border-radius: 1.2rem;
+  background: linear-gradient(180deg, rgba(37, 99, 235, .13), rgba(15, 23, 42, .6));
+  box-shadow: 0 20px 70px rgba(0, 0, 0, .22);
+}
+
+.public-info-principles svg { color: var(--public-blue-strong); }
+.public-info-principles strong { font-size: 1.2rem; }
+.public-info-principles span { color: var(--public-muted); line-height: 1.65; }
+
+.public-info-intro-grid,
+.public-info-section,
+.public-info-warning {
+  width: min(1180px, calc(100% - 2.4rem));
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.public-info-intro-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+  margin-bottom: clamp(4rem, 8vw, 7rem);
+}
+
+.public-info-intro-grid article,
+.public-info-use-grid article,
+.public-info-contact-grid article,
+.public-info-example-grid article {
+  border: 1px solid var(--public-border);
+  border-radius: 1rem;
+  background: var(--public-panel-soft);
+}
+
+.public-info-intro-grid article {
+  padding: 1.3rem;
+}
+
+.public-info-intro-grid svg,
+.public-info-use-grid svg,
+.public-info-contact-grid svg {
+  color: var(--public-blue-strong);
+}
+
+.public-info-intro-grid h2,
+.public-info-intro-grid h3 {
+  margin: .85rem 0 .55rem;
+  font-size: 1.05rem;
+}
+
+.public-info-intro-grid p,
+.public-info-use-grid p,
+.public-info-contact-grid p,
+.public-info-example-grid p {
+  color: var(--public-muted);
+  line-height: 1.65;
+}
+
+.public-info-section {
+  padding: clamp(2rem, 4vw, 4rem) 0 clamp(3.2rem, 7vw, 6rem);
+}
+
+.public-info-section-heading {
+  max-width: 780px;
+  margin-bottom: 1.5rem;
+}
+
+.public-info-section-heading > span {
+  color: var(--public-blue-strong);
+  font-size: .76rem;
+  font-weight: 850;
+  letter-spacing: .13em;
+}
+
+.public-info-section-heading h2 {
+  margin: .6rem 0 .7rem;
+  font-size: clamp(1.85rem, 4vw, 3.4rem);
+  letter-spacing: -.03em;
+}
+
+.public-info-section-heading p {
+  margin: 0;
+  color: var(--public-muted);
+  line-height: 1.7;
+}
+
+.public-info-step-list {
+  display: grid;
+  gap: 1rem;
+}
+
+.public-info-step {
+  display: grid;
+  grid-template-columns: 72px minmax(0, 1fr);
+  gap: 1.2rem;
+  padding: 1.5rem;
+  border: 1px solid var(--public-border);
+  border-radius: 1.1rem;
+  background: var(--public-panel);
+}
+
+.public-info-step-number {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 58px;
+  height: 58px;
+  border-radius: 50%;
+  background: rgba(94, 160, 255, .12);
+  color: var(--public-blue-strong);
+  font-weight: 900;
+}
+
+.public-info-step h3 {
+  margin: 0 0 .6rem;
+  font-size: 1.25rem;
+}
+
+.public-info-step p {
+  margin: 0 0 .9rem;
+  color: var(--public-muted);
+  line-height: 1.65;
+}
+
+.public-info-step ul {
+  display: grid;
+  gap: .55rem;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.public-info-step li {
+  display: flex;
+  gap: .55rem;
+  align-items: flex-start;
+  color: #d8e1ef;
+  line-height: 1.5;
+}
+
+.public-info-step li svg {
+  flex: 0 0 auto;
+  margin-top: .17rem;
+  color: var(--public-green);
+}
+
+.public-info-example {
+  padding-top: 1rem;
+}
+
+.public-info-example-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.public-info-example-grid article {
+  padding: 1.2rem;
+}
+
+.public-info-example-grid strong {
+  color: var(--public-blue-strong);
+}
+
+.public-info-example-grid p {
+  margin-bottom: 0;
+}
+
+.public-info-warning {
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
+  margin-bottom: clamp(4rem, 7vw, 6rem);
+  padding: 1.3rem;
+  border: 1px solid rgba(125, 179, 255, .25);
+  border-radius: 1rem;
+  background: rgba(37, 99, 235, .08);
+}
+
+.public-info-warning > svg {
+  flex: 0 0 auto;
+  color: var(--public-blue-strong);
+  margin-top: .2rem;
+}
+
+.public-info-warning h2 {
+  margin: 0 0 .45rem;
+  font-size: 1.05rem;
+}
+
+.public-info-warning p {
+  margin: 0 0 .55rem;
+  color: var(--public-muted);
+  line-height: 1.65;
+}
+
+.public-info-warning a {
+  color: var(--public-blue-strong);
+  font-weight: 750;
+  text-decoration: none;
+}
+
+.public-info-use-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.public-info-use-grid-small {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.public-info-use-grid article {
+  padding: 1.25rem;
+}
+
+.public-info-use-grid h3 {
+  margin: .75rem 0 .5rem;
+  font-size: 1.1rem;
+}
+
+.public-info-use-grid article > div {
+  display: grid;
+  gap: .25rem;
+  margin-top: .9rem;
+  padding-top: .8rem;
+  border-top: 1px solid var(--public-border);
+}
+
+.public-info-use-grid article > div strong {
+  color: var(--public-text);
+  font-size: .85rem;
+}
+
+.public-info-use-grid article > div span {
+  color: var(--public-muted);
+  line-height: 1.55;
+}
+
+.public-info-boundaries {
+  padding-top: 0;
+}
+
+.public-info-contact-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.public-info-contact-grid article {
+  padding: 1.2rem;
+}
+
+.public-info-contact-grid h3 {
+  margin: .7rem 0 .45rem;
+}
+
+.public-info-contact-grid a {
+  display: inline-block;
+  margin-top: .35rem;
+  color: var(--public-blue-strong);
+  font-weight: 750;
+  word-break: break-word;
+  text-decoration: none;
+}
+
+.public-info-footer {
+  margin-top: 2rem;
+  border-top: 1px solid var(--public-border);
+  padding: 3rem clamp(1.2rem, 4vw, 4rem) 1.5rem;
+  background: #060a12;
+}
+
+.public-info-footer-grid {
+  width: min(1180px, 100%);
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: 1.4fr repeat(3, 1fr);
+  gap: 2rem;
+}
+
+.public-info-footer-grid > div {
+  display: grid;
+  align-content: start;
+  gap: .65rem;
+}
+
+.public-info-footer h3 {
+  margin: 0 0 .3rem;
+  font-size: .78rem;
+  letter-spacing: .12em;
+  text-transform: uppercase;
+}
+
+.public-info-footer-brand > a {
+  color: var(--public-text);
+  font-weight: 900;
+  font-size: 1.15rem;
+}
+
+.public-info-footer-brand p {
+  margin: 0;
+  color: var(--public-muted);
+  line-height: 1.6;
+}
+
+.public-info-footer-bottom {
+  width: min(1180px, 100%);
+  margin: 2.2rem auto 0;
+  padding-top: 1.2rem;
+  border-top: 1px solid var(--public-border);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  color: var(--public-muted);
+  flex-wrap: wrap;
+}
+
+.public-info-footer-bottom div {
+  display: flex;
+  gap: 1rem;
+}
+
+@media (max-width: 900px) {
+  .public-info-topbar { align-items: flex-start; }
+  .public-info-topbar nav { justify-content: flex-end; }
+  .public-info-hero { grid-template-columns: 1fr; }
+  .public-info-intro-grid,
+  .public-info-contact-grid,
+  .public-info-use-grid-small { grid-template-columns: 1fr 1fr; }
+  .public-info-footer-grid { grid-template-columns: 1fr 1fr; }
+}
+
+@media (max-width: 640px) {
+  .public-info-topbar {
+    position: static;
+    padding: .9rem 1rem;
+  }
+  .public-info-topbar nav {
+    display: none;
+  }
+  .public-info-hero,
+  .public-info-intro-grid,
+  .public-info-section,
+  .public-info-warning {
+    width: min(100% - 2rem, 1180px);
+  }
+  .public-info-hero {
+    padding-top: 3.1rem;
+  }
+  .public-info-hero h1 {
+    font-size: clamp(2.3rem, 12vw, 3.5rem);
+  }
+  .public-info-status {
+    margin: .65rem 0 0;
+  }
+  .public-info-intro-grid,
+  .public-info-use-grid,
+  .public-info-use-grid-small,
+  .public-info-contact-grid,
+  .public-info-example-grid,
+  .public-info-footer-grid {
+    grid-template-columns: 1fr;
+  }
+  .public-info-step {
+    grid-template-columns: 1fr;
+  }
+  .public-info-footer {
+    padding-left: 1rem;
+    padding-right: 1rem;
+  }
+  .public-info-footer-bottom {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+}

--- a/frontend/src/PublicInfoPages.jsx
+++ b/frontend/src/PublicInfoPages.jsx
@@ -1,0 +1,400 @@
+import {
+  ArrowRight,
+  BriefcaseBusiness,
+  CheckCircle2,
+  FileCheck2,
+  LockKeyhole,
+  Mail,
+  ReceiptText,
+  ShieldCheck,
+  Target,
+  Users,
+} from "lucide-react";
+import "./PublicInfoPages.css";
+
+const CONTACT_EMAILS = [
+  {
+    title: "General questions",
+    email: "contact@usebragstack.com",
+    description: "Product questions, partnerships, press, feedback, and anything that does not fit another category.",
+  },
+  {
+    title: "Account & product support",
+    email: "support@usebragstack.com",
+    description: "Sign-in problems, unexpected product behavior, exports, account questions, and help using BragStack.",
+  },
+  {
+    title: "Privacy",
+    email: "privacy@usebragstack.com",
+    description: "Access, correction, deletion, export, privacy-rights requests, or questions about how personal information is handled.",
+  },
+  {
+    title: "Security",
+    email: "security@usebragstack.com",
+    description: "Suspected vulnerabilities, account compromise, unexpected data exposure, or other security concerns.",
+  },
+  {
+    title: "Billing",
+    email: "billing@usebragstack.com",
+    description: "Subscription status, invoices, renewals, cancellations, or other billing questions.",
+  },
+  {
+    title: "Legal",
+    email: "legal@usebragstack.com",
+    description: "Terms, legal notices, intellectual-property questions, or formal legal correspondence.",
+  },
+];
+
+const HOW_IT_WORKS = [
+  {
+    number: "01",
+    title: "Capture the work while the context is fresh",
+    text: "Create an accomplishment record when something meaningful happens. Record the situation, what you contributed, what changed, the skills involved, and any measurable result you can actually support.",
+    bullets: [
+      "Describe your contribution rather than claiming the entire team's work.",
+      "Add metrics only when you know where the number came from.",
+      "Reference useful evidence without copying restricted employer or client material into BragStack.",
+    ],
+  },
+  {
+    number: "02",
+    title: "Turn important accomplishments into Impact Receipts",
+    text: "Impact Receipts organize a strong accomplishment into reusable proof: contribution, result, evidence, skills, shared credit, and visibility. The goal is a clearer record of what happened—not a more impressive-sounding version of it.",
+    bullets: [
+      "Evidence can support a claim without making the underlying private file public.",
+      "Shared work should preserve shared credit.",
+      "Where verification is available, a collaborator can confirm the claim they were specifically asked to review.",
+    ],
+  },
+  {
+    number: "03",
+    title: "Package the right proof for the career moment",
+    text: "The same underlying evidence can be reorganized for different needs. A performance review needs a different presentation than a resume, promotion packet, or interview story, but the facts should stay consistent.",
+    bullets: [
+      "Build resume material from documented accomplishments.",
+      "Prepare review and promotion material from evidence captured throughout the cycle.",
+      "Use real situations and outcomes as the source for interview practice.",
+    ],
+  },
+  {
+    number: "04",
+    title: "Share selectively",
+    text: "BragStack is designed around private-by-default career evidence. Public proof should be a deliberate subset of your workspace, not a mirror of everything you have recorded.",
+    bullets: [
+      "Review every public item for confidential or identifying information first.",
+      "Publish only the accomplishments or receipts you intentionally choose.",
+      "Remember that someone who can view public content may copy or retain it outside BragStack.",
+    ],
+  },
+  {
+    number: "05",
+    title: "Keep building a durable evidence record",
+    text: "Career proof becomes more useful when it is captured continuously. Over time, your records can reveal recurring skills, stronger categories of impact, evidence gaps, and examples worth reusing later.",
+    bullets: [
+      "Use career analytics as a view into your own documented history, not as an employee score.",
+      "Update records when you learn that a metric, date, or attribution needs correction.",
+      "Keep private evidence private when sharing would create unnecessary risk.",
+    ],
+  },
+];
+
+const USE_CASES = [
+  {
+    title: "Performance reviews",
+    intro: "Build the review throughout the year instead of rebuilding it from memory at the deadline.",
+    capture: "Wins, customer outcomes, reliability improvements, completed projects, praise, ownership, mentoring, lessons, and measurable impact.",
+    use: "A review-ready record that helps you describe scope, results, growth, and specific examples with less guesswork.",
+  },
+  {
+    title: "Promotions & raises",
+    intro: "Show how your scope and impact changed over time rather than relying on a list of tasks.",
+    capture: "Expanded responsibility, leadership, cross-team work, difficult problems, repeated impact, new skills, and evidence of higher-level work.",
+    use: "Promotion material organized around ownership, outcomes, progression, and the strongest proof you have available.",
+  },
+  {
+    title: "Resume & job search",
+    intro: "Keep the raw material for stronger resume bullets before old projects become hard to remember.",
+    capture: "Situation, action, result, technologies, scale, constraints, metrics, and the parts of the work you personally owned.",
+    use: "Resume material grounded in real accomplishments instead of generic responsibility statements or invented numbers.",
+  },
+  {
+    title: "Interview preparation",
+    intro: "Prepare stories from work you actually did, with enough context to explain your decisions and impact clearly.",
+    capture: "Challenges, tradeoffs, actions, mistakes, recovery, collaboration, leadership, customer impact, technical decisions, and results.",
+    use: "A library of real examples for behavioral, situational, leadership, and technical conversations.",
+  },
+  {
+    title: "Career changers",
+    intro: "Make new skills visible by documenting how and where you used them.",
+    capture: "Projects, labs, certifications, volunteer work, coursework, open-source work, practical exercises, and transferable accomplishments.",
+    use: "Evidence that connects previous experience to the skills and responsibilities of the next role you are pursuing.",
+  },
+  {
+    title: "Freelancers & consultants",
+    intro: "Turn completed engagements into a reusable record of client value without exposing private client information.",
+    capture: "Problems solved, deliverables, before-and-after outcomes, approved testimonials, measurable results, and reusable lessons.",
+    use: "Case-study material, client updates, portfolio proof, and a clearer record of the kinds of outcomes you repeatedly deliver.",
+  },
+  {
+    title: "Founders & creators",
+    intro: "Document the work behind launches and experiments instead of keeping the whole company story in your head.",
+    capture: "Launches, product changes, customer feedback, experiments, operational improvements, audience milestones, and lessons learned.",
+    use: "A factual record that can support future hiring, fundraising conversations, partnerships, portfolios, or your own career story.",
+  },
+  {
+    title: "Adult education & early career",
+    intro: "Adults age 18+ can document growth before they have a long employment history.",
+    capture: "Projects, academic work, service, internships, competitions, leadership, certifications, practical skills, and meaningful learning milestones.",
+    use: "Material for internships, scholarships, applications, portfolios, interviews, and early-career storytelling. BragStack accounts are 18+ for now.",
+  },
+];
+
+function Header() {
+  return (
+    <header className="public-info-topbar">
+      <a className="public-info-brand" href="/"><img src="/brandmark.svg" alt="" /><strong>BragStack</strong></a>
+      <nav aria-label="Public information navigation">
+        <a href="/how-it-works">How it works</a>
+        <a href="/use-cases">Use cases</a>
+        <a href="/security">Trust & privacy</a>
+        <a href="/docs">Docs</a>
+        <a href="/login">Sign in</a>
+      </nav>
+    </header>
+  );
+}
+
+function Footer() {
+  return (
+    <footer className="public-info-footer">
+      <div className="public-info-footer-grid">
+        <div className="public-info-footer-brand"><a href="/">BragStack</a><p>Turn everyday work into career proof you can use when it matters.</p></div>
+        <div><h3>Resources</h3><a href="/how-it-works">How it works</a><a href="/use-cases">Use cases</a><a href="/docs">Docs</a><a href="/nda-safety">NDA & confidential work</a></div>
+        <div><h3>Company</h3><a href="/contact">Contact</a><a href="/team">Team waitlist</a><a href="/enterprise">Enterprise</a><a href="/security">Trust & privacy</a></div>
+        <div><h3>Legal</h3><a href="/privacy">Privacy Policy</a><a href="/terms">Terms & Conditions</a><a href="/nda-safety">Confidentiality guidance</a></div>
+      </div>
+      <div className="public-info-footer-bottom"><span>© 2026 BragStack</span><span>Private by default · Your proof stays yours.</span><div><a href="/login">Log in</a><a href="/register">Start free</a></div></div>
+    </footer>
+  );
+}
+
+function Hero({ eyebrow, title, description, badge, primaryHref = "/register", primaryLabel = "Start free", secondaryHref = "/docs", secondaryLabel = "Read the docs" }) {
+  return (
+    <section className="public-info-hero">
+      <div>
+        <span className="public-info-kicker"><ReceiptText size={16} /> {eyebrow}</span>
+        {badge && <span className="public-info-status">{badge}</span>}
+        <h1>{title}</h1>
+        <p>{description}</p>
+        <div className="public-info-actions">
+          <a className="public-info-primary" href={primaryHref}>{primaryLabel}<ArrowRight size={17} /></a>
+          <a className="public-info-secondary" href={secondaryHref}>{secondaryLabel}</a>
+        </div>
+      </div>
+      <aside className="public-info-principles">
+        <ShieldCheck size={31} />
+        <strong>Evidence before exaggeration.</strong>
+        <span>BragStack is designed to help you organize what you can support, keep private work private, and choose what becomes public.</span>
+      </aside>
+    </section>
+  );
+}
+
+function HowItWorksPage() {
+  return (
+    <>
+      <Header />
+      <Hero
+        eyebrow="HOW BRAGSTACK WORKS"
+        title="Capture → Prove → Package → Share → Keep building."
+        description="BragStack gives your accomplishments somewhere durable to live before the details disappear. Capture the work once, connect the evidence you are allowed to keep, and reuse the strongest proof when a career moment needs it."
+        secondaryHref="/nda-safety"
+        secondaryLabel="Confidential-work guide"
+      />
+      <section className="public-info-intro-grid">
+        <article><Target size={23} /><h2>What BragStack is</h2><p>A private career-evidence workspace for documenting accomplishments, impact, skills, evidence references, and reusable professional stories.</p></article>
+        <article><LockKeyhole size={23} /><h2>What stays private</h2><p>Your account and private proof are not meant to become public automatically. Sharing is a separate, intentional action.</p></article>
+        <article><FileCheck2 size={23} /><h2>What “proof” means here</h2><p>Proof can include your own structured record, supporting evidence references, measurable results, shared credit, and verification where a feature supports it.</p></article>
+      </section>
+      <section className="public-info-section">
+        <div className="public-info-section-heading"><span>THE WORKFLOW</span><h2>Five steps, with the details that matter.</h2><p>Each stage has a different job. The product should help you preserve facts—not blur the line between documented work and generated wording.</p></div>
+        <div className="public-info-step-list">
+          {HOW_IT_WORKS.map((step) => (
+            <article key={step.number} className="public-info-step">
+              <span className="public-info-step-number">{step.number}</span>
+              <div><h3>{step.title}</h3><p>{step.text}</p><ul>{step.bullets.map((item) => <li key={item}><CheckCircle2 size={16} />{item}</li>)}</ul></div>
+            </article>
+          ))}
+        </div>
+      </section>
+      <section className="public-info-section public-info-example">
+        <div className="public-info-section-heading"><span>EXAMPLE</span><h2>What a healthy evidence trail can look like.</h2></div>
+        <div className="public-info-example-grid">
+          <article><strong>Situation</strong><p>A recurring customer escalation took too long to diagnose because troubleshooting knowledge was scattered.</p></article>
+          <article><strong>Contribution</strong><p>You documented the failure pattern, clarified the diagnostic path, and created a reusable internal troubleshooting guide.</p></article>
+          <article><strong>Result</strong><p>The team gained a more repeatable resolution path. Add a time or percentage improvement only if you have a reliable source for it.</p></article>
+          <article><strong>Evidence</strong><p>Reference an approved ticket, dashboard, sanitized screenshot, public artifact, or manager-confirmed result only when your policies allow it.</p></article>
+        </div>
+      </section>
+      <section className="public-info-warning"><ShieldCheck size={21} /><div><h2>Confidentiality comes before career proof.</h2><p>Do not move passwords, secrets, source code, customer data, private logs, restricted documents, trade secrets, or material covered by an NDA or employer policy into BragStack just to make an accomplishment look stronger. A generalized description is often safer and still useful.</p><a href="/nda-safety">Read the NDA & confidential-work guidance →</a></div></section>
+      <Footer />
+    </>
+  );
+}
+
+function UseCasesPage() {
+  return (
+    <>
+      <Header />
+      <Hero
+        eyebrow="BRAGSTACK USE CASES"
+        title="Use the same documented work for different career moments."
+        description="A good career-proof system should reduce rework. Capture the facts once, then organize the relevant subset for a review, promotion, resume, interview, portfolio, or next opportunity without changing what actually happened."
+        secondaryHref="/how-it-works"
+        secondaryLabel="See the workflow"
+      />
+      <section className="public-info-section">
+        <div className="public-info-section-heading"><span>REAL CAREER MOMENTS</span><h2>What to capture—and what it can become.</h2><p>These are examples, not guarantees of a particular hiring, compensation, school, or promotion outcome.</p></div>
+        <div className="public-info-use-grid">
+          {USE_CASES.map((item) => (
+            <article key={item.title}>
+              <BriefcaseBusiness size={22} />
+              <h3>{item.title}</h3>
+              <p>{item.intro}</p>
+              <div><strong>Capture</strong><span>{item.capture}</span></div>
+              <div><strong>Use it for</strong><span>{item.use}</span></div>
+            </article>
+          ))}
+        </div>
+      </section>
+      <section className="public-info-section public-info-boundaries">
+        <div className="public-info-section-heading"><span>BOUNDARIES</span><h2>What BragStack should not become.</h2></div>
+        <div className="public-info-intro-grid">
+          <article><ShieldCheck size={22} /><h3>Not a fabrication engine</h3><p>Generated wording should never silently create employers, credentials, dates, metrics, projects, or outcomes you did not provide.</p></article>
+          <article><LockKeyhole size={22} /><h3>Not an employer surveillance feed</h3><p>Your private career evidence is for you. Planned organization features are intended to use bounded, user-approved sharing rather than hidden observation.</p></article>
+          <article><FileCheck2 size={22} /><h3>Not a reason to break confidentiality</h3><p>If a detail is restricted, leave it out or generalize it. Your employer, client, contract, NDA, and applicable law still control what you may retain or disclose.</p></article>
+        </div>
+      </section>
+      <Footer />
+    </>
+  );
+}
+
+function ContactPage() {
+  return (
+    <>
+      <Header />
+      <Hero
+        eyebrow="CONTACT BRAGSTACK"
+        title="Get your question to the right place."
+        description="Use the address that best matches what you need. Keeping support, privacy, security, billing, and legal requests separate helps important messages reach the right workflow."
+        primaryHref="mailto:contact@usebragstack.com?subject=BragStack%20question"
+        primaryLabel="Email BragStack"
+        secondaryHref="/docs"
+        secondaryLabel="Check the docs first"
+      />
+      <section className="public-info-section">
+        <div className="public-info-section-heading"><span>CONTACT ROUTES</span><h2>Choose the address that fits your request.</h2><p>Do not send passwords, authentication tokens, full payment-card numbers, employer secrets, or confidential evidence by email.</p></div>
+        <div className="public-info-contact-grid">
+          {CONTACT_EMAILS.map((item) => (
+            <article key={item.email}><Mail size={21} /><h3>{item.title}</h3><p>{item.description}</p><a href={`mailto:${item.email}?subject=BragStack%20${encodeURIComponent(item.title)}`}>{item.email}</a></article>
+          ))}
+        </div>
+      </section>
+      <section className="public-info-section">
+        <div className="public-info-section-heading"><span>HELP US HELP YOU</span><h2>What to include in a useful support message.</h2></div>
+        <div className="public-info-intro-grid">
+          <article><h3>Account issue</h3><p>Include the email address associated with the account, the page you were using, what you expected to happen, what happened instead, and the approximate time of the problem.</p></article>
+          <article><h3>Bug report</h3><p>Include reproducible steps, device/browser information, screenshots with sensitive information removed, and any error text that is safe to share.</p></article>
+          <article><h3>Security report</h3><p>Describe the suspected vulnerability or exposure clearly. Avoid testing against other users, accessing data you are not authorized to access, or emailing secrets as proof.</p></article>
+        </div>
+      </section>
+      <Footer />
+    </>
+  );
+}
+
+function TeamPage() {
+  return (
+    <>
+      <Header />
+      <Hero
+        eyebrow="BRAGSTACK FOR TEAMS"
+        badge="COMING SOON"
+        title="Support professional growth without turning career evidence into surveillance."
+        description="BragStack Team is planned as an organization layer around the employee-controlled evidence model. The goal is to make reviews, recognition, and development easier while keeping private individual proof separate from what a person intentionally shares with an organization."
+        primaryHref="mailto:contact@usebragstack.com?subject=BragStack%20Team%20waitlist"
+        primaryLabel="Join the Team waitlist"
+        secondaryHref="/security"
+        secondaryLabel="Read the trust model"
+      />
+      <section className="public-info-section">
+        <div className="public-info-section-heading"><span>PLANNED DIRECTION</span><h2>What the Team product is intended to support.</h2><p>These capabilities are roadmap direction, not a promise that every item is generally available today.</p></div>
+        <div className="public-info-use-grid public-info-use-grid-small">
+          <article><Users size={22} /><h3>Shared review templates</h3><p>Give teams a consistent structure for review cycles without forcing every person's private BragStack workspace into the organization.</p></article>
+          <article><FileCheck2 size={22} /><h3>Optional manager confirmation</h3><p>Let a user request confirmation for specific work when confirmation is appropriate instead of treating a manager as the owner of the record.</p></article>
+          <article><ReceiptText size={22} /><h3>Review-cycle packets</h3><p>Organize employee-approved evidence into clearer performance and development conversations.</p></article>
+          <article><Target size={22} /><h3>Bounded organization analytics</h3><p>Provide useful aggregate or workflow-level signals without turning a person's private evidence history into an employee score.</p></article>
+          <article><BriefcaseBusiness size={22} /><h3>Centralized billing</h3><p>Make it practical for an organization to pay for participating users while keeping account ownership and permissions explicit.</p></article>
+        </div>
+      </section>
+      <section className="public-info-section public-info-boundaries">
+        <div className="public-info-section-heading"><span>DESIGN PRINCIPLES</span><h2>What we are trying to protect as teams are added.</h2></div>
+        <div className="public-info-intro-grid">
+          <article><LockKeyhole size={22} /><h3>Private means private</h3><p>An organization should not automatically receive a copy of everything an employee records in a personal career workspace.</p></article>
+          <article><ShieldCheck size={22} /><h3>Sharing should be understandable</h3><p>People should know what they are sharing, who can see it, and why an organization is asking for it.</p></article>
+          <article><Users size={22} /><h3>Recognition should preserve credit</h3><p>Collaborative work should not be flattened into a single-person claim simply because the software makes that easier.</p></article>
+        </div>
+      </section>
+      <section className="public-info-warning"><Users size={21} /><div><h2>Current availability</h2><p>Individual BragStack accounts are the live product today. Team features are still being developed. Joining the waitlist is an expression of interest, not a purchase commitment or guarantee of a launch date.</p><a href="mailto:contact@usebragstack.com?subject=BragStack%20Team%20waitlist">Join the Team waitlist →</a></div></section>
+      <Footer />
+    </>
+  );
+}
+
+function EnterprisePage() {
+  return (
+    <>
+      <Header />
+      <Hero
+        eyebrow="BRAGSTACK ENTERPRISE"
+        badge="EARLY / PLANNED"
+        title="Governed career evidence for larger organizations—without pretending the enterprise layer is finished."
+        description="The enterprise direction builds on BragStack's employee-controlled evidence model with additional identity, policy, retention, governance, and support capabilities. Enterprise is not presented here as a generally available compliance product today."
+        primaryHref="mailto:contact@usebragstack.com?subject=BragStack%20Enterprise"
+        primaryLabel="Discuss enterprise needs"
+        secondaryHref="/security"
+        secondaryLabel="Security overview"
+      />
+      <section className="public-info-section">
+        <div className="public-info-section-heading"><span>ENTERPRISE ROADMAP</span><h2>Capabilities being considered for larger deployments.</h2><p>The exact package should be driven by real customer requirements, security review, and the controls BragStack can actually support at launch.</p></div>
+        <div className="public-info-use-grid public-info-use-grid-small">
+          <article><Users size={22} /><h3>Enterprise identity</h3><p>Organization-managed sign-in and identity controls are part of the enterprise roadmap. Specific SSO or provisioning standards should not be assumed until they are documented as available.</p></article>
+          <article><ShieldCheck size={22} /><h3>Audit & governance controls</h3><p>Provide administrators with appropriate records and policy controls for enterprise workflows while avoiding access to unrelated private career evidence.</p></article>
+          <article><FileCheck2 size={22} /><h3>Retention controls</h3><p>Support organization policy around records that belong to enterprise workflows, with clearer separation from a person's private evidence where the product model requires it.</p></article>
+          <article><LockKeyhole size={22} /><h3>Admin policy controls</h3><p>Define what an organization can request, what can be shared into an organization workflow, and which controls apply to managed enterprise use.</p></article>
+          <article><BriefcaseBusiness size={22} /><h3>Integrations & support</h3><p>Evaluate customer-specific integration and support needs instead of claiming broad integrations before they exist and are tested.</p></article>
+        </div>
+      </section>
+      <section className="public-info-section">
+        <div className="public-info-section-heading"><span>PROCUREMENT & TRUST</span><h2>Questions we expect serious enterprise buyers to ask.</h2></div>
+        <div className="public-info-intro-grid">
+          <article><h3>What data does BragStack store?</h3><p>Enterprise evaluation should document the exact data flows, roles, retention behavior, public/private sharing boundaries, and third-party services used by the version being evaluated.</p></article>
+          <article><h3>What security attestations exist?</h3><p>Do not assume BragStack holds SOC 2, ISO 27001, HIPAA, FedRAMP, or another certification unless BragStack explicitly publishes that current status. Security claims should match evidence.</p></article>
+          <article><h3>Can an employer see private evidence?</h3><p>The product direction is to keep individual evidence ownership separate from bounded organization workflows. Any enterprise permission model should state exactly what admins can and cannot access.</p></article>
+        </div>
+      </section>
+      <section className="public-info-warning"><ShieldCheck size={21} /><div><h2>Enterprise is a conversation before it is a contract.</h2><p>BragStack should only commit to controls, integrations, support levels, or compliance requirements after confirming that the product and operating processes can meet them. If your organization has specific procurement, security, privacy, or data-residency requirements, include them in your inquiry.</p><a href="mailto:contact@usebragstack.com?subject=BragStack%20Enterprise">Start an enterprise conversation →</a></div></section>
+      <Footer />
+    </>
+  );
+}
+
+export default function PublicInfoPage({ page }) {
+  if (page === "how-it-works") return <HowItWorksPage />;
+  if (page === "use-cases") return <UseCasesPage />;
+  if (page === "contact") return <ContactPage />;
+  if (page === "team") return <TeamPage />;
+  if (page === "enterprise") return <EnterprisePage />;
+  return <HowItWorksPage />;
+}

--- a/frontend/src/RootContent.jsx
+++ b/frontend/src/RootContent.jsx
@@ -23,6 +23,7 @@ const LandingInterviewShowcase = lazyPage(() => import("./LandingInterviewShowca
 const LandingResumeShowcase = lazyPage(() => import("./LandingResumeShowcase.jsx"));
 const OpsConsolePage = lazyPage(() => import("./OpsConsolePage.jsx"));
 const OpsUsersPage = lazyPage(() => import("./OpsUsersPage.jsx"));
+const PublicInfoPage = lazyPage(() => import("./PublicInfoPages.jsx"));
 const ReceiptVerificationCenter = lazyPage(() => import("./ReceiptVerificationCenter.jsx"));
 const ReceiptVerificationPage = lazyPage(() => import("./ReceiptVerificationPage.jsx"));
 const ResumeBuilderPage = lazyPage(() => import("./ResumeBuilderPage.jsx"));
@@ -175,6 +176,11 @@ function RootContent() {
   else if (path === "/docs") content = <DocsPage />;
   else if (path === "/nda-safety") content = <NDAGuidancePage />;
   else if (path === "/security") content = <SecurityPage />;
+  else if (path === "/how-it-works") content = <PublicInfoPage page="how-it-works" />;
+  else if (path === "/use-cases") content = <PublicInfoPage page="use-cases" />;
+  else if (path === "/contact") content = <PublicInfoPage page="contact" />;
+  else if (path === "/team") content = <PublicInfoPage page="team" />;
+  else if (path === "/enterprise") content = <PublicInfoPage page="enterprise" />;
   else if (seoLandingContent) content = <SeoLandingPage content={seoLandingContent} />;
   else if (path === "/") content = <><App /><LandingInterviewShowcase /><LandingResumeShowcase /><SearchSitelinksNav /></>;
   else {

--- a/frontend/src/useSearchAppearanceMeta.js
+++ b/frontend/src/useSearchAppearanceMeta.js
@@ -14,6 +14,42 @@ const PUBLIC_META = {
     title: "Sign up for BragStack | Start Free",
     description: "Create a free BragStack account and start turning your accomplishments into career proof for resumes, interviews, reviews, and promotions.",
   },
+  "/how-it-works": {
+    title: "How BragStack Works | Capture, Prove & Reuse Career Evidence",
+    description: "See how BragStack helps you capture accomplishments, create Impact Receipts, reuse evidence for career moments, share selectively, and keep private work private.",
+  },
+  "/use-cases": {
+    title: "BragStack Use Cases | Reviews, Promotions, Resumes & Interviews",
+    description: "Explore practical BragStack use cases for performance reviews, promotions, resumes, interviews, career changes, freelancers, founders, and adults in education.",
+  },
+  "/contact": {
+    title: "Contact BragStack | Support, Privacy, Security & Billing",
+    description: "Contact BragStack for product support, general questions, privacy requests, security concerns, billing questions, or legal correspondence.",
+  },
+  "/team": {
+    title: "BragStack for Teams | Coming Soon",
+    description: "Learn about the planned BragStack Team direction for evidence-backed reviews, employee-controlled sharing, bounded analytics, and organization workflows without surveillance.",
+  },
+  "/enterprise": {
+    title: "BragStack Enterprise | Governance Roadmap for Career Evidence",
+    description: "Learn about BragStack's early enterprise direction for identity, governance, retention, admin policy controls, integrations, and employee-controlled evidence boundaries.",
+  },
+  "/security": {
+    title: "BragStack Security | Private-by-Default Career Evidence",
+    description: "Read BragStack's security approach, private-by-default model, confidential-work guidance, payment handling, and instructions for reporting a security concern.",
+  },
+  "/privacy": {
+    title: "Privacy Policy | BragStack",
+    description: "Read the BragStack Privacy Policy, including information collection, career evidence, sharing, AI-assisted features, retention, security, and privacy choices.",
+  },
+  "/terms": {
+    title: "Terms and Conditions | BragStack",
+    description: "Read the terms governing BragStack accounts, user content, acceptable use, subscriptions, AI-assisted career content, confidentiality, and service use.",
+  },
+  "/nda-safety": {
+    title: "NDA & Confidential Work Guidance | BragStack",
+    description: "Learn how to document professional accomplishments in BragStack without overriding NDAs, employer policies, client agreements, or confidentiality obligations.",
+  },
   "/education": {
     title: "BragStack Education | Student Wins & Growth for Ages 18+",
     description: "BragStack Education helps adults age 18+ capture real education wins from school, projects, activities, service, work, and learning. High-school students who are already 18 and adult college/university students can use the live workspace today.",


### PR DESCRIPTION
## Summary

Adds full public-facing content for the footer destinations that were previously section anchors or mailto-only links.

### New substantive pages
- `/how-it-works` — detailed five-step evidence workflow, example, and confidentiality guidance
- `/use-cases` — detailed use cases for reviews, promotions, resumes, interviews, career changes, freelancers, founders, and adults 18+ in education
- `/contact` — separate general, support, privacy, security, billing, and legal contact routes plus safe support guidance
- `/team` — clearly labeled **Coming Soon** page with planned Team capabilities and privacy/design principles
- `/enterprise` — clearly labeled **Early / Planned** page with governance roadmap and explicit no-unverified-compliance-claims language

### Existing pages preserved
The current `/security`, `/privacy`, `/terms`, `/nda-safety`, `/login`, `/register`, and `/docs` pages remain in place because they already contain functional or substantive content.

### Navigation/SEO
- Footer links now route to real pages instead of only anchors/mailto actions where appropriate
- Added page-specific titles/descriptions and canonical coverage
- Added the new public destinations to the sitemap

### Accuracy / legal-safety choices
- Team and Enterprise capabilities are described as planned, not generally available
- No SOC 2 / ISO / HIPAA / FedRAMP certification is claimed
- Confidential-work language explicitly defers to NDAs, employer/client policy, contracts, and applicable law
- BragStack Education remains stated as 18+ for now
