### PR TITLE
Upgrade Career Intelligence to v3 proof-quality model

### DIFF
--- a/backend/app/career_intelligence.py
+++ b/backend/app/career_intelligence.py
@@ -7,7 +7,15 @@ from datetime import date, datetime, timezone
 from typing import Iterable, Iterator
 
 QUANTIFIED_PATTERN = re.compile(
-    r"(?:\$\s?\d|\b\d+(?:\.\d+)?\s?(?:%|x)(?!\w)|\b\d+(?:\.\d+)?\s?(?:hours?|hrs?|minutes?|mins?|days?|weeks?|months?|years?|users?|customers?|tickets?|incidents?|requests?|deployments?|projects?|people|members?)\b)",
+    r"(?:"
+    r"\$\s?\d"
+    r"|\b\d+(?:\.\d+)?\s?(?:%|x)(?!\w)"
+    r"|\b\d+(?:\.\d+)?\s?(?:"
+    r"milliseconds?|ms|seconds?|secs?|minutes?|mins?|hours?|hrs?|days?|weeks?|months?|years?"
+    r"|users?|customers?|tickets?|incidents?|requests?|pull requests?|prs?|deployments?|releases?"
+    r"|builds?|servers?|containers?|nodes?|projects?|people|members?|mb|gb|tb"
+    r")\b"
+    r")",
     re.IGNORECASE,
 )
 
@@ -18,11 +26,20 @@ SKILL_SEPARATOR_PATTERN = re.compile(r"\s*(?:[·•|;,]|\r?\n)+\s*")
 RECENT_WINDOW_DAYS = 180
 PRIMARY_SKILL_LIMIT = 4
 EMERGING_SKILL_LIMIT = 4
+PRIMARY_THEME_LIMIT = 2
+
+_SIGNAL_RANK = {"emerging": 1, "established": 2, "strong": 3}
+_SUPPORT_RANK = {"basic": 1, "supported": 2, "well-supported": 3}
 
 
 def _clean_text(value) -> str:
     """Return trimmed text without turning None into the literal string 'None'."""
     return str(value or "").strip()
+
+
+def _display_text(value) -> str:
+    """Normalize whitespace while preserving user-facing capitalization."""
+    return re.sub(r"\s+", " ", _clean_text(value))
 
 
 def _split_skill_values(value) -> Iterator[str]:
@@ -37,7 +54,7 @@ def _split_skill_values(value) -> Iterator[str]:
     if not text:
         return
     for part in SKILL_SEPARATOR_PATTERN.split(text):
-        cleaned = part.strip(" \t-–—")
+        cleaned = _display_text(part).strip(" \t-–—")
         if cleaned:
             yield cleaned
 
@@ -113,24 +130,93 @@ def _document_id(document: dict) -> str | None:
     return text or None
 
 
+def _percent(numerator: int, denominator: int) -> int:
+    """Return a bounded whole-number coverage percentage."""
+    if denominator <= 0:
+        return 0
+    return max(0, min(100, round((numerator / denominator) * 100)))
+
+
+def _signal_label(demonstrations: int, support_level: str) -> str:
+    """Classify durability separately from proof-quality enrichment."""
+    if demonstrations >= 4 and support_level != "basic":
+        return "strong"
+    if demonstrations >= 2:
+        return "established"
+    return "emerging"
+
+
+def _support_level(
+    *,
+    quantified_count: int,
+    evidence_backed_count: int,
+    confirmed_demo_count: int,
+) -> str:
+    """Classify how well demonstrations are substantiated.
+
+    This is intentionally separate from durability. One deeply documented
+    example can be well-supported while still being an emerging career signal.
+    """
+    dimensions = sum(
+        1
+        for count in (quantified_count, evidence_backed_count, confirmed_demo_count)
+        if count > 0
+    )
+    if dimensions == 3 and (evidence_backed_count >= 2 or quantified_count >= 2):
+        return "well-supported"
+    if dimensions >= 2 or confirmed_demo_count > 0:
+        return "supported"
+    return "basic"
+
+
 def _skill_evidence_points(
     *,
     demonstrations: int,
     quantified_count: int,
-    evidence_count: int,
-    confirmed_count: int,
-) -> int:
-    """Score proof strength without letting freshness masquerade as proof quality.
+    evidence_backed_count: int,
+    confirmed_demo_count: int,
+) -> tuple[int, dict]:
+    """Score proof strength using breadth across demonstrations, not file volume.
 
