### PR TITLE
Fix direct navigation to public SPA routes

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "vite build && node scripts/generate-static-route-shells.mjs",
     "lint": "eslint .",
     "test:analytics": "node --test src/analytics.test.js",
     "test:interview": "node --test src/interviewEngine*.test.js",

--- a/frontend/scripts/generate-static-route-shells.mjs
+++ b/frontend/scripts/generate-static-route-shells.mjs
@@ -1,0 +1,68 @@
+import { copyFile, mkdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const FRONTEND_DIR = path.resolve(SCRIPT_DIR, "..");
+const DIST_DIR = path.join(FRONTEND_DIR, "dist");
+const INDEX_FILE = path.join(DIST_DIR, "index.html");
+const SITEMAP_FILE = path.join(FRONTEND_DIR, "public", "sitemap.xml");
+const SITE_ORIGIN = "https://usebragstack.com";
+
+const REQUIRED_CLIENT_ROUTES = [
+  "/privacy",
+  "/terms",
+  "/nda-safety",
+  "/security",
+  "/contact",
+  "/team",
+  "/enterprise",
+  "/use-cases",
+  "/how-it-works",
+  "/login",
+  "/register",
+  "/upgrade",
+  "/verify-receipt",
+  "/education",
+  "/docs",
+  "/docs/education",
+];
+
+function normalizeRoute(route) {
+  const pathname = route.split(/[?#]/, 1)[0] || "/";
+  if (!pathname.startsWith("/")) return null;
+  if (pathname === "/") return null;
+  if (pathname.includes("..")) throw new Error(`Unsafe route in static shell generator: ${route}`);
+  return pathname.replace(/\/+$/, "");
+}
+
+function sitemapRoutes(xml) {
+  const routes = [];
+  const pattern = /<loc>([^<]+)<\/loc>/g;
+  for (const match of xml.matchAll(pattern)) {
+    const url = new URL(match[1]);
+    if (url.origin !== SITE_ORIGIN) continue;
+    const normalized = normalizeRoute(url.pathname);
+    if (normalized) routes.push(normalized);
+  }
+  return routes;
+}
+
+const sitemapXml = await readFile(SITEMAP_FILE, "utf8");
+const routes = new Set([
+  ...sitemapRoutes(sitemapXml),
+  ...REQUIRED_CLIENT_ROUTES.map(normalizeRoute).filter(Boolean),
+]);
+
+for (const route of [...routes].sort()) {
+  const relativeRoute = route.slice(1);
+  const routeDir = path.join(DIST_DIR, relativeRoute);
+  await mkdir(routeDir, { recursive: true });
+  await copyFile(INDEX_FILE, path.join(routeDir, "index.html"));
+}
+
+// Render serves a static site, so unknown client-side routes need an SPA shell too.
+// This keeps dynamic public profile/share links from becoming a dead-end 404 page.
+await copyFile(INDEX_FILE, path.join(DIST_DIR, "404.html"));
+
+console.log(`Generated SPA route shells for ${routes.size} public/client routes.`);


### PR DESCRIPTION
## Fix

Render serves BragStack as a static site. Direct requests such as `/privacy` were not guaranteed to receive the SPA `index.html`, so users could hit a dead end even though the React route existed.

This hotfix makes the built artifact safe for direct navigation by:
- generating `index.html` route shells for every sitemap URL
- also generating shells for important client routes such as `/privacy`, `/terms`, `/security`, `/contact`, `/team`, `/enterprise`, `/education`, `/docs/education`, `/upgrade`, and `/verify-receipt`
- generating `dist/404.html` from the SPA shell as a fallback for dynamic client routes
- running this automatically after every Vite production build

This is intentionally a build-output fix so it works with the current Render static-site setup without requiring a manual dashboard rewrite rule.