### PR TITLE
Hotfix: remove backend accomplishment edit lock

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,9 +1,7 @@
 """Document this first-party Python module."""
 import os
 import time
-from datetime import datetime, timedelta, timezone
 
-from bson import ObjectId
 from fastapi import Depends, FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
@@ -50,7 +48,6 @@ app = FastAPI(
     version="1.0.0",
 )
 frontend_url = os.getenv("FRONTEND_URL", "http://localhost:5173").rstrip("/")
-ENTRY_EDIT_WINDOW = timedelta(hours=1)
 mongo_admin = mongo_client.admin
 
 
@@ -180,53 +177,24 @@ app.add_middleware(
 )
 
 
-def _as_utc(value: datetime) -> datetime:
-    """Handle as utc.
-
-    Args:
-        value: Function argument.
-
-    Returns:
-        Function result.
-    """
-    if value.tzinfo is None:
-        return value.replace(tzinfo=timezone.utc)
-    return value.astimezone(timezone.utc)
-
-
 def enforce_entry_usage(request: Request, current_user: dict = Depends(get_current_user)):
-    """Handle enforce entry usage.
+    """Enforce entry-count limits when creating accomplishments.
 
-    Args:
-        request: Function argument.
-        current_user: Function argument.
+    Existing accomplishments remain editable at any time. Verification and
+    trust-sensitive immutability are handled separately from the owner's
+    editable accomplishment record.
     """
     path = request.url.path.rstrip("/")
+    if request.method != "POST" or path != "/entries":
+        return
+
     user_id = str(current_user["_id"])
-    if request.method == "POST" and path == "/entries":
-        enforce_usage_limit(
-            user=current_user,
-            entitlement_name="max_entries",
-            current_count=entries_collection.count_documents({"user_id": user_id}),
-            resource_name="proof entries",
-        )
-        return
-    if request.method != "PUT" or not path.startswith("/entries/"):
-        return
-    entry_id = path.removeprefix("/entries/")
-    if not ObjectId.is_valid(entry_id):
-        return
-    existing_entry = entries_collection.find_one(
-        {"_id": ObjectId(entry_id), "user_id": user_id},
-        {"created_at": 1},
+    enforce_usage_limit(
+        user=current_user,
+        entitlement_name="max_entries",
+        current_count=entries_collection.count_documents({"user_id": user_id}),
+        resource_name="proof entries",
     )
-    if not existing_entry:
-        return
-    created_at = existing_entry.get("created_at")
-    if not isinstance(created_at, datetime):
-        raise HTTPException(status_code=403, detail="This accomplishment can no longer be edited.")
-    if datetime.now(timezone.utc) - _as_utc(created_at) >= ENTRY_EDIT_WINDOW:
-        raise HTTPException(status_code=403, detail="The 60-minute edit window for this accomplishment has ended.")
 
 
 def enforce_receipt_usage(request: Request, current_user: dict = Depends(get_current_user)):

--- a/backend/tests/test_entry_editability_policy.py
+++ b/backend/tests/test_entry_editability_policy.py
@@ -1,0 +1,16 @@
+"""Regression tests for accomplishment editability policy."""
+
+from types import SimpleNamespace
+
+import app.main as main
+
+
+def test_put_entry_is_not_blocked_by_usage_dependency():
+    """Existing accomplishments remain editable regardless of age."""
+    request = SimpleNamespace(
+        method="PUT",
+        url=SimpleNamespace(path="/entries/64f000000000000000000001"),
+    )
+    current_user = {"_id": "64f000000000000000000000"}
+
+    assert main.enforce_entry_usage(request, current_user) is None


### PR DESCRIPTION
## Root cause
PR #298 removed the 60-minute lock from the frontend, but the API still enforced the same rule inside `enforce_entry_usage`. That is why the new Edit and Public/Private controls rendered correctly but every PUT for an older accomplishment returned 403.

## Fix
- remove the backend 60-minute PUT restriction for owned accomplishments
- keep entry-count entitlement enforcement on POST creation only
- add a regression test proving PUT requests are not blocked by the usage dependency

## Result
Existing accomplishments can be edited and switched Public/Private at any time, matching the UI and product decision from #298.