-    Recency is still exposed separately and used only as a late ranking
-    tie-breaker. Repetition, measurable outcomes, evidence, and confirmation
-    therefore remain the things that make a skill stronger.
+    A single receipt with several attachments should not receive the same signal
+    boost as several distinct work examples. Raw attachment and confirmation
+    counts are still exposed, but the score uses distinct underlying proof keys.
     """
-    points = min(demonstrations, 5) * 10
-    points += min(quantified_count, 3) * 12
-    points += min(evidence_count, 3) * 8
-    points += min(confirmed_count, 2) * 10
-    return min(points, 100)
+    breakdown = {
+        "demonstration_breadth": min(demonstrations, 5) * 12,
+        "quantified_breadth": min(quantified_count, 3) * 8,
+        "evidence_breadth": min(evidence_backed_count, 3) * 6,
+        "confirmation_breadth": min(confirmed_demo_count, 2) * 8,
+    }
+    return min(sum(breakdown.values()), 100), breakdown
+
+
+def _strength_reasons(
+    *,
+    demonstrations: int,
+    quantified_count: int,
+    evidence_backed_count: int,
+    confirmed_demo_count: int,
+) -> list[str]:
+    """Return concise, inspectable reasons behind a skill signal."""
+    reasons = [
+        f"{demonstrations} distinct demonstration{'' if demonstrations == 1 else 's'}",
+    ]
+    if quantified_count:
+        reasons.append(
+            f"{quantified_count} quantified example{'' if quantified_count == 1 else 's'}"
+        )
+    if evidence_backed_count:
+        reasons.append(
+            f"{evidence_backed_count} evidence-backed demonstration"
+            f"{'' if evidence_backed_count == 1 else 's'}"
+        )
+    if confirmed_demo_count:
+        reasons.append(
+            f"{confirmed_demo_count} confirmed demonstration"
+            f"{'' if confirmed_demo_count == 1 else 's'}"
+        )
+    return reasons
 
 
 def _profile_skill_sets(skills: list[dict]) -> tuple[list[dict], list[dict]]:
@@ -157,68 +243,225 @@ def _profile_skill_sets(skills: list[dict]) -> tuple[list[dict], list[dict]]:
     return primary, emerging
 
 
+def _profile_maturity(distinct_demonstrations: int, repeated_skill_count: int) -> str:
+    """Describe evidence coverage without predicting employment outcomes."""
+    if distinct_demonstrations < 3:
+        return "early"
+    if distinct_demonstrations < 6 or repeated_skill_count < 2:
+        return "developing"
+    return "well-supported"
+
+
+def _theme_rows(category_state: dict, now: datetime) -> list[dict]:
+    """Build category-level themes from accomplishment history."""
+    rows: list[dict] = []
+    for state in category_state.values():
+        demonstrations = len(state["proof_keys"])
+        if demonstrations <= 0:
+            continue
+
+        display = max(
+            state["display_names"].items(),
+            key=lambda item: (item[1], len(item[0])),
+        )[0]
+        latest_at = state["latest_at"]
+        days_since = (now - latest_at).days if latest_at else None
+        recent = days_since is not None and days_since <= RECENT_WINDOW_DAYS
+        support = _support_level(
+            quantified_count=len(state["quantified_keys"]),
+            evidence_backed_count=len(state["evidence_keys"]),
+            confirmed_demo_count=len(state["confirmed_keys"]),
+        )
+        signal = _signal_label(demonstrations, support)
+
+        ranked_skills = []
+        for skill_key, proof_keys in state["skill_proof_keys"].items():
+            display_names = state["skill_display_names"][skill_key]
+            skill_display = max(
+                display_names.items(),
+                key=lambda item: (item[1], len(item[0])),
+            )[0]
+            ranked_skills.append(
+                (len(proof_keys), skill_display.casefold(), skill_display)
+            )
+        ranked_skills.sort(reverse=True)
+
+        rows.append(
+            {
+                "theme": display,
+                "signal": signal,
+                "support_level": support,
+                "demonstrations": demonstrations,
+                "skills": [item[2] for item in ranked_skills[:4]],
+                "quantified_examples": len(state["quantified_keys"]),
+                "evidence_backed_demonstrations": len(state["evidence_keys"]),
+                "confirmed_demonstrations": len(state["confirmed_keys"]),
+                "recent": recent,
+                "last_demonstrated_at": latest_at.isoformat() if latest_at else None,
+            }
+        )
+
+    rows.sort(
+        key=lambda item: (
+            _SIGNAL_RANK[item["signal"]],
+            item["demonstrations"],
+            _SUPPORT_RANK[item["support_level"]],
+            item["quantified_examples"],
+            item["theme"].casefold(),
+        ),
+        reverse=True,
+    )
+    return rows
+
+
 def _build_career_profile(
     skills: list[dict],
+    themes: list[dict],
     *,
     total_proof_records: int,
+    distinct_demonstrations: int,
     accomplishment_count: int,
     receipt_count: int,
 ) -> dict:
     """Build the combined profile shown above any one individual skill."""
     primary, emerging = _profile_skill_sets(skills)
-    repeated_count = sum(1 for skill in skills if skill["demonstrations"] >= 2)
+    repeated = [skill for skill in skills if skill["demonstrations"] >= 2]
+    repeated_count = len(repeated)
     strong_count = sum(1 for skill in skills if skill["signal"] == "strong")
     established_count = sum(1 for skill in skills if skill["signal"] == "established")
+    maturity = _profile_maturity(distinct_demonstrations, repeated_count)
 
-    if not primary:
-        return {
-            "headline": "Build your career signal",
-            "primary_skills": [],
-            "emerging_skills": [],
-            "repeated_skill_count": 0,
-            "established_skill_count": 0,
-            "strong_skill_count": 0,
-            "summary": (
-                "Add specific skills to accomplishments and Impact Receipts so "
-                "BragStack can connect your proof into a combined career profile."
-            ),
-        }
-
+    durable_themes = [
+        theme
+        for theme in themes
+        if theme["demonstrations"] >= 2 and theme["theme"] != "Uncategorized"
+    ][:PRIMARY_THEME_LIMIT]
+    primary_theme_names = [theme["theme"] for theme in durable_themes]
     primary_names = [skill["skill"] for skill in primary]
     emerging_names = [skill["skill"] for skill in emerging]
-    headline = " · ".join(primary_names[:3])
+    recent_emerging = [
+        skill["skill"]
+        for skill in skills
+        if skill["demonstrations"] == 1 and skill["recent"]
+    ][:EMERGING_SKILL_LIMIT]
 
-    if repeated_count:
-        repeated_names = [
-            skill["skill"] for skill in skills if skill["demonstrations"] >= 2
-        ][:3]
+    if primary_theme_names:
+        headline = " · ".join(primary_theme_names)
+    elif repeated:
+        headline = " · ".join(skill["skill"] for skill in repeated[:3])
+    elif primary_names:
+        headline = " · ".join(primary_names[:3])
+    else:
+        headline = "Build your career signal"
+
+    if not skills:
         summary = (
-            f"Across {total_proof_records} proof record"
-            f"{'' if total_proof_records == 1 else 's'}, your strongest repeated "
-            f"signals include {', '.join(repeated_names)}. "
-            f"The profile combines {accomplishment_count} accomplishment"
-            f"{'' if accomplishment_count == 1 else 's'} and {receipt_count} "
-            f"Impact Receipt{'' if receipt_count == 1 else 's'} instead of "
-            "promoting whichever accomplishment was added most recently."
+            "Add specific skills to accomplishments and Impact Receipts so "
+            "BragStack can connect your proof into a combined career profile."
+        )
+    elif repeated:
+        repeated_names = ", ".join(skill["skill"] for skill in repeated[:3])
+        summary = (
+            f"Across {total_proof_records} saved proof record"
+            f"{'' if total_proof_records == 1 else 's'} representing "
+            f"{distinct_demonstrations} distinct demonstration"
+            f"{'' if distinct_demonstrations == 1 else 's'}, your most durable "
+            f"signals include {repeated_names}. BragStack ranks repeated work "
+            "before emerging signals and tracks recent growth separately."
         )
     else:
         summary = (
-            f"Across {total_proof_records} proof record"
-            f"{'' if total_proof_records == 1 else 's'}, BragStack sees several "
-            "emerging signals but not enough repeated demonstrations yet to call "
-            "one a durable core strength. The profile therefore shows a balanced "
-            "set rather than elevating the newest record."
+            f"Across {total_proof_records} saved proof record"
+            f"{'' if total_proof_records == 1 else 's'} representing "
+            f"{distinct_demonstrations} distinct demonstration"
+            f"{'' if distinct_demonstrations == 1 else 's'}, BragStack sees "
+            "promising emerging signals but not enough repeated demonstrations "
+            "yet to call one a durable core strength."
         )
 
     return {
         "headline": headline,
+        "primary_themes": primary_theme_names,
         "primary_skills": primary_names,
         "emerging_skills": emerging_names,
+        "recent_emerging_skills": recent_emerging,
         "repeated_skill_count": repeated_count,
         "established_skill_count": established_count,
         "strong_skill_count": strong_count,
+        "maturity": maturity,
+        "accomplishment_count": accomplishment_count,
+        "receipt_count": receipt_count,
+        "distinct_demonstrations": distinct_demonstrations,
         "summary": summary,
     }
+
+
+def _recommendations(skills: list[dict], gaps: list[dict]) -> list[str]:
+    """Build prioritized, evidence-aware next actions."""
+    recommendations: list[str] = []
+    repeated = [skill for skill in skills if skill["demonstrations"] >= 2]
+
+    if repeated:
+        names = ", ".join(skill["skill"] for skill in repeated[:3])
+        recommendations.append(
+            f"Lead with your repeated signals: {names}. They are backed by more "
+            "than one distinct work example."
+        )
+
+        top = repeated[0]
+        if top["quantified_examples"] == 0:
+            recommendations.append(
+                f"Add a measurable outcome to a {top['skill']} example where "
+                "you can do so accurately."
+            )
+        elif top["evidence_backed_demonstrations"] == 0:
+            recommendations.append(
+                f"Strengthen {top['skill']} by turning one strong example into "
+                "an Impact Receipt with safe supporting evidence."
+            )
+        elif top["confirmed_demonstrations"] == 0 and top["impact_receipts"]:
+            recommendations.append(
+                f"If appropriate, add independent confirmation to one "
+                f"{top['skill']} Impact Receipt."
+            )
+    elif skills:
+        names = ", ".join(skill["skill"] for skill in skills[:3])
+        recommendations.append(
+            f"Build repetition around {names}; another distinct example will "
+            "help separate durable strengths from one-off work."
+        )
+
+    for gap in gaps:
+        action = gap["action"]
+        if action not in recommendations:
+            recommendations.append(action)
+        if len(recommendations) >= 4:
+            break
+
+    if len(recommendations) < 4:
+        recent_emerging = next(
+            (
+                skill
+                for skill in skills
+                if skill["demonstrations"] == 1 and skill["recent"]
+            ),
+            None,
+        )
+        if recent_emerging:
+            action = (
+                f"If {recent_emerging['skill']} is becoming a recurring part of "
+                "your work, capture the next distinct example so BragStack can "
+                "measure whether it is becoming established."
+            )
+            if action not in recommendations:
+                recommendations.append(action)
+
+    if not recommendations:
+        recommendations.append(
+            "Keep capturing new accomplishments so your career signals stay current."
+        )
+
+    return recommendations[:4]
 
 
 def build_career_intelligence(
@@ -229,10 +472,10 @@ def build_career_intelligence(
 ) -> dict:
     """Build explainable career signals from user-owned proof records.
 
