### PR TITLE
Keep accomplishments editable and make visibility reversible

### DIFF
--- a/frontend/src/AccomplishmentsPage.css
+++ b/frontend/src/AccomplishmentsPage.css
@@ -41,11 +41,46 @@
 .accomplishment-card-top{display:flex;justify-content:space-between;gap:18px;align-items:flex-start}
 .accomplishment-card h2{margin:6px 0 0;font-size:1.35rem}
 .accomplishment-card-actions{display:flex;align-items:center;flex-wrap:wrap;justify-content:flex-end;gap:8px}
-.accomplishment-edit-group{display:inline-flex;align-items:center;gap:7px;padding:4px 6px 4px 4px;border:1px solid rgba(148,163,184,.16);border-radius:14px;background:rgba(2,6,23,.3)}
-.accomplishment-edit-group>span{color:#94a3b8;font-size:.72rem;font-weight:800;white-space:nowrap}
-.accomplishment-icon-action{width:40px;height:40px;display:grid;place-items:center;padding:0;border:1px solid rgba(148,163,184,.24);border-radius:11px;color:#dbeafe;background:#0b1425;box-shadow:none;cursor:pointer;transition:border-color .16s,background .16s,color .16s,transform .16s}
-.accomplishment-icon-action:hover{color:#f8fafc;border-color:rgba(125,211,252,.48);background:#101d31;transform:translateY(-1px)}
-.accomplishment-icon-action:focus-visible{outline:2px solid #7dd3fc;outline-offset:2px}
-.edit-window-locked{color:#64748b;font-size:.72rem;font-weight:800}
-.proof-public,.proof-private{flex:0 0 auto;padding:7px 10px;border-radius:999px;font-size:.76rem;font-weight:900}.proof-public{color:#bbf7d0;background:rgba(34,197,94,.1);border:1px solid rgba(34,197,94,.2)}.proof-private{color:#cbd5e1;background:rgba(148,163,184,.08);border:1px solid rgba(148,163,184,.16)}.accomplishment-bullet{margin:16px 0;color:#dbeafe;line-height:1.7}.accomplishment-proof-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:12px}.accomplishment-proof-grid>div{padding:14px;border-radius:18px;background:rgba(2,6,23,.36);border:1px solid rgba(148,163,184,.1)}.accomplishment-proof-grid strong{color:#f8fafc}.accomplishment-proof-grid p{margin-bottom:0;color:#cbd5e1;line-height:1.6}.accomplishment-tags{display:flex;flex-wrap:wrap;gap:8px;margin-top:16px}.accomplishment-tags span{padding:6px 10px;border-radius:999px;color:#bae6fd;background:rgba(14,165,233,.08);border:1px solid rgba(14,165,233,.14);font-size:.8rem;font-weight:800}.accomplishments-empty,.accomplishments-error{padding:28px;border-radius:24px;text-align:center}.accomplishments-error{color:#fecaca;margin-bottom:16px}.pagination{display:flex;align-items:center;justify-content:center;gap:12px;margin-top:24px}.pagination>button,.pagination-pages button{min-height:40px;border-radius:12px;border:1px solid rgba(148,163,184,.18);background:rgba(15,23,42,.7);color:#e2e8f0;cursor:pointer;font-weight:800}.pagination>button{display:inline-flex;align-items:center;gap:6px;padding:0 14px}.pagination-pages{display:flex;gap:7px}.pagination-pages button{width:40px}.pagination-pages button.active{color:#020617;background:linear-gradient(135deg,#f8fafc,#bae6fd)}.pagination button:disabled{cursor:not-allowed;opacity:.4}
-@media(max-width:760px){.accomplishments-page{width:min(100% - 24px,1180px);padding-top:24px}.accomplishments-hero,.accomplishments-toolbar,.accomplishment-card-top{flex-direction:column}.accomplishments-toolbar{align-items:stretch}.accomplishments-toolbar>p{white-space:normal}.accomplishment-card-actions{width:100%;justify-content:flex-start}.accomplishment-proof-grid{grid-template-columns:1fr}.pagination{flex-wrap:wrap}.modal-backdrop{align-items:flex-start;padding:12px}.modal-card{grid-template-columns:1fr;gap:16px;max-height:calc(100vh - 24px);padding:20px;border-radius:20px}.modal-card>label:nth-of-type(1),.modal-card>label:nth-of-type(2){grid-column:auto}.modal-card .form-grid{grid-template-columns:1fr;gap:16px}.modal-actions{bottom:-20px;margin:2px -20px -20px;padding:14px 20px;border-radius:0 0 20px 20px}.modal-actions .btn{flex:1;padding:0 12px}}
+.accomplishment-edit-button{display:inline-flex;align-items:center;justify-content:center;gap:7px;min-height:40px;padding:0 12px;border:1px solid rgba(148,163,184,.24);border-radius:11px;color:#dbeafe;background:#0b1425;box-shadow:none;font:inherit;font-size:.78rem;font-weight:900;cursor:pointer;transition:border-color .16s,background .16s,color .16s,transform .16s}
+.accomplishment-edit-button:hover{color:#f8fafc;border-color:rgba(125,211,252,.48);background:#101d31;transform:translateY(-1px)}
+.accomplishment-edit-button:focus-visible{outline:2px solid #7dd3fc;outline-offset:2px}
+.proof-public,.proof-private{flex:0 0 auto;padding:7px 10px;border-radius:999px;font-size:.76rem;font-weight:900}
+.proof-public{color:#bbf7d0;background:rgba(34,197,94,.1);border:1px solid rgba(34,197,94,.2)}
+.proof-private{color:#cbd5e1;background:rgba(148,163,184,.08);border:1px solid rgba(148,163,184,.16)}
+.proof-visibility-button{min-height:40px;padding:0 12px;font:inherit;font-size:.76rem;font-weight:900;cursor:pointer;transition:border-color .16s,background .16s,transform .16s,opacity .16s}
+.proof-visibility-button:hover:not(:disabled){transform:translateY(-1px);border-color:rgba(125,211,252,.4)}
+.proof-visibility-button:focus-visible{outline:2px solid #7dd3fc;outline-offset:2px}
+.proof-visibility-button:disabled{opacity:.6;cursor:wait}
+.accomplishment-bullet{margin:16px 0;color:#dbeafe;line-height:1.7}
+.accomplishment-proof-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:12px}
+.accomplishment-proof-grid>div{padding:14px;border-radius:18px;background:rgba(2,6,23,.36);border:1px solid rgba(148,163,184,.1)}
+.accomplishment-proof-grid strong{color:#f8fafc}
+.accomplishment-proof-grid p{margin-bottom:0;color:#cbd5e1;line-height:1.6}
+.accomplishment-tags{display:flex;flex-wrap:wrap;gap:8px;margin-top:16px}
+.accomplishment-tags span{padding:6px 10px;border-radius:999px;color:#bae6fd;background:rgba(14,165,233,.08);border:1px solid rgba(14,165,233,.14);font-size:.8rem;font-weight:800}
+.accomplishments-empty,.accomplishments-error{padding:28px;border-radius:24px;text-align:center}
+.accomplishments-error{color:#fecaca;margin-bottom:16px}
+.pagination{display:flex;align-items:center;justify-content:center;gap:12px;margin-top:24px}
+.pagination>button,.pagination-pages button{min-height:40px;border-radius:12px;border:1px solid rgba(148,163,184,.18);background:rgba(15,23,42,.7);color:#e2e8f0;cursor:pointer;font-weight:800}
+.pagination>button{display:inline-flex;align-items:center;gap:6px;padding:0 14px}
+.pagination-pages{display:flex;gap:7px}
+.pagination-pages button{width:40px}
+.pagination-pages button.active{color:#020617;background:linear-gradient(135deg,#f8fafc,#bae6fd)}
+.pagination button:disabled{cursor:not-allowed;opacity:.4}
+
+@media(max-width:760px){
+  .accomplishments-page{width:min(100% - 24px,1180px);padding-top:24px}
+  .accomplishments-hero,.accomplishments-toolbar,.accomplishment-card-top{flex-direction:column}
+  .accomplishments-toolbar{align-items:stretch}
+  .accomplishments-toolbar>p{white-space:normal}
+  .accomplishment-card-actions{width:100%;justify-content:flex-start}
+  .accomplishment-edit-button,.proof-visibility-button{min-height:44px}
+  .accomplishment-proof-grid{grid-template-columns:1fr}
+  .pagination{flex-wrap:wrap}
+  .modal-backdrop{align-items:flex-start;padding:12px}
+  .modal-card{grid-template-columns:1fr;gap:16px;max-height:calc(100vh - 24px);padding:20px;border-radius:20px}
+  .modal-card>label:nth-of-type(1),.modal-card>label:nth-of-type(2){grid-column:auto}
+  .modal-card .form-grid{grid-template-columns:1fr;gap:16px}
+  .modal-actions{bottom:-20px;margin:2px -20px -20px;padding:14px 20px;border-radius:0 0 20px 20px}
+  .modal-actions .btn{flex:1;padding:0 12px}
+}

--- a/frontend/src/AccomplishmentsPage.jsx
+++ b/frontend/src/AccomplishmentsPage.jsx
@@ -6,7 +6,6 @@ import BragStackLoader from "./BragStackLoader.jsx";
 import "./AccomplishmentsPage.css";
 
 const PAGE_SIZE = 10;
-const EDIT_WINDOW_MS = 60 * 60 * 1000;
 const ENTRY_TYPES = [
   "Current Job",
   "Previous Job",
@@ -18,7 +17,11 @@ const ENTRY_TYPES = [
   "Open Source",
   "Learning / Certification",
 ];
-const STUDENT_ENTRY_TYPES = new Set(["Middle School", "High School", "College / University"]);
+const STUDENT_ENTRY_TYPES = new Set([
+  "Middle School",
+  "High School",
+  "College / University",
+]);
 const STUDENT_CATEGORIES = [
   "Academic Achievement",
   "Award / Honor",
@@ -33,34 +36,640 @@ const STUDENT_CATEGORIES = [
   "Special Program",
   "Certification / Course",
 ];
+
 const today = () => new Date().toISOString().slice(0, 10);
-const emptyForm = () => ({ title: "", category: "", entry_date: today(), entry_type: "Current Job", situation: "", action: "", impact: "", lesson: "", tags: "", is_public: false });
-function entryToForm(entry) { return { title: entry.title || "", category: entry.category || "", entry_date: entry.entry_date || today(), entry_type: entry.entry_type || "Current Job", situation: entry.situation || "", action: entry.action || "", impact: entry.impact || "", lesson: entry.lesson || "", tags: (entry.tags || []).join(", "), is_public: Boolean(entry.is_public) }; }
-function getEditWindow(entry, nowMs) { if (!entry?.created_at) return { editable: false, minutesLeft: 0 }; const createdAtMs = new Date(entry.created_at).getTime(); if (!Number.isFinite(createdAtMs)) return { editable: false, minutesLeft: 0 }; const remainingMs = EDIT_WINDOW_MS - (nowMs - createdAtMs); return { editable: remainingMs > 0, minutesLeft: Math.max(0, Math.ceil(remainingMs / 60000)) }; }
+const emptyForm = () => ({
+  title: "",
+  category: "",
+  entry_date: today(),
+  entry_type: "Current Job",
+  situation: "",
+  action: "",
+  impact: "",
+  lesson: "",
+  tags: "",
+  is_public: false,
+});
+
+function entryToForm(entry) {
+  return {
+    title: entry.title || "",
+    category: entry.category || "",
+    entry_date: entry.entry_date || today(),
+    entry_type: entry.entry_type || "Current Job",
+    situation: entry.situation || "",
+    action: entry.action || "",
+    impact: entry.impact || "",
+    lesson: entry.lesson || "",
+    tags: (entry.tags || []).join(", "),
+    is_public: Boolean(entry.is_public),
+  };
+}
+
+function entryToPayload(entry, isPublic = Boolean(entry.is_public)) {
+  return {
+    title: entry.title || "",
+    category: entry.category || "",
+    entry_date: entry.entry_date || today(),
+    entry_type: entry.entry_type || "Current Job",
+    situation: entry.situation || "",
+    action: entry.action || "",
+    impact: entry.impact || "",
+    lesson: entry.lesson || "",
+    tags: Array.isArray(entry.tags) ? entry.tags : [],
+    is_public: isPublic,
+  };
+}
 
 function AccomplishmentsPage() {
-  const [entries, setEntries] = useState([]); const [page, setPage] = useState(1); const [totalEntries, setTotalEntries] = useState(0); const [isLoading, setIsLoading] = useState(true); const [error, setError] = useState(""); const [searchTerm, setSearchTerm] = useState(""); const [showCreate, setShowCreate] = useState(() => new URLSearchParams(window.location.search).get("create") === "1"); const [editingEntry, setEditingEntry] = useState(null); const [form, setForm] = useState(emptyForm); const [isSaving, setIsSaving] = useState(false); const [createError, setCreateError] = useState(""); const [nowMs, setNowMs] = useState(() => Date.now());
-  async function loadPage(targetPage = page) { setIsLoading(true); setError(""); try { const data = await getEntries(PAGE_SIZE, (targetPage - 1) * PAGE_SIZE); setEntries(data.entries ?? []); setTotalEntries(data.total_entries ?? 0); } catch (requestError) { if (requestError.response?.status === 401) { localStorage.removeItem("bragstack_token"); window.location.assign("/login"); return; } setError("BragStack could not load your accomplishments."); } finally { setIsLoading(false); } }
-  useEffect(() => { const timeoutId = window.setTimeout(() => { void loadPage(page); }, 0); return () => window.clearTimeout(timeoutId); /* eslint-disable-next-line react-hooks/exhaustive-deps */ }, [page]);
-  useEffect(() => { const intervalId = window.setInterval(() => setNowMs(Date.now()), 30000); return () => window.clearInterval(intervalId); }, []);
-  const totalPages = Math.max(1, Math.ceil(totalEntries / PAGE_SIZE)); const startEntry = totalEntries === 0 ? 0 : (page - 1) * PAGE_SIZE + 1; const endEntry = Math.min(page * PAGE_SIZE, totalEntries);
-  const visibleEntries = useMemo(() => { const query = searchTerm.trim().toLowerCase(); if (!query) return entries; return entries.filter((entry) => [entry.title, entry.category, entry.entry_type, entry.situation, entry.action, entry.impact, entry.lesson, ...(entry.tags ?? [])].filter(Boolean).join(" ").toLowerCase().includes(query)); }, [entries, searchTerm]);
-  const pageNumbers = useMemo(() => { const first = Math.max(1, page - 2); const last = Math.min(totalPages, first + 4); const adjustedFirst = Math.max(1, last - 4); return Array.from({ length: last - adjustedFirst + 1 }, (_, index) => adjustedFirst + index); }, [page, totalPages]);
-  function openCreate() { setCreateError(""); setEditingEntry(null); setForm(emptyForm()); setShowCreate(true); window.history.replaceState({}, "", "/app/accomplishments?create=1"); }
-  function openEdit(entry) { const editWindow = getEditWindow(entry, nowMs); if (!editWindow.editable) return; setCreateError(""); setEditingEntry(entry); setForm(entryToForm(entry)); setShowCreate(true); window.history.replaceState({}, "", `/app/accomplishments?edit=${encodeURIComponent(entry.id)}`); }
-  function closeCreate() { setShowCreate(false); setEditingEntry(null); setCreateError(""); window.history.replaceState({}, "", "/app/accomplishments"); }
-  function goToPage(nextPage) { const safePage = Math.min(Math.max(nextPage, 1), totalPages); setPage(safePage); window.scrollTo({ top: 0, behavior: "smooth" }); }
-  function handleFormChange(event) { const { name, value, type, checked } = event.target; setForm((current) => ({ ...current, [name]: type === "checkbox" ? checked : value })); }
-  async function handleSave(event) { event.preventDefault(); setIsSaving(true); setCreateError(""); try { const payload = { ...form, tags: form.tags.split(",").map((tag) => tag.trim()).filter(Boolean) }; if (editingEntry) { const editWindow = getEditWindow(editingEntry, nowMs); if (!editWindow.editable) { setCreateError("The 60-minute edit window for this accomplishment has ended."); return; } await updateEntry(editingEntry.id, payload); } else await createEntry(payload); const wasEditing = Boolean(editingEntry); setForm(emptyForm()); closeCreate(); if (!wasEditing) setPage(1); await loadPage(wasEditing ? page : 1); } catch (requestError) { setCreateError(requestError.response?.data?.detail || `Your accomplishment could not be ${editingEntry ? "updated" : "saved"}.`); } finally { setIsSaving(false); } }
-  const editingWindow = editingEntry ? getEditWindow(editingEntry, nowMs) : null;
+  const [entries, setEntries] = useState([]);
+  const [page, setPage] = useState(1);
+  const [totalEntries, setTotalEntries] = useState(0);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [searchTerm, setSearchTerm] = useState("");
+  const [showCreate, setShowCreate] = useState(
+    () => new URLSearchParams(window.location.search).get("create") === "1",
+  );
+  const [editingEntry, setEditingEntry] = useState(null);
+  const [form, setForm] = useState(emptyForm);
+  const [isSaving, setIsSaving] = useState(false);
+  const [createError, setCreateError] = useState("");
+  const [visibilityUpdatingId, setVisibilityUpdatingId] = useState(null);
+
+  async function loadPage(targetPage = page) {
+    setIsLoading(true);
+    setError("");
+    try {
+      const data = await getEntries(PAGE_SIZE, (targetPage - 1) * PAGE_SIZE);
+      setEntries(data.entries ?? []);
+      setTotalEntries(data.total_entries ?? 0);
+    } catch (requestError) {
+      if (requestError.response?.status === 401) {
+        localStorage.removeItem("bragstack_token");
+        window.location.assign("/login");
+        return;
+      }
+      setError("BragStack could not load your accomplishments.");
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    const timeoutId = window.setTimeout(() => {
+      void loadPage(page);
+    }, 0);
+    return () => window.clearTimeout(timeoutId);
+    /* eslint-disable-next-line react-hooks/exhaustive-deps */
+  }, [page]);
+
+  const totalPages = Math.max(1, Math.ceil(totalEntries / PAGE_SIZE));
+  const startEntry = totalEntries === 0 ? 0 : (page - 1) * PAGE_SIZE + 1;
+  const endEntry = Math.min(page * PAGE_SIZE, totalEntries);
+
+  const visibleEntries = useMemo(() => {
+    const query = searchTerm.trim().toLowerCase();
+    if (!query) return entries;
+    return entries.filter((entry) =>
+      [
+        entry.title,
+        entry.category,
+        entry.entry_type,
+        entry.situation,
+        entry.action,
+        entry.impact,
+        entry.lesson,
+        ...(entry.tags ?? []),
+      ]
+        .filter(Boolean)
+        .join(" ")
+        .toLowerCase()
+        .includes(query),
+    );
+  }, [entries, searchTerm]);
+
+  const pageNumbers = useMemo(() => {
+    const first = Math.max(1, page - 2);
+    const last = Math.min(totalPages, first + 4);
+    const adjustedFirst = Math.max(1, last - 4);
+    return Array.from(
+      { length: last - adjustedFirst + 1 },
+      (_, index) => adjustedFirst + index,
+    );
+  }, [page, totalPages]);
+
+  function openCreate() {
+    setCreateError("");
+    setEditingEntry(null);
+    setForm(emptyForm());
+    setShowCreate(true);
+    window.history.replaceState({}, "", "/app/accomplishments?create=1");
+  }
+
+  function openEdit(entry) {
+    setCreateError("");
+    setEditingEntry(entry);
+    setForm(entryToForm(entry));
+    setShowCreate(true);
+    window.history.replaceState(
+      {},
+      "",
+      `/app/accomplishments?edit=${encodeURIComponent(entry.id)}`,
+    );
+  }
+
+  function closeCreate() {
+    setShowCreate(false);
+    setEditingEntry(null);
+    setCreateError("");
+    window.history.replaceState({}, "", "/app/accomplishments");
+  }
+
+  function goToPage(nextPage) {
+    const safePage = Math.min(Math.max(nextPage, 1), totalPages);
+    setPage(safePage);
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  }
+
+  function handleFormChange(event) {
+    const { name, value, type, checked } = event.target;
+    setForm((current) => ({
+      ...current,
+      [name]: type === "checkbox" ? checked : value,
+    }));
+  }
+
+  async function handleSave(event) {
+    event.preventDefault();
+    setIsSaving(true);
+    setCreateError("");
+    try {
+      const payload = {
+        ...form,
+        tags: form.tags
+          .split(",")
+          .map((tag) => tag.trim())
+          .filter(Boolean),
+      };
+      if (editingEntry) {
+        await updateEntry(editingEntry.id, payload);
+      } else {
+        await createEntry(payload);
+      }
+      const wasEditing = Boolean(editingEntry);
+      setForm(emptyForm());
+      closeCreate();
+      if (!wasEditing) setPage(1);
+      await loadPage(wasEditing ? page : 1);
+    } catch (requestError) {
+      setCreateError(
+        requestError.response?.data?.detail ||
+          `Your accomplishment could not be ${editingEntry ? "updated" : "saved"}.`,
+      );
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  async function handleVisibilityToggle(entry) {
+    setVisibilityUpdatingId(entry.id);
+    setError("");
+    try {
+      const updatedEntry = await updateEntry(
+        entry.id,
+        entryToPayload(entry, !entry.is_public),
+      );
+      setEntries((current) =>
+        current.map((item) => (item.id === entry.id ? updatedEntry : item)),
+      );
+    } catch (requestError) {
+      if (requestError.response?.status === 401) {
+        localStorage.removeItem("bragstack_token");
+        window.location.assign("/login");
+        return;
+      }
+      setError(
+        requestError.response?.data?.detail ||
+          "That accomplishment's visibility could not be changed.",
+      );
+    } finally {
+      setVisibilityUpdatingId(null);
+    }
+  }
+
   const isStudentEntry = STUDENT_ENTRY_TYPES.has(form.entry_type);
-  return <main className="accomplishments-page">
-    <header className="accomplishments-hero"><div><p className="mini-label">Career & Education Evidence Library</p><h1>Your accomplishments</h1><p>Build a private record of meaningful work, education achievements, activities, leadership, service, research, awards, and projects before the details are forgotten. BragStack accounts are currently limited to adults age 18+.</p></div><button className="accomplishments-add" type="button" onClick={openCreate}><Plus size={18} /> Add accomplishment</button></header>
-    {showCreate && <section className="modal-backdrop" onMouseDown={closeCreate}><form className="modal-card" onSubmit={handleSave} onMouseDown={(event) => event.stopPropagation()}><div className="modal-header"><div><p className="mini-label">{editingEntry ? "Edit accomplishment evidence" : "New accomplishment evidence"}</p><h2>{editingEntry ? "Edit accomplishment" : "Create accomplishment"}</h2>{isStudentEntry ? <p className="edit-window-note">For adults documenting education: capture grade/year, school or program, your role, time commitment, scope, recognition, measurable results, and safe evidence when you know them. BragStack does not currently offer accounts for minors.</p> : <p className="edit-window-note">Capture enough context now that you can reuse this story later for resumes, interviews, reviews, promotions, and applications.</p>}{editingWindow?.editable && <p className="edit-window-note">Editable for about {editingWindow.minutesLeft} more minute{editingWindow.minutesLeft === 1 ? "" : "s"}.</p>}</div><button type="button" className="icon-button" onClick={closeCreate} aria-label="Close"><X size={20} /></button></div>{createError && <div className="notice"><strong>Could not save</strong><span>{createError}</span></div>}<label>Title<input name="title" value={form.title} onChange={handleFormChange} required placeholder={isStudentEntry ? "Led robotics team to state finals, earned science award, organized service project…" : "What did you accomplish?"} /></label><label>Category<input name="category" list={isStudentEntry ? "student-accomplishment-categories" : undefined} value={form.category} onChange={handleFormChange} required placeholder={isStudentEntry ? "Choose or type an education-friendly category" : "Platform Engineering, Customer Support, Leadership…"} />{isStudentEntry && <datalist id="student-accomplishment-categories">{STUDENT_CATEGORIES.map((category) => <option key={category} value={category} />)}</datalist>}</label><div className="form-grid"><label>Date<input type="date" name="entry_date" value={form.entry_date} onChange={handleFormChange} required /></label><label>Type<select name="entry_type" value={form.entry_type} onChange={handleFormChange}>{ENTRY_TYPES.map((type) => <option key={type} value={type} disabled={type === "Middle School" && form.entry_type !== "Middle School"}>{type === "Middle School" ? "Middle School — coming soon for student accounts" : type}</option>)}</select></label></div><p className="edit-window-note"><s>Middle School student accounts</s> — <strong>Coming soon.</strong> We are keeping the feature visible on the roadmap, but BragStack is 18+ while youth privacy and parental-consent requirements are reviewed with counsel.</p><label>Situation<textarea name="situation" value={form.situation} onChange={handleFormChange} required placeholder={isStudentEntry ? "What was the class, club, team, school, program, competition, or community need? Include year and organization when useful." : "What was happening?"} /></label><label>Action<textarea name="action" value={form.action} onChange={handleFormChange} required placeholder={isStudentEntry ? "What did you personally do, create, lead, research, organize, solve, perform, or contribute?" : "What did you specifically do?"} /></label><label>Impact<textarea name="impact" value={form.impact} onChange={handleFormChange} required placeholder={isStudentEntry ? "What changed? Include placement, award level, people served, money raised, growth, time commitment, audience, results, or recognition when available." : "What changed? Add numbers when you have them."} /></label><label>Lesson<textarea name="lesson" value={form.lesson} onChange={handleFormChange} placeholder={isStudentEntry ? "What did you learn, and how did you grow?" : "What did you learn?"} /></label><label>Skills / tags<input name="tags" value={form.tags} onChange={handleFormChange} placeholder={isStudentEntry ? "Research, Leadership, Robotics, Writing, Service" : "Docker, Python, Leadership"} /></label><label className="checkbox-row"><input type="checkbox" name="is_public" checked={form.is_public} onChange={handleFormChange} /> Make this accomplishment public</label>{isStudentEntry && <p className="edit-window-note">Education records stay private unless you explicitly choose to make an accomplishment public. Avoid entering sensitive information you would not want included in a public portfolio or application record.</p>}<div className="modal-actions"><button type="button" className="btn secondary" onClick={closeCreate}>Cancel</button><button type="submit" className="btn primary" disabled={isSaving || (editingEntry && !editingWindow?.editable)}>{isSaving ? "Saving…" : editingEntry ? "Save changes" : "Create accomplishment"}</button></div></form></section>}
-    <section className="accomplishments-toolbar"><div className="accomplishments-search"><Search size={18} /><input value={searchTerm} onChange={(event) => setSearchTerm(event.target.value)} placeholder="Filter by skill, education/work context, category, action, or impact..." /></div><p>Showing <strong>{startEntry}–{endEntry}</strong> of <strong>{totalEntries}</strong> accomplishments</p></section>
-    {error && <div className="accomplishments-error">{error}</div>}
-    {isLoading ? <BragStackLoader compact message="Loading your proof…" detail="Gathering accomplishments, outcomes, skills, and evidence." /> : visibleEntries.length === 0 ? <section className="accomplishments-empty"><h2>No accomplishments found.</h2><p>{searchTerm ? "Try a different search on this page." : "Add your first accomplishment now so you do not have to reconstruct it from memory later."}</p>{!searchTerm && <button className="btn primary" type="button" onClick={openCreate}>Create accomplishment</button>}</section> : <section className="accomplishments-list">{visibleEntries.map((entry) => { const editWindow = getEditWindow(entry, nowMs); return <article className="accomplishment-card" key={entry.id}><div className="accomplishment-card-top"><div><p className="mini-label">{entry.category} • {entry.entry_type} • {entry.entry_date}</p><h2>{entry.title}</h2></div><div className="accomplishment-card-actions">{editWindow.editable ? <div className="accomplishment-edit-group"><button type="button" className="accomplishment-icon-action" onClick={() => openEdit(entry)} aria-label={`Edit ${entry.title}`} title={`Edit accomplishment · ${editWindow.minutesLeft} minutes left`}><Pencil size={17} /></button><span>{editWindow.minutesLeft}m left</span></div> : entry.created_at ? <span className="edit-window-locked">Edit window closed</span> : null}<span className={entry.is_public ? "proof-public" : "proof-private"}>{entry.is_public ? "Public proof" : "Private proof"}</span></div></div><p className="accomplishment-bullet">{entry.resume_bullet}</p><div className="accomplishment-proof-grid"><div><strong>Situation</strong><p>{entry.situation}</p></div><div><strong>Action</strong><p>{entry.action}</p></div><div><strong>Impact</strong><p>{entry.impact}</p></div>{entry.lesson && <div><strong>Lesson</strong><p>{entry.lesson}</p></div>}</div><div className="accomplishment-tags">{entry.tags?.map((tag) => <span key={tag}>{tag}</span>)}</div></article>; })}</section>}
-    {totalPages > 1 && <nav className="pagination" aria-label="Accomplishments pages"><button type="button" onClick={() => goToPage(page - 1)} disabled={page === 1}><ChevronLeft size={17} /> Previous</button><div className="pagination-pages">{pageNumbers.map((pageNumber) => <button type="button" key={pageNumber} className={pageNumber === page ? "active" : ""} onClick={() => goToPage(pageNumber)}>{pageNumber}</button>)}</div><button type="button" onClick={() => goToPage(page + 1)} disabled={page === totalPages}>Next <ChevronRight size={17} /></button></nav>}
-  </main>;
+
+  return (
+    <main className="accomplishments-page">
+      <header className="accomplishments-hero">
+        <div>
+          <p className="mini-label">Career & Education Evidence Library</p>
+          <h1>Your accomplishments</h1>
+          <p>
+            Build a private record of meaningful work, education achievements,
+            activities, leadership, service, research, awards, and projects
+            before the details are forgotten. BragStack accounts are currently
+            limited to adults age 18+.
+          </p>
+        </div>
+        <button className="accomplishments-add" type="button" onClick={openCreate}>
+          <Plus size={18} /> Add accomplishment
+        </button>
+      </header>
+
+      {showCreate && (
+        <section className="modal-backdrop" onMouseDown={closeCreate}>
+          <form
+            className="modal-card"
+            onSubmit={handleSave}
+            onMouseDown={(event) => event.stopPropagation()}
+          >
+            <div className="modal-header">
+              <div>
+                <p className="mini-label">
+                  {editingEntry
+                    ? "Edit accomplishment evidence"
+                    : "New accomplishment evidence"}
+                </p>
+                <h2>
+                  {editingEntry ? "Edit accomplishment" : "Create accomplishment"}
+                </h2>
+                {isStudentEntry ? (
+                  <p className="edit-window-note">
+                    For adults documenting education: capture grade/year, school
+                    or program, your role, time commitment, scope, recognition,
+                    measurable results, and safe evidence when you know them.
+                    BragStack does not currently offer accounts for minors.
+                  </p>
+                ) : (
+                  <p className="edit-window-note">
+                    Capture enough context now that you can reuse this story later
+                    for resumes, interviews, reviews, promotions, and applications.
+                    You can update it whenever your record needs a correction or
+                    more context.
+                  </p>
+                )}
+              </div>
+              <button
+                type="button"
+                className="icon-button"
+                onClick={closeCreate}
+                aria-label="Close"
+              >
+                <X size={20} />
+              </button>
+            </div>
+
+            {createError && (
+              <div className="notice">
+                <strong>Could not save</strong>
+                <span>{createError}</span>
+              </div>
+            )}
+
+            <label>
+              Title
+              <input
+                name="title"
+                value={form.title}
+                onChange={handleFormChange}
+                required
+                placeholder={
+                  isStudentEntry
+                    ? "Led robotics team to state finals, earned science award, organized service project…"
+                    : "What did you accomplish?"
+                }
+              />
+            </label>
+
+            <label>
+              Category
+              <input
+                name="category"
+                list={isStudentEntry ? "student-accomplishment-categories" : undefined}
+                value={form.category}
+                onChange={handleFormChange}
+                required
+                placeholder={
+                  isStudentEntry
+                    ? "Choose or type an education-friendly category"
+                    : "Platform Engineering, Customer Support, Leadership…"
+                }
+              />
+              {isStudentEntry && (
+                <datalist id="student-accomplishment-categories">
+                  {STUDENT_CATEGORIES.map((category) => (
+                    <option key={category} value={category} />
+                  ))}
+                </datalist>
+              )}
+            </label>
+
+            <div className="form-grid">
+              <label>
+                Date
+                <input
+                  type="date"
+                  name="entry_date"
+                  value={form.entry_date}
+                  onChange={handleFormChange}
+                  required
+                />
+              </label>
+              <label>
+                Type
+                <select
+                  name="entry_type"
+                  value={form.entry_type}
+                  onChange={handleFormChange}
+                >
+                  {ENTRY_TYPES.map((type) => (
+                    <option
+                      key={type}
+                      value={type}
+                      disabled={
+                        type === "Middle School" && form.entry_type !== "Middle School"
+                      }
+                    >
+                      {type === "Middle School"
+                        ? "Middle School — coming soon for student accounts"
+                        : type}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            </div>
+
+            <p className="edit-window-note">
+              <s>Middle School student accounts</s> — <strong>Coming soon.</strong>{" "}
+              We are keeping the feature visible on the roadmap, but BragStack is
+              18+ while youth privacy and parental-consent requirements are reviewed
+              with counsel.
+            </p>
+
+            <label>
+              Situation
+              <textarea
+                name="situation"
+                value={form.situation}
+                onChange={handleFormChange}
+                required
+                placeholder={
+                  isStudentEntry
+                    ? "What was the class, club, team, school, program, competition, or community need? Include year and organization when useful."
+                    : "What was happening?"
+                }
+              />
+            </label>
+
+            <label>
+              Action
+              <textarea
+                name="action"
+                value={form.action}
+                onChange={handleFormChange}
+                required
+                placeholder={
+                  isStudentEntry
+                    ? "What did you personally do, create, lead, research, organize, solve, perform, or contribute?"
+                    : "What did you specifically do?"
+                }
+              />
+            </label>
+
+            <label>
+              Impact
+              <textarea
+                name="impact"
+                value={form.impact}
+                onChange={handleFormChange}
+                required
+                placeholder={
+                  isStudentEntry
+                    ? "What changed? Include placement, award level, people served, money raised, growth, time commitment, audience, results, or recognition when available."
+                    : "What changed? Add numbers when you have them."
+                }
+              />
+            </label>
+
+            <label>
+              Lesson
+              <textarea
+                name="lesson"
+                value={form.lesson}
+                onChange={handleFormChange}
+                placeholder={
+                  isStudentEntry
+                    ? "What did you learn, and how did you grow?"
+                    : "What did you learn?"
+                }
+              />
+            </label>
+
+            <label>
+              Skills / tags
+              <input
+                name="tags"
+                value={form.tags}
+                onChange={handleFormChange}
+                placeholder={
+                  isStudentEntry
+                    ? "Research, Leadership, Robotics, Writing, Service"
+                    : "Docker, Python, Leadership"
+                }
+              />
+            </label>
+
+            <label className="checkbox-row">
+              <input
+                type="checkbox"
+                name="is_public"
+                checked={form.is_public}
+                onChange={handleFormChange}
+              />
+              Make this accomplishment public
+            </label>
+
+            {isStudentEntry && (
+              <p className="edit-window-note">
+                Education records stay private unless you explicitly choose to make
+                an accomplishment public. Avoid entering sensitive information you
+                would not want included in a public portfolio or application record.
+              </p>
+            )}
+
+            <div className="modal-actions">
+              <button type="button" className="btn secondary" onClick={closeCreate}>
+                Cancel
+              </button>
+              <button type="submit" className="btn primary" disabled={isSaving}>
+                {isSaving
+                  ? "Saving…"
+                  : editingEntry
+                    ? "Save changes"
+                    : "Create accomplishment"}
+              </button>
+            </div>
+          </form>
+        </section>
+      )}
+
+      <section className="accomplishments-toolbar">
+        <div className="accomplishments-search">
+          <Search size={18} />
+          <input
+            value={searchTerm}
+            onChange={(event) => setSearchTerm(event.target.value)}
+            placeholder="Filter by skill, education/work context, category, action, or impact..."
+          />
+        </div>
+        <p>
+          Showing <strong>{startEntry}–{endEntry}</strong> of{" "}
+          <strong>{totalEntries}</strong> accomplishments
+        </p>
+      </section>
+
+      {error && <div className="accomplishments-error">{error}</div>}
+
+      {isLoading ? (
+        <BragStackLoader
+          compact
+          message="Loading your proof…"
+          detail="Gathering accomplishments, outcomes, skills, and evidence."
+        />
+      ) : visibleEntries.length === 0 ? (
+        <section className="accomplishments-empty">
+          <h2>No accomplishments found.</h2>
+          <p>
+            {searchTerm
+              ? "Try a different search on this page."
+              : "Add your first accomplishment now so you do not have to reconstruct it from memory later."}
+          </p>
+          {!searchTerm && (
+            <button className="btn primary" type="button" onClick={openCreate}>
+              Create accomplishment
+            </button>
+          )}
+        </section>
+      ) : (
+        <section className="accomplishments-list">
+          {visibleEntries.map((entry) => {
+            const visibilityUpdating = visibilityUpdatingId === entry.id;
+            return (
+              <article className="accomplishment-card" key={entry.id}>
+                <div className="accomplishment-card-top">
+                  <div>
+                    <p className="mini-label">
+                      {entry.category} • {entry.entry_type} • {entry.entry_date}
+                    </p>
+                    <h2>{entry.title}</h2>
+                  </div>
+
+                  <div className="accomplishment-card-actions">
+                    <button
+                      type="button"
+                      className="accomplishment-edit-button"
+                      onClick={() => openEdit(entry)}
+                      aria-label={`Edit ${entry.title}`}
+                      title="Edit accomplishment"
+                    >
+                      <Pencil size={16} />
+                      Edit
+                    </button>
+
+                    <button
+                      type="button"
+                      className={`proof-visibility-button ${
+                        entry.is_public ? "proof-public" : "proof-private"
+                      }`}
+                      onClick={() => handleVisibilityToggle(entry)}
+                      disabled={visibilityUpdating}
+                      aria-pressed={entry.is_public}
+                      aria-label={
+                        entry.is_public
+                          ? `Make ${entry.title} private`
+                          : `Make ${entry.title} public`
+                      }
+                      title={
+                        entry.is_public
+                          ? "Make this accomplishment private"
+                          : "Make this accomplishment public"
+                      }
+                    >
+                      {visibilityUpdating
+                        ? "Updating…"
+                        : entry.is_public
+                          ? "Public · Make private"
+                          : "Private · Make public"}
+                    </button>
+                  </div>
+                </div>
+
+                <p className="accomplishment-bullet">{entry.resume_bullet}</p>
+
+                <div className="accomplishment-proof-grid">
+                  <div>
+                    <strong>Situation</strong>
+                    <p>{entry.situation}</p>
+                  </div>
+                  <div>
+                    <strong>Action</strong>
+                    <p>{entry.action}</p>
+                  </div>
+                  <div>
+                    <strong>Impact</strong>
+                    <p>{entry.impact}</p>
+                  </div>
+                  {entry.lesson && (
+                    <div>
+                      <strong>Lesson</strong>
+                      <p>{entry.lesson}</p>
+                    </div>
+                  )}
+                </div>
+
+                <div className="accomplishment-tags">
+                  {entry.tags?.map((tag) => <span key={tag}>{tag}</span>)}
+                </div>
+              </article>
+            );
+          })}
+        </section>
+      )}
+
+      {totalPages > 1 && (
+        <nav className="pagination" aria-label="Accomplishments pages">
+          <button
+            type="button"
+            onClick={() => goToPage(page - 1)}
+            disabled={page === 1}
+          >
+            <ChevronLeft size={17} /> Previous
+          </button>
+          <div className="pagination-pages">
+            {pageNumbers.map((pageNumber) => (
+              <button
+                type="button"
+                key={pageNumber}
+                className={pageNumber === page ? "active" : ""}
+                onClick={() => goToPage(pageNumber)}
+              >
+                {pageNumber}
+              </button>
+            ))}
+          </div>
+          <button
+            type="button"
+            onClick={() => goToPage(page + 1)}
+            disabled={page === totalPages}
+          >
+            Next <ChevronRight size={17} />
+          </button>
+        </nav>
+      )}
+    </main>
+  );
 }
+
 export default AccomplishmentsPage;


### PR DESCRIPTION
## What changed
- removes the 60-minute accomplishment edit lock from the Accomplishments UI
- keeps the Edit action available for existing accomplishments at any age
- adds an always-available Public/Private control directly on each accomplishment card
- keeps the existing privacy checkbox in the editor
- updates mobile styling so both actions remain easy to tap

## Why
Accomplishments are living career records. Users need to correct wording, add context, and change public/private visibility after the original capture window. Trust-sensitive verification can remain a separate concern for Impact Receipts/evidence rather than permanently freezing the accomplishment itself.

## Backend
No backend change is required: the authenticated entry update endpoint already supports updating owned accomplishments without a 60-minute restriction.