-    Every accomplishment and every Impact Receipt is analyzed. For a
-    skill-specific demonstration count, a receipt derived from an
-    accomplishment enriches the same underlying demonstration rather than
-    inflating that skill merely because a second document exists.
+    Every accomplishment and every Impact Receipt is analyzed. A linked receipt
+    enriches its source accomplishment instead of creating a second underlying
+    demonstration. Strength, proof quality, themes, and recency are exposed as
+    separate concepts so freshness cannot masquerade as career depth.
     """
     entries = list(entries)
     receipts = list(receipts)
@@ -246,37 +489,73 @@ def build_career_intelligence(
             "receipt_count": 0,
             "proof_keys": set(),
             "quantified_keys": set(),
-            "evidence_count": 0,
-            "confirmed_count": 0,
+            "evidence_keys": set(),
+            "confirmed_keys": set(),
+            "evidence_item_count": 0,
+            "confirmation_count": 0,
+            "latest_at": None,
+        }
+    )
+    category_state = defaultdict(
+        lambda: {
+            "display_names": defaultdict(int),
+            "proof_keys": set(),
+            "quantified_keys": set(),
+            "evidence_keys": set(),
+            "confirmed_keys": set(),
+            "skill_proof_keys": defaultdict(set),
+            "skill_display_names": defaultdict(lambda: defaultdict(int)),
             "latest_at": None,
         }
     )
 
-    categories = defaultdict(int)
     evidence_items = 0
     confirmed_receipts = 0
     quantified_proof_keys: set[str] = set()
+    evidence_proof_keys: set[str] = set()
+    confirmed_proof_keys: set[str] = set()
+    all_proof_keys: set[str] = set()
+    linked_receipt_entry_ids: set[str] = set()
 
     entry_proof_keys: dict[str, str] = {}
+    entry_dates: dict[str, datetime | None] = {}
+    proof_category_keys: dict[str, str] = {}
+
     for index, entry in enumerate(entries):
         entry_id = _document_id(entry)
         proof_key = f"entry:{entry_id}" if entry_id else f"entry-index:{index}"
+        all_proof_keys.add(proof_key)
         if entry_id:
             entry_proof_keys[entry_id] = proof_key
 
-        category = _clean_text(entry.get("category")) or "Uncategorized"
-        categories[category] += 1
+        observed_at = _document_datetime(entry)
+        if entry_id:
+            entry_dates[entry_id] = observed_at
+
+        category_display = _display_text(entry.get("category")) or "Uncategorized"
+        category_key = category_display.casefold()
+        proof_category_keys[proof_key] = category_key
+        theme = category_state[category_key]
+        theme["display_names"][category_display] += 1
+        theme["proof_keys"].add(proof_key)
+        if observed_at and (
+            theme["latest_at"] is None or observed_at > theme["latest_at"]
+        ):
+            theme["latest_at"] = observed_at
+
         is_quantified = _has_quantified_text(
             entry.get("impact"), entry.get("resume_bullet"), entry.get("action")
         )
         if is_quantified:
             quantified_proof_keys.add(proof_key)
-        observed_at = _document_datetime(entry)
+            theme["quantified_keys"].add(proof_key)
+
         seen_in_entry = set()
         for key, display in _normalized_skills(entry.get("tags", []) or []):
             if key in seen_in_entry:
                 continue
             seen_in_entry.add(key)
+
             state = skill_state[key]
             state["display_names"][display] += 1
             state["entry_count"] += 1
@@ -288,12 +567,20 @@ def build_career_intelligence(
             ):
                 state["latest_at"] = observed_at
 
+            theme["skill_proof_keys"][key].add(proof_key)
+            theme["skill_display_names"][key][display] += 1
+
     for index, receipt in enumerate(receipts):
         receipt_id = _document_id(receipt)
         source_entry_id = _clean_text(receipt.get("source_entry_id")) or None
-        proof_key = entry_proof_keys.get(source_entry_id or "")
+        linked_proof_key = entry_proof_keys.get(source_entry_id or "")
+        proof_key = linked_proof_key
         if proof_key is None:
             proof_key = f"receipt:{receipt_id}" if receipt_id else f"receipt-index:{index}"
+        else:
+            linked_receipt_entry_ids.add(source_entry_id)
+
+        all_proof_keys.add(proof_key)
 
         evidence = receipt.get("evidence", []) or []
         evidence_items += len(evidence)
@@ -303,26 +590,58 @@ def build_career_intelligence(
         has_metrics = bool(receipt.get("metrics")) or _has_quantified_text(
             receipt.get("result")
         )
+
         if has_metrics:
             quantified_proof_keys.add(proof_key)
-        observed_at = _document_datetime(receipt)
+        if evidence:
+            evidence_proof_keys.add(proof_key)
+        if confirmations:
+            confirmed_proof_keys.add(proof_key)
+
+        # A linked receipt documents the original work; creating the receipt later
+        # should not make old work look newly demonstrated.
+        if linked_proof_key is not None and source_entry_id:
+            observed_at = entry_dates.get(source_entry_id) or _document_datetime(receipt)
+        else:
+            observed_at = _document_datetime(receipt)
+
+        category_key = proof_category_keys.get(proof_key)
+        if category_key is not None:
+            theme = category_state[category_key]
+            if has_metrics:
+                theme["quantified_keys"].add(proof_key)
+            if evidence:
+                theme["evidence_keys"].add(proof_key)
+            if confirmations:
+                theme["confirmed_keys"].add(proof_key)
+
         seen_in_receipt = set()
         for key, display in _normalized_skills(receipt.get("skills", []) or []):
             if key in seen_in_receipt:
                 continue
             seen_in_receipt.add(key)
+
             state = skill_state[key]
             state["display_names"][display] += 1
             state["receipt_count"] += 1
             state["proof_keys"].add(proof_key)
-            state["evidence_count"] += len(evidence)
-            state["confirmed_count"] += confirmations
+            state["evidence_item_count"] += len(evidence)
+            state["confirmation_count"] += confirmations
             if has_metrics:
                 state["quantified_keys"].add(proof_key)
+            if evidence:
+                state["evidence_keys"].add(proof_key)
+            if confirmations:
+                state["confirmed_keys"].add(proof_key)
             if observed_at and (
                 state["latest_at"] is None or observed_at > state["latest_at"]
             ):
                 state["latest_at"] = observed_at
+
+            if category_key is not None:
+                theme = category_state[category_key]
+                theme["skill_proof_keys"][key].add(proof_key)
+                theme["skill_display_names"][key][display] += 1
 
     skills = []
     for state in skill_state.values():
@@ -332,49 +651,61 @@ def build_career_intelligence(
         )[0]
         demonstrations = len(state["proof_keys"])
         quantified_count = len(state["quantified_keys"])
+        evidence_backed_count = len(state["evidence_keys"])
+        confirmed_demo_count = len(state["confirmed_keys"])
         latest_at = state["latest_at"]
         days_since = (now - latest_at).days if latest_at else None
         recent = days_since is not None and days_since <= RECENT_WINDOW_DAYS
 
-        points = _skill_evidence_points(
+        support = _support_level(
+            quantified_count=quantified_count,
+            evidence_backed_count=evidence_backed_count,
+            confirmed_demo_count=confirmed_demo_count,
+        )
+        signal = _signal_label(demonstrations, support)
+        points, score_breakdown = _skill_evidence_points(
             demonstrations=demonstrations,
             quantified_count=quantified_count,
-            evidence_count=state["evidence_count"],
-            confirmed_count=state["confirmed_count"],
+            evidence_backed_count=evidence_backed_count,
+            confirmed_demo_count=confirmed_demo_count,
         )
-
-        if demonstrations >= 4 and (state["evidence_count"] or quantified_count >= 2):
-            label = "strong"
-        elif demonstrations >= 2:
-            label = "established"
-        else:
-            label = "emerging"
 
         skills.append(
             {
                 "skill": display,
-                "signal": label,
+                "signal": signal,
+                "support_level": support,
                 "evidence_points": points,
+                "score_breakdown": score_breakdown,
+                "strength_reasons": _strength_reasons(
+                    demonstrations=demonstrations,
+                    quantified_count=quantified_count,
+                    evidence_backed_count=evidence_backed_count,
+                    confirmed_demo_count=confirmed_demo_count,
+                ),
                 "demonstrations": demonstrations,
                 "accomplishments": state["entry_count"],
                 "impact_receipts": state["receipt_count"],
                 "quantified_examples": quantified_count,
-                "evidence_items": state["evidence_count"],
-                "confirmations": state["confirmed_count"],
+                "evidence_items": state["evidence_item_count"],
+                "evidence_backed_demonstrations": evidence_backed_count,
+                "confirmations": state["confirmation_count"],
+                "confirmed_demonstrations": confirmed_demo_count,
                 "recent": recent,
                 "last_demonstrated_at": latest_at.isoformat() if latest_at else None,
             }
         )
 
-    # Evidence strength comes first. Freshness only breaks otherwise-close ties;
-    # it is not added to proof points and cannot make a new singleton look like a
-    # stronger body of work by itself.
+    # Durability is the first sort dimension: a deeply documented one-off can be
+    # high-quality evidence while still remaining an emerging career signal.
     skills.sort(
         key=lambda item: (
-            item["evidence_points"],
+            _SIGNAL_RANK[item["signal"]],
             item["demonstrations"],
+            item["evidence_points"],
+            _SUPPORT_RANK[item["support_level"]],
             item["quantified_examples"],
-            item["confirmations"],
+            item["confirmed_demonstrations"],
             bool(item["recent"]),
             item["last_demonstrated_at"] or "",
             item["skill"].casefold(),
@@ -382,105 +713,170 @@ def build_career_intelligence(
         reverse=True,
     )
 
+    themes = _theme_rows(category_state, now)
+    distinct_demonstrations = len(all_proof_keys)
+    quantified_count = len(quantified_proof_keys)
+    evidence_demo_count = len(evidence_proof_keys)
+    confirmed_demo_count = len(confirmed_proof_keys)
+
+    # Legacy receipts may predate source_entry_id linking. Use explicit linkage
+    # when available, with a conservative document-count fallback so old data is
+    # not treated as having zero structured coverage.
+    explicit_receipt_coverage = len(linked_receipt_entry_ids)
+    fallback_receipt_coverage = min(len(receipts), len(entries))
+    effective_receipt_coverage = max(
+        explicit_receipt_coverage,
+        fallback_receipt_coverage,
+    )
+    receipt_coverage_percent = _percent(effective_receipt_coverage, len(entries))
+
     gaps = []
-    if entries and len(receipts) < max(1, len(entries) // 3):
+    if entries and receipt_coverage_percent < 34:
         gaps.append(
             {
                 "type": "receipt_coverage",
                 "title": "Turn more wins into Impact Receipts",
-                "detail": "Your accomplishment history is stronger than your structured proof coverage.",
+                "detail": (
+                    f"Structured proof currently covers about "
+                    f"{receipt_coverage_percent}% of your accomplishments."
+                ),
                 "action": "Create Impact Receipts for your highest-impact accomplishments.",
             }
         )
-    if entries and not quantified_proof_keys:
+
+    quantified_coverage_percent = _percent(quantified_count, distinct_demonstrations)
+    if distinct_demonstrations and quantified_coverage_percent < 34:
         gaps.append(
             {
                 "type": "quantified_impact",
-                "title": "Add measurable outcomes",
-                "detail": "No quantified results are visible in your current career proof.",
-                "action": "Add a number, percentage, time saved, volume, cost, or other measurable result where accurate.",
+                "title": "Increase measurable-outcome coverage",
+                "detail": (
+                    f"{quantified_count} of {distinct_demonstrations} distinct "
+                    "demonstrations currently include a measurable result."
+                ),
+                "action": (
+                    "Add a number, percentage, time saved, volume, cost, or other "
+                    "measurable result where accurate."
+                ),
             }
         )
-    if receipts and evidence_items == 0:
+
+    evidence_coverage_percent = _percent(evidence_demo_count, distinct_demonstrations)
+    if receipts and evidence_coverage_percent < 34:
         gaps.append(
             {
                 "type": "supporting_evidence",
-                "title": "Strengthen supporting evidence",
-                "detail": "Your Impact Receipts do not currently reference supporting evidence.",
-                "action": "Attach safe evidence metadata such as reports, feedback, links, or artifacts.",
+                "title": "Broaden supporting-evidence coverage",
+                "detail": (
+                    f"{evidence_demo_count} of {distinct_demonstrations} distinct "
+                    "demonstrations are backed by supporting evidence metadata."
+                ),
+                "action": (
+                    "Attach safe evidence metadata such as reports, feedback, links, "
+                    "or artifacts to more of your strongest receipts."
+                ),
             }
         )
-    if receipts and confirmed_receipts == 0:
+
+    confirmation_coverage_percent = _percent(
+        confirmed_demo_count,
+        distinct_demonstrations,
+    )
+    if receipts and confirmed_demo_count == 0:
         gaps.append(
             {
                 "type": "recognition",
                 "title": "Capture independent recognition",
-                "detail": "None of your Impact Receipts currently include a confirmed contribution.",
-                "action": "Where appropriate, request or record collaborator, stakeholder, or organization confirmation.",
+                "detail": "None of your distinct demonstrations currently include confirmation.",
+                "action": (
+                    "Where appropriate, request or record collaborator, stakeholder, "
+                    "or organization confirmation."
+                ),
             }
         )
+
     if not skills and entries:
         gaps.append(
             {
                 "type": "skills",
                 "title": "Tag demonstrated skills",
                 "detail": "Your accomplishments do not yet expose reusable skill signals.",
-                "action": "Add specific skills to accomplishments so BragStack can connect work to capabilities.",
+                "action": (
+                    "Add specific skills to accomplishments so BragStack can connect "
+                    "work to capabilities."
+                ),
+            }
+        )
+
+    if (
+        skills
+        and distinct_demonstrations >= 2
+        and not any(skill["demonstrations"] >= 2 for skill in skills)
+    ):
+        gaps.append(
+            {
+                "type": "repetition",
+                "title": "Build repeatable career signals",
+                "detail": (
+                    "Your proof shows several skills, but none appears across more "
+                    "than one distinct work example yet."
+                ),
+                "action": (
+                    "Keep tagging recurring skills consistently so repeated strengths "
+                    "become visible over time."
+                ),
             }
         )
 
     profile = _build_career_profile(
         skills,
+        themes,
         total_proof_records=total_proof_records,
+        distinct_demonstrations=distinct_demonstrations,
         accomplishment_count=len(entries),
         receipt_count=len(receipts),
     )
 
-    recommendations = [gap["action"] for gap in gaps[:3]]
-    repeated_skills = [skill for skill in skills if skill["demonstrations"] >= 2]
-    if repeated_skills:
-        names = ", ".join(skill["skill"] for skill in repeated_skills[:3])
-        recommendations.insert(
-            0,
-            f"Lead with your repeated signals: {names}. They are supported by more than one distinct demonstration rather than recency alone.",
-        )
-    elif skills:
-        names = ", ".join(skill["skill"] for skill in skills[:3])
-        recommendations.insert(
-            0,
-            f"Build repetition around {names}; these are promising signals, but each needs another distinct demonstration before BragStack treats it as established.",
-        )
-    if not recommendations:
-        recommendations.append(
-            "Keep capturing new accomplishments so your career signals stay current."
-        )
+    top_categories = [
+        {"category": theme["theme"], "count": theme["demonstrations"]}
+        for theme in themes[:5]
+    ]
 
-    top_categories = sorted(categories.items(), key=lambda item: (-item[1], item[0]))[:5]
     return {
         "summary": {
             "accomplishments": len(entries),
             "impact_receipts": len(receipts),
             "total_proof_records": total_proof_records,
+            "distinct_demonstrations": distinct_demonstrations,
             "unique_skills": len(skills),
-            "quantified_results": len(quantified_proof_keys),
+            "quantified_results": quantified_count,
+            "quantified_coverage_percent": quantified_coverage_percent,
             "evidence_items": evidence_items,
+            "evidence_backed_demonstrations": evidence_demo_count,
+            "evidence_coverage_percent": evidence_coverage_percent,
             "confirmed_receipts": confirmed_receipts,
+            "confirmed_demonstrations": confirmed_demo_count,
+            "confirmation_coverage_percent": confirmation_coverage_percent,
+            "receipt_coverage_percent": receipt_coverage_percent,
         },
         "career_profile": profile,
+        "career_themes": themes,
         "top_skills": skills[:8],
         "skills": skills,
-        "top_categories": [
-            {"category": category, "count": count} for category, count in top_categories
-        ],
+        "top_categories": top_categories,
         "gaps": gaps,
-        "recommended_actions": recommendations[:4],
+        "recommended_actions": _recommendations(skills, gaps),
         "methodology": {
-            "version": "career-intelligence-v2",
+            "version": "career-intelligence-v3",
+            "schema_version": "career-intelligence-v3",
             "employment_decision": False,
             "description": (
-                "Signals summarize user-owned proof. Repetition, measurable outcomes, "
-                "evidence, and confirmation determine proof strength; recency is only "
-                "a tie-breaker. BragStack does not predict hiring or promotion outcomes."
+                "Signals summarize user-owned proof. Durability is based on repeated "
+                "distinct demonstrations; proof quality is tracked separately through "
+                "measurable outcomes, evidence-backed demonstrations, and confirmations. "
+                "Linked receipts enrich their source work without creating fake repetition, "
+                "and receipt creation dates do not make older work look newly demonstrated. "
+                "BragStack does not predict hiring or promotion outcomes."
             ),
         },
     }

--- a/backend/app/career_intelligence_routes.py
+++ b/backend/app/career_intelligence_routes.py
@@ -10,28 +10,90 @@ from app.education_intelligence import APPLICATION_PROFILES, build_application_i
 router = APIRouter(prefix="/career-intelligence", tags=["career-intelligence"])
 
 
+def _bounded_percent(value) -> bool:
+    """Return whether a value can represent a percentage from 0 through 100."""
+    try:
+        number = int(value or 0)
+    except (TypeError, ValueError):
+        return False
+    return 0 <= number <= 100
+
+
 def _verify_intelligence(result: dict, entries: list[dict], receipts: list[dict]) -> list[str]:
     """Return invariant violations that would make smart analysis misleading."""
     violations: list[str] = []
     summary = result.get("summary") or {}
+    methodology = result.get("methodology") or {}
     expected_total = len(entries) + len(receipts)
+
     if summary.get("accomplishments") != len(entries):
         violations.append("accomplishment_count_mismatch")
     if summary.get("impact_receipts") != len(receipts):
         violations.append("receipt_count_mismatch")
     if summary.get("total_proof_records") != expected_total:
         violations.append("total_proof_count_mismatch")
+
+    try:
+        distinct_demonstrations = int(summary.get("distinct_demonstrations") or 0)
+    except (TypeError, ValueError):
+        distinct_demonstrations = -1
+    if distinct_demonstrations < 0 or distinct_demonstrations > expected_total:
+        violations.append("distinct_demonstration_count_invalid")
+
     if int(summary.get("confirmed_receipts") or 0) > len(receipts):
         violations.append("confirmed_receipt_overcount")
-    if int(summary.get("quantified_results") or 0) > expected_total:
+    if int(summary.get("quantified_results") or 0) > distinct_demonstrations:
         violations.append("quantified_result_overcount")
+    if int(summary.get("evidence_backed_demonstrations") or 0) > distinct_demonstrations:
+        violations.append("evidence_demonstration_overcount")
+    if int(summary.get("confirmed_demonstrations") or 0) > distinct_demonstrations:
+        violations.append("confirmed_demonstration_overcount")
     if int(summary.get("evidence_items") or 0) < 0:
         violations.append("negative_evidence_count")
+
+    for field in (
+        "quantified_coverage_percent",
+        "evidence_coverage_percent",
+        "confirmation_coverage_percent",
+        "receipt_coverage_percent",
+    ):
+        if not _bounded_percent(summary.get(field)):
+            violations.append(f"{field}_invalid")
+
+    valid_signals = {"emerging", "established", "strong"}
+    valid_support_levels = {"basic", "supported", "well-supported"}
     for skill in result.get("skills") or []:
         demonstrations = int(skill.get("demonstrations") or 0)
-        if demonstrations < 0 or demonstrations > expected_total:
+        if demonstrations < 0 or demonstrations > distinct_demonstrations:
             violations.append("skill_demonstration_count_invalid")
             break
+        if int(skill.get("evidence_backed_demonstrations") or 0) > demonstrations:
+            violations.append("skill_evidence_demonstration_overcount")
+            break
+        if int(skill.get("confirmed_demonstrations") or 0) > demonstrations:
+            violations.append("skill_confirmed_demonstration_overcount")
+            break
+        points = int(skill.get("evidence_points") or 0)
+        if points < 0 or points > 100:
+            violations.append("skill_evidence_points_invalid")
+            break
+        if skill.get("signal") not in valid_signals:
+            violations.append("skill_signal_invalid")
+            break
+        if skill.get("support_level") not in valid_support_levels:
+            violations.append("skill_support_level_invalid")
+            break
+
+    profile = result.get("career_profile") or {}
+    if profile.get("maturity") not in {"early", "developing", "well-supported"}:
+        violations.append("career_profile_maturity_invalid")
+
+    version = str(methodology.get("version") or "")
+    if not version.startswith("career-intelligence-v"):
+        violations.append("career_intelligence_version_invalid")
+    if methodology.get("employment_decision") is not False:
+        violations.append("employment_decision_enabled")
+
     return sorted(set(violations))
 
 
@@ -69,17 +131,24 @@ def _load_intelligence(current_user: dict) -> dict:
     receipts = list(impact_receipts_collection.find({"user_id": user_id}))
     result = build_career_intelligence(entries, receipts)
     violations = _verify_intelligence(result, entries, receipts)
+    methodology = result.get("methodology") or {}
+    version = str(methodology.get("version") or "career-intelligence-unknown")
+    schema_version = str(methodology.get("schema_version") or version)
     record_verification_event(
         feature="career_intelligence",
         task="analysis",
         passed=not violations,
         violation_codes=violations,
         provider="deterministic",
-        model_id="career-intelligence-v1",
+        model_id=version,
         model_revision="deterministic",
-        schema_version="career-intelligence-v1",
+        schema_version=schema_version,
         source_count=len(entries) + len(receipts),
-        generated_item_count=len(result.get("skills") or []) + len(result.get("recommended_actions") or []),
+        generated_item_count=(
+            len(result.get("skills") or [])
+            + len(result.get("career_themes") or [])
+            + len(result.get("recommended_actions") or [])
+        ),
         user_id=user_id,
     )
     if violations:

--- a/backend/tests/test_career_intelligence.py
+++ b/backend/tests/test_career_intelligence.py
@@ -8,8 +8,18 @@ def test_career_intelligence_combines_entries_and_receipts():
     """Verify career intelligence combines entries and receipts."""
     now = datetime(2026, 8, 26, tzinfo=timezone.utc)
     entries = [
-        {"category": "Platform Engineering", "tags": ["Docker", "Python"], "impact": "Reduced deployment time by 40%", "entry_date": "2026-08-01"},
-        {"category": "Platform Engineering", "tags": ["docker", "Linux"], "impact": "Automated container health checks", "entry_date": "2026-07-15"},
+        {
+            "category": "Platform Engineering",
+            "tags": ["Docker", "Python"],
+            "impact": "Reduced deployment time by 40%",
+            "entry_date": "2026-08-01",
+        },
+        {
+            "category": "Platform Engineering",
+            "tags": ["docker", "Linux"],
+            "impact": "Automated container health checks",
+            "entry_date": "2026-07-15",
+        },
     ]
     receipts = [
         {
@@ -17,7 +27,9 @@ def test_career_intelligence_combines_entries_and_receipts():
             "result": "Cut recovery time to 12 minutes",
             "metrics": [{"label": "Recovery time", "value": "12 min"}],
             "evidence": [{"title": "Incident report"}],
-            "confirmations": [{"status": "confirmed", "confirmation_type": "stakeholder"}],
+            "confirmations": [
+                {"status": "confirmed", "confirmation_type": "stakeholder"}
+            ],
             "created_at": datetime(2026, 8, 5, tzinfo=timezone.utc),
         }
     ]
@@ -27,18 +39,25 @@ def test_career_intelligence_combines_entries_and_receipts():
     assert result["summary"]["accomplishments"] == 2
     assert result["summary"]["impact_receipts"] == 1
     assert result["summary"]["total_proof_records"] == 3
+    assert result["summary"]["distinct_demonstrations"] == 3
     assert result["summary"]["quantified_results"] == 2
-    docker = next(skill for skill in result["skills"] if skill["skill"].casefold() == "docker")
+    docker = next(
+        skill for skill in result["skills"] if skill["skill"].casefold() == "docker"
+    )
     assert docker["demonstrations"] == 3
     assert docker["quantified_examples"] == 2
     assert docker["evidence_items"] == 1
+    assert docker["evidence_backed_demonstrations"] == 1
     assert docker["confirmations"] == 1
+    assert docker["confirmed_demonstrations"] == 1
+    assert docker["support_level"] == "well-supported"
     assert docker["recent"] is True
     assert result["career_profile"]["primary_skills"]
     assert "Docker" in result["career_profile"]["primary_skills"]
+    assert result["career_profile"]["maturity"] == "developing"
     assert "repeated signals" in result["recommended_actions"][0]
     assert result["methodology"]["employment_decision"] is False
-    assert result["methodology"]["version"] == "career-intelligence-v2"
+    assert result["methodology"]["version"] == "career-intelligence-v3"
 
 
 def test_linked_receipt_enriches_instead_of_double_counting_proof():
@@ -61,7 +80,9 @@ def test_linked_receipt_enriches_instead_of_double_counting_proof():
             "result": "Reduced deployment time by 40%",
             "metrics": [{"label": "Deployment time", "value": "40%"}],
             "evidence": [{"title": "Deployment report"}],
-            "confirmations": [{"status": "confirmed", "confirmation_type": "stakeholder"}],
+            "confirmations": [
+                {"status": "confirmed", "confirmation_type": "stakeholder"}
+            ],
             "created_at": datetime(2026, 8, 2, tzinfo=timezone.utc),
         }
     ]
@@ -69,23 +90,42 @@ def test_linked_receipt_enriches_instead_of_double_counting_proof():
     result = build_career_intelligence(entries, receipts, now=now)
 
     assert result["summary"]["total_proof_records"] == 2
+    assert result["summary"]["distinct_demonstrations"] == 1
     assert result["summary"]["quantified_results"] == 1
+    assert result["summary"]["receipt_coverage_percent"] == 100
     docker = next(skill for skill in result["skills"] if skill["skill"] == "Docker")
     assert docker["demonstrations"] == 1
     assert docker["accomplishments"] == 1
     assert docker["impact_receipts"] == 1
     assert docker["quantified_examples"] == 1
     assert docker["evidence_items"] == 1
+    assert docker["evidence_backed_demonstrations"] == 1
     assert docker["confirmations"] == 1
+    assert docker["confirmed_demonstrations"] == 1
 
 
 def test_career_intelligence_surfaces_proof_gaps_without_readiness_score():
     """Verify career intelligence surfaces proof gaps without readiness score."""
     result = build_career_intelligence(
         [
-            {"category": "Operations", "tags": [], "impact": "Improved the process", "entry_date": "2026-08-01"},
-            {"category": "Operations", "tags": [], "impact": "Documented the workflow", "entry_date": "2026-08-02"},
-            {"category": "Operations", "tags": [], "impact": "Coordinated the launch", "entry_date": "2026-08-03"},
+            {
+                "category": "Operations",
+                "tags": [],
+                "impact": "Improved the process",
+                "entry_date": "2026-08-01",
+            },
+            {
+                "category": "Operations",
+                "tags": [],
+                "impact": "Documented the workflow",
+                "entry_date": "2026-08-02",
+            },
+            {
+                "category": "Operations",
+                "tags": [],
+                "impact": "Coordinated the launch",
+                "entry_date": "2026-08-03",
+            },
         ],
         [],
         now=datetime(2026, 8, 26, tzinfo=timezone.utc),
@@ -109,6 +149,7 @@ def test_compound_skill_tags_are_split_into_individual_signals():
                 "tags": [
                     "Linux · Raspberry Pi · SSH · Networking · Systems Administration",
                     "Troubleshooting, Platform Engineering; Edge Computing | Developer Tooling",
+                    "Python\nDocker",
                 ],
                 "impact": "Built and troubleshot a portable Linux platform.",
                 "entry_date": "2026-09-05",
@@ -129,6 +170,8 @@ def test_compound_skill_tags_are_split_into_individual_signals():
         "Platform Engineering",
         "Edge Computing",
         "Developer Tooling",
+        "Python",
+        "Docker",
     }.issubset(names)
     assert not any(" · " in name for name in names)
     assert not any("," in name or ";" in name or "|" in name for name in names)
@@ -162,7 +205,9 @@ def test_recent_singleton_does_not_get_extra_proof_strength_for_recency():
     )
 
     linux = next(skill for skill in result["skills"] if skill["skill"] == "Linux")
-    pi = next(skill for skill in result["skills"] if skill["skill"] == "Raspberry Pi")
+    pi = next(
+        skill for skill in result["skills"] if skill["skill"] == "Raspberry Pi"
+    )
 
     assert linux["recent"] is False
     assert pi["recent"] is True
@@ -208,5 +253,173 @@ def test_career_profile_synthesizes_multiple_records_instead_of_one_latest_skill
     assert "Linux" in profile["primary_skills"]
     assert "Troubleshooting" in profile["primary_skills"]
     assert len(profile["primary_skills"]) > 1
-    assert "instead of promoting whichever accomplishment was added most recently" in profile["summary"]
+    assert profile["headline"] == "Platform Engineering"
+    assert "ranks repeated work before emerging signals" in profile["summary"]
     assert "Raspberry Pi · SSH · Networking" not in profile["headline"]
+
+
+def test_linked_receipt_creation_date_does_not_refresh_old_work():
+    """Documenting old work later must not make the underlying skill recent."""
+    result = build_career_intelligence(
+        [
+            {
+                "_id": "entry-old",
+                "category": "Systems",
+                "tags": ["Linux"],
+                "impact": "Maintained production systems",
+                "entry_date": "2024-01-01",
+            }
+        ],
+        [
+            {
+                "_id": "receipt-new",
+                "source_entry_id": "entry-old",
+                "skills": ["Linux"],
+                "evidence": [{"title": "Historical runbook"}],
+                "created_at": "2026-09-05",
+            }
+        ],
+        now=datetime(2026, 9, 5, tzinfo=timezone.utc),
+    )
+
+    linux = result["skills"][0]
+    assert linux["skill"] == "Linux"
+    assert linux["recent"] is False
+    assert linux["last_demonstrated_at"].startswith("2024-01-01")
+
+
+def test_attachment_volume_does_not_inflate_skill_breadth_score():
+    """Several files on one example should not fake several demonstrations."""
+    base_receipt = {
+        "_id": "receipt-1",
+        "skills": ["Docker"],
+        "result": "Documented a container deployment",
+        "created_at": "2026-09-01",
+    }
+    one_file = build_career_intelligence(
+        [],
+        [{**base_receipt, "evidence": [{"title": "Report"}]}],
+        now=datetime(2026, 9, 5, tzinfo=timezone.utc),
+    )
+    many_files = build_career_intelligence(
+        [],
+        [
+            {
+                **base_receipt,
+                "evidence": [
+                    {"title": "Report"},
+                    {"title": "Runbook"},
+                    {"title": "Dashboard"},
+                    {"title": "Ticket"},
+                    {"title": "Diagram"},
+                ],
+            }
+        ],
+        now=datetime(2026, 9, 5, tzinfo=timezone.utc),
+    )
+
+    one = one_file["skills"][0]
+    many = many_files["skills"][0]
+    assert one["evidence_items"] == 1
+    assert many["evidence_items"] == 5
+    assert one["evidence_backed_demonstrations"] == 1
+    assert many["evidence_backed_demonstrations"] == 1
+    assert one["evidence_points"] == many["evidence_points"]
+
+
+def test_established_signal_ranks_ahead_of_well_documented_singleton():
+    """Durability should rank ahead of a newly documented one-off skill."""
+    result = build_career_intelligence(
+        [
+            {
+                "category": "Operations",
+                "tags": ["Linux"],
+                "impact": "Resolved incidents",
+                "entry_date": "2025-01-01",
+            },
+            {
+                "category": "Operations",
+                "tags": ["Linux"],
+                "impact": "Maintained servers",
+                "entry_date": "2025-02-01",
+            },
+        ],
+        [
+            {
+                "skills": ["Raspberry Pi"],
+                "result": "Reduced setup time by 50%",
+                "metrics": [{"label": "Setup time", "value": "50%"}],
+                "evidence": [{"title": "Build notes"}],
+                "confirmations": [{"status": "confirmed"}],
+                "created_at": "2026-09-05",
+            }
+        ],
+        now=datetime(2026, 9, 5, tzinfo=timezone.utc),
+    )
+
+    linux = next(skill for skill in result["skills"] if skill["skill"] == "Linux")
+    pi = next(
+        skill for skill in result["skills"] if skill["skill"] == "Raspberry Pi"
+    )
+    assert linux["signal"] == "established"
+    assert pi["signal"] == "emerging"
+    assert pi["evidence_points"] > linux["evidence_points"]
+    assert result["skills"][0]["skill"] == "Linux"
+
+
+def test_summary_exposes_proof_coverage_and_career_themes():
+    """Coverage and themes should explain the body of proof without a readiness score."""
+    result = build_career_intelligence(
+        [
+            {
+                "_id": "e1",
+                "category": "Platform Engineering",
+                "tags": ["Docker", "Linux"],
+                "impact": "Cut deployment time by 30%",
+                "entry_date": "2026-01-01",
+            },
+            {
+                "_id": "e2",
+                "category": "Platform Engineering",
+                "tags": ["Docker", "Troubleshooting"],
+                "impact": "Resolved incidents",
+                "entry_date": "2026-02-01",
+            },
+            {
+                "_id": "e3",
+                "category": "Developer Tooling",
+                "tags": ["Python"],
+                "impact": "Built internal tooling",
+                "entry_date": "2026-03-01",
+            },
+        ],
+        [
+            {
+                "source_entry_id": "e1",
+                "skills": ["Docker"],
+                "metrics": [{"label": "Deployment time", "value": "30%"}],
+                "evidence": [{"title": "Deployment report"}],
+                "confirmations": [{"status": "confirmed"}],
+                "created_at": "2026-04-01",
+            }
+        ],
+        now=datetime(2026, 9, 5, tzinfo=timezone.utc),
+    )
+
+    summary = result["summary"]
+    assert summary["total_proof_records"] == 4
+    assert summary["distinct_demonstrations"] == 3
+    assert summary["quantified_coverage_percent"] == 33
+    assert summary["evidence_coverage_percent"] == 33
+    assert summary["confirmation_coverage_percent"] == 33
+    assert summary["receipt_coverage_percent"] == 33
+
+    platform = next(
+        theme
+        for theme in result["career_themes"]
+        if theme["theme"] == "Platform Engineering"
+    )
+    assert platform["demonstrations"] == 2
+    assert "Docker" in platform["skills"]
+    assert result["career_profile"]["primary_themes"] == ["Platform Engineering"]
+    assert result["career_profile"]["maturity"] == "developing"

--- a/frontend/src/CareerIntelligencePage.jsx
+++ b/frontend/src/CareerIntelligencePage.jsx
@@ -36,7 +36,7 @@ function LoadingShell() {
         <div>
           <span className="ci-kicker"><BrainCircuit size={17} /> BragStack Career Intelligence™</span>
           <h1>Your career proof, interpreted.</h1>
-          <p>See what your work actually demonstrates, where your evidence is strongest, and which proof gaps are worth fixing next.</p>
+          <p>See what your body of work repeatedly demonstrates, how well each signal is supported, and what is emerging next.</p>
           <div className="ci-hero-actions">
             <a className="ci-primary" href="/app/accomplishments?create=1">Capture new proof <ArrowRight size={17} /></a>
             <a className="ci-secondary" href="/app/impact-receipts">View Impact Receipts</a>
@@ -45,10 +45,10 @@ function LoadingShell() {
         <aside className="ci-lead-signal">
           <span>Analyzing your proof</span>
           <strong>Building your combined career signal…</strong>
-          <p>Your saved accomplishments and Impact Receipts are being connected into one evidence-backed view.</p>
+          <p>Your accomplishments and Impact Receipts are being reconciled into distinct work demonstrations, durable skills, proof quality, and career themes.</p>
         </aside>
       </section>
-      <BragStackLoader message="Reading your career proof…" detail="Connecting accomplishments, skills, evidence, and Impact Receipts." />
+      <BragStackLoader message="Reading your career proof…" detail="Separating repetition, proof quality, themes, and recent growth." />
     </main>
   );
 }
@@ -92,7 +92,8 @@ function CareerIntelligencePage() {
         const accomplishments = payload?.summary?.accomplishments ?? 0;
         const receipts = payload?.summary?.impact_receipts ?? 0;
         const total = payload?.summary?.total_proof_records ?? accomplishments + receipts;
-        setRefreshMessage(`Career Intelligence re-ran across ${total} proof record${total === 1 ? "" : "s"}: ${accomplishments} accomplishment${accomplishments === 1 ? "" : "s"} + ${receipts} Impact Receipt${receipts === 1 ? "" : "s"}.`);
+        const demonstrations = payload?.summary?.distinct_demonstrations ?? total;
+        setRefreshMessage(`Career Intelligence re-ran across ${total} saved proof record${total === 1 ? "" : "s"}, representing ${demonstrations} distinct work demonstration${demonstrations === 1 ? "" : "s"}.`);
       }
     } catch (requestError) {
       console.error(requestError);
@@ -117,9 +118,7 @@ function CareerIntelligencePage() {
   const totalSkillPages = Math.max(1, Math.ceil(allSkills.length / SKILLS_PER_PAGE));
   const visibleSkills = allSkills.slice((skillPage - 1) * SKILLS_PER_PAGE, skillPage * SKILLS_PER_PAGE);
 
-  if (!data && !error) {
-    return <LoadingShell />;
-  }
+  if (!data && !error) return <LoadingShell />;
 
   if (error) {
     return (
@@ -139,17 +138,27 @@ function CareerIntelligencePage() {
     recommended_actions: actions = [],
     top_categories: categories = [],
     career_profile: careerProfile = {},
+    career_themes: careerThemes = [],
   } = data;
+
   const totalProofRecords = summary.total_proof_records ?? ((summary.accomplishments ?? 0) + (summary.impact_receipts ?? 0));
+  const distinctDemonstrations = summary.distinct_demonstrations ?? totalProofRecords;
   const profileSkills = Array.isArray(careerProfile.primary_skills) && careerProfile.primary_skills.length
     ? careerProfile.primary_skills
     : allSkills.slice(0, 4).map((skill) => skill.skill);
-  const profileHeadline = careerProfile.headline || profileSkills.slice(0, 3).join(" · ");
+  const profileThemes = Array.isArray(careerProfile.primary_themes) ? careerProfile.primary_themes : [];
+  const profileHeadline = careerProfile.headline || profileThemes.join(" · ") || profileSkills.slice(0, 3).join(" · ");
   const profileSummary = careerProfile.summary || (
     profileSkills.length
-      ? "These are the strongest signals across your saved proof, not simply the skills from your newest accomplishment."
+      ? "These are the strongest repeated signals across your saved proof, with proof quality and recency tracked separately."
       : "Add accomplishments and skills to start creating evidence-backed career intelligence."
   );
+  const recentGrowth = Array.isArray(careerProfile.recent_emerging_skills)
+    ? careerProfile.recent_emerging_skills
+    : [];
+  const themeRows = Array.isArray(careerThemes) && careerThemes.length
+    ? careerThemes
+    : categories.map(({ category, count }) => ({ theme: category, demonstrations: count }));
 
   return (
     <main className="ci-page">
@@ -157,7 +166,7 @@ function CareerIntelligencePage() {
         <div>
           <span className="ci-kicker"><BrainCircuit size={17} /> BragStack Career Intelligence™</span>
           <h1>Your career proof, interpreted.</h1>
-          <p>See what your work actually demonstrates, where your evidence is strongest, and which proof gaps are worth fixing next.</p>
+          <p>See what your body of work repeatedly demonstrates, how strongly each signal is supported, and what is emerging next.</p>
           <div className="ci-hero-actions">
             <a className="ci-primary" href="/app/accomplishments?create=1">Capture new proof <ArrowRight size={17} /></a>
             <button className="ci-secondary ci-refresh" type="button" disabled={isRefreshing} onClick={() => void loadIntelligence({ refresh: true })}>
@@ -167,15 +176,20 @@ function CareerIntelligencePage() {
           </div>
           {refreshMessage && <div className="ci-refresh-message" role="status">{refreshMessage}</div>}
         </div>
+
         <aside className="ci-lead-signal">
           <span>Combined career signal</span>
           {profileSkills.length ? (
             <>
               <strong>{profileHeadline}</strong>
               <p>
-                <b>{totalProofRecords} total proof record{totalProofRecords === 1 ? "" : "s"} analyzed.</b>{" "}
+                <b>{totalProofRecords} saved proof record{totalProofRecords === 1 ? "" : "s"} → {distinctDemonstrations} distinct demonstration{distinctDemonstrations === 1 ? "" : "s"}.</b>{" "}
                 {profileSummary}
               </p>
+              {careerProfile.maturity && <p><b>Profile maturity:</b> {titleCase(careerProfile.maturity)} evidence coverage.</p>}
+              {recentGrowth.length > 0 && (
+                <p><b>Recent growth:</b> {recentGrowth.join(" · ")}. These stay separate from durable strengths until they repeat across distinct work examples.</p>
+              )}
             </>
           ) : (
             <>
@@ -187,10 +201,30 @@ function CareerIntelligencePage() {
       </section>
 
       <section className="ci-metrics" aria-label="Career proof summary">
-        <article><ReceiptText size={20} /><span>Total proof analyzed</span><strong>{totalProofRecords}</strong><small>{summary.accomplishments ?? 0} accomplishments + {summary.impact_receipts ?? 0} receipts</small></article>
-        <article><Sparkles size={20} /><span>Impact Receipts</span><strong>{summary.impact_receipts ?? 0}</strong></article>
-        <article><TrendingUp size={20} /><span>Quantified results</span><strong>{summary.quantified_results ?? 0}</strong></article>
-        <article><CheckCircle2 size={20} /><span>Confirmed receipts</span><strong>{summary.confirmed_receipts ?? 0}</strong></article>
+        <article>
+          <ReceiptText size={20} />
+          <span>Total proof analyzed</span>
+          <strong>{totalProofRecords}</strong>
+          <small>{summary.accomplishments ?? 0} accomplishments + {summary.impact_receipts ?? 0} receipts</small>
+        </article>
+        <article>
+          <Sparkles size={20} />
+          <span>Distinct demonstrations</span>
+          <strong>{distinctDemonstrations}</strong>
+          <small>Linked receipts enrich proof without double-counting work</small>
+        </article>
+        <article>
+          <TrendingUp size={20} />
+          <span>Quantified coverage</span>
+          <strong>{summary.quantified_coverage_percent ?? 0}%</strong>
+          <small>{summary.quantified_results ?? 0} measurable demonstration{summary.quantified_results === 1 ? "" : "s"}</small>
+        </article>
+        <article>
+          <CheckCircle2 size={20} />
+          <span>Evidence-backed</span>
+          <strong>{summary.evidence_coverage_percent ?? 0}%</strong>
+          <small>{summary.confirmed_demonstrations ?? 0} confirmed demonstration{summary.confirmed_demonstrations === 1 ? "" : "s"}</small>
+        </article>
       </section>
 
       <section className="ci-grid">
@@ -208,11 +242,11 @@ function CareerIntelligencePage() {
                     <div className="ci-bar"><span style={{ width: `${Math.max(6, skill.evidence_points)}%` }} /></div>
                     <div className="ci-proof-facts">
                       <span>{skill.demonstrations} distinct demonstrations</span>
-                      <span>{skill.accomplishments ?? 0} accomplishments</span>
+                      <span>{titleCase(skill.support_level || "basic")} proof support</span>
+                      <span>{skill.quantified_examples ?? 0} quantified</span>
+                      <span>{skill.evidence_backed_demonstrations ?? 0} evidence-backed</span>
+                      <span>{skill.confirmed_demonstrations ?? 0} confirmed</span>
                       <span>{skill.impact_receipts ?? 0} receipts</span>
-                      <span>{skill.quantified_examples} quantified</span>
-                      <span>{skill.evidence_items} evidence</span>
-                      <span>{skill.confirmations} confirmed</span>
                     </div>
                   </div>
                 ))}
@@ -238,19 +272,34 @@ function CareerIntelligencePage() {
           </article>
 
           <article className="ci-panel">
-            <div className="ci-panel-heading"><div><span>Career breadth</span><h2>Top career areas</h2></div><Target size={22} /></div>
-            {categories.length ? <div className="ci-categories">{categories.map(({ category, count }) => <div key={category}><span>{category}</span><strong>{count}</strong></div>)}</div> : <p className="ci-muted">Career areas will appear as you capture accomplishments.</p>}
+            <div className="ci-panel-heading"><div><span>Career breadth</span><h2>Career themes</h2></div><Target size={22} /></div>
+            {themeRows.length ? (
+              <div className="ci-categories">
+                {themeRows.slice(0, 5).map((theme) => (
+                  <div key={theme.theme}>
+                    <span>{theme.theme}</span>
+                    <strong>{theme.demonstrations ?? 0}</strong>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <p className="ci-muted">Career themes will appear as you capture accomplishments.</p>
+            )}
           </article>
         </aside>
       </section>
 
       <section className="ci-panel ci-gaps-panel">
         <div className="ci-panel-heading"><div><span>Evidence gaps</span><h2>Ways to strengthen your case</h2></div><BrainCircuit size={22} /></div>
-        {gaps.length ? <div className="ci-gap-grid">{gaps.map((gap) => <article key={gap.type}><strong>{gap.title}</strong><p>{gap.detail}</p><span>{gap.action}</span></article>)}</div> : <div className="ci-healthy"><CheckCircle2 size={22} /><div><strong>Your proof foundation looks healthy.</strong><p>Keep capturing fresh accomplishments and evidence as your work changes.</p></div></div>}
+        {gaps.length ? (
+          <div className="ci-gap-grid">{gaps.map((gap) => <article key={gap.type}><strong>{gap.title}</strong><p>{gap.detail}</p><span>{gap.action}</span></article>)}</div>
+        ) : (
+          <div className="ci-healthy"><CheckCircle2 size={22} /><div><strong>Your proof foundation looks healthy.</strong><p>Keep capturing fresh accomplishments and evidence as your work changes.</p></div></div>
+        )}
       </section>
 
       <p className="ci-methodology">
-        Career Intelligence analyzes every saved accomplishment and Impact Receipt. Compound pasted skill lists are normalized into individual skills, linked receipts enrich the same underlying demonstration instead of double-counting it, and recency only breaks close ranking ties rather than adding proof strength.
+        Career Intelligence separates durable signals from proof quality and recency. Repetition is measured across distinct work demonstrations; linked Impact Receipts enrich the original work instead of creating fake repetition, attachment volume cannot inflate breadth, and creating a receipt later does not make old work look newly demonstrated.
       </p>
     </main>
   );


### PR DESCRIPTION
## Why
Career Intelligence v2 fixed the biggest ranking issue: the newest accomplishment no longer becomes the user's entire career signal. This follow-up makes the engine harder to game and more explainable by separating **career durability**, **proof quality**, **recency**, and **career themes**.

## Engine changes
- Introduces `career-intelligence-v3`.
- Ranks durable repeated signals ahead of one-off skills, even when a singleton has a deeply documented receipt.
- Separates skill durability (`emerging`, `established`, `strong`) from proof support (`basic`, `supported`, `well-supported`).
- Scores evidence breadth across distinct work demonstrations instead of raw attachment volume.
- Prevents several files attached to one receipt from masquerading as several distinct demonstrations.
- Keeps linked Impact Receipts de-duplicated against their source accomplishment.
- Uses the source accomplishment date for linked receipts, so documenting old work today does not make the old work look newly demonstrated.
- Expands deterministic quantified-result detection for more engineering units and work volumes.

## Combined career model
- Adds category-level `career_themes` with durability, support, top skills, quantified breadth, evidence breadth, confirmation breadth, and recency.
- Makes durable career themes eligible to headline the combined career profile before individual skills.
- Tracks recent emerging skills separately from durable strengths.
- Adds evidence-data maturity (`early`, `developing`, `well-supported`) without introducing a hiring or promotion readiness prediction.

## Coverage + recommendations
- Adds distinct-demonstration counts and coverage percentages for quantified outcomes, supporting evidence, confirmations, and Impact Receipts.
- Evidence gaps now trigger on weak coverage instead of only all-or-nothing zero counts.
- Recommendations adapt to the strongest repeated signal: add measurable impact, structured evidence, or confirmation only where that layer is actually missing.

## Verification
- Extends Career Intelligence invariants for v3 counts, coverage percentages, signal/support labels, proof points, and profile maturity.
- Verification telemetry now records the engine's actual methodology/schema version instead of the old hard-coded v1 metadata.

## UI
- Shows saved proof records versus distinct underlying work demonstrations.
- Shows quantified and evidence-backed coverage instead of raw receipt counts in the top metrics.
- Skill cards now distinguish durability from proof support.
- Replaces the old career-area count list with Career Themes when v3 data is available.
- Explicitly explains that linked receipts, attachment volume, and late documentation do not create fake repetition or fake recency.

## Regression coverage
- compound skill splitting including newline-delimited tags
- linked receipt de-duplication
- old accomplishment + newly created receipt remains non-recent
- attachment volume cannot inflate breadth score
- established repeated skill ranks ahead of a highly documented singleton
- coverage percentages reconcile to distinct demonstrations
- combined career profile and career-theme synthesis
- proof-gap behavior remains non-predictive
