### PR TITLE
Add temporal trajectory to Career Intelligence v4

### DIFF
--- a/backend/app/career_intelligence_routes.py
+++ b/backend/app/career_intelligence_routes.py
@@ -4,6 +4,10 @@ from fastapi import APIRouter, Depends, HTTPException
 from app.ai.verification import record_verification_event
 from app.auth import get_current_user
 from app.career_intelligence import build_career_intelligence
+from app.career_intelligence_trajectory import (
+    TRAJECTORY_LABELS,
+    enrich_career_trajectory,
+)
 from app.database import entries_collection, impact_receipts_collection
 from app.education_intelligence import APPLICATION_PROFILES, build_application_intelligence
 
@@ -83,6 +87,15 @@ def _verify_intelligence(result: dict, entries: list[dict], receipts: list[dict]
         if skill.get("support_level") not in valid_support_levels:
             violations.append("skill_support_level_invalid")
             break
+        if "trajectory" in skill and skill.get("trajectory") not in TRAJECTORY_LABELS:
+            violations.append("skill_trajectory_invalid")
+            break
+        if int(skill.get("recent_demonstrations") or 0) > demonstrations:
+            violations.append("skill_recent_demonstration_overcount")
+            break
+        if int(skill.get("historical_demonstrations") or 0) > demonstrations:
+            violations.append("skill_historical_demonstration_overcount")
+            break
 
     profile = result.get("career_profile") or {}
     if profile.get("maturity") not in {"early", "developing", "well-supported"}:
@@ -125,11 +138,12 @@ def _verify_application_intelligence(result: dict, entries: list[dict], receipts
 
 
 def _load_intelligence(current_user: dict) -> dict:
-    """Build and verify Career Intelligence from the user's own proof."""
+    """Build, enrich, and verify Career Intelligence from the user's own proof."""
     user_id = str(current_user["_id"])
     entries = list(entries_collection.find({"user_id": user_id}))
     receipts = list(impact_receipts_collection.find({"user_id": user_id}))
     result = build_career_intelligence(entries, receipts)
+    result = enrich_career_trajectory(result, entries, receipts)
     violations = _verify_intelligence(result, entries, receipts)
     methodology = result.get("methodology") or {}
     version = str(methodology.get("version") or "career-intelligence-unknown")

--- a/backend/app/career_intelligence_trajectory.py
+++ b/backend/app/career_intelligence_trajectory.py
@@ -1,0 +1,222 @@
+"""Temporal trajectory enrichment for deterministic Career Intelligence."""
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import datetime, timezone
+from typing import Iterable
+
+from app.career_intelligence import (
+    RECENT_WINDOW_DAYS,
+    _clean_text,
+    _document_datetime,
+    _document_id,
+    _normalized_skills,
+)
+
+TRAJECTORY_LABELS = {
+    "current-core",
+    "active",
+    "historical-core",
+    "recent-emerging",
+    "historical",
+    "undated",
+}
+
+
+def _proof_key(document: dict, *, kind: str, index: int) -> str:
+    """Mirror the base engine's stable proof-key construction."""
+    document_id = _document_id(document)
+    if document_id:
+        return f"{kind}:{document_id}"
+    return f"{kind}-index:{index}"
+
+
+def _trajectory_label(*, demonstrations: int, recent: int, dated: int) -> str:
+    """Classify temporal position without changing proof-strength scoring."""
+    if dated == 0:
+        return "undated"
+    if demonstrations >= 2:
+        if recent >= 2:
+            return "current-core"
+        if recent == 1:
+            return "active"
+        return "historical-core"
+    if recent == 1:
+        return "recent-emerging"
+    return "historical"
+
+
+def _trajectory_reason(label: str, *, recent: int, historical: int) -> str:
+    """Return a concise explanation for one trajectory label."""
+    if label == "current-core":
+        return f"Repeated strength with {recent} recent distinct demonstrations."
+    if label == "active":
+        return "Repeated strength with at least one recent demonstration."
+    if label == "historical-core":
+        return f"Repeated strength supported by {historical} historical demonstrations, with no recent example in the current window."
+    if label == "recent-emerging":
+        return "Newly demonstrated skill; another distinct example would show whether it is becoming durable."
+    if label == "undated":
+        return "The proof is usable, but no reliable demonstration date is available for trajectory analysis."
+    return "A historical one-off demonstration; useful context, but not a current repeated signal."
+
+
+def enrich_career_trajectory(
+    result: dict,
+    entries: Iterable[dict],
+    receipts: Iterable[dict],
+    *,
+    now: datetime | None = None,
+) -> dict:
+    """Add current-vs-historical trajectory to an existing intelligence result.
+
+    This enrichment never changes evidence points or durability labels. It only
+    describes *when* the distinct demonstrations happened, so recency remains a
+    separate dimension rather than an invisible score bonus.
+    """
+    entries = list(entries)
+    receipts = list(receipts)
+    now = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+
+    entry_proof_keys: dict[str, str] = {}
+    entry_dates: dict[str, datetime | None] = {}
+    proof_dates: dict[str, datetime | None] = {}
+    skill_proofs: dict[str, set[str]] = defaultdict(set)
+
+    for index, entry in enumerate(entries):
+        proof_key = _proof_key(entry, kind="entry", index=index)
+        entry_id = _document_id(entry)
+        observed_at = _document_datetime(entry)
+        proof_dates[proof_key] = observed_at
+        if entry_id:
+            entry_proof_keys[entry_id] = proof_key
+            entry_dates[entry_id] = observed_at
+        for key, _display in _normalized_skills(entry.get("tags", []) or []):
+            skill_proofs[key].add(proof_key)
+
+    for index, receipt in enumerate(receipts):
+        source_entry_id = _clean_text(receipt.get("source_entry_id")) or None
+        linked_key = entry_proof_keys.get(source_entry_id or "")
+        proof_key = linked_key or _proof_key(receipt, kind="receipt", index=index)
+        if linked_key is not None and source_entry_id:
+            observed_at = entry_dates.get(source_entry_id) or _document_datetime(receipt)
+        else:
+            observed_at = _document_datetime(receipt)
+        proof_dates.setdefault(proof_key, observed_at)
+        for key, _display in _normalized_skills(receipt.get("skills", []) or []):
+            skill_proofs[key].add(proof_key)
+
+    current_core: list[str] = []
+    active: list[str] = []
+    historical_core: list[str] = []
+    recent_emerging: list[str] = []
+
+    for skill in result.get("skills") or []:
+        key = _clean_text(skill.get("skill")).casefold()
+        proofs = skill_proofs.get(key, set())
+        demonstrations = int(skill.get("demonstrations") or len(proofs))
+        dates = [proof_dates.get(proof_key) for proof_key in proofs]
+        dated = sum(1 for observed_at in dates if observed_at is not None)
+        recent = sum(
+            1
+            for observed_at in dates
+            if observed_at is not None
+            and 0 <= (now - observed_at).days <= RECENT_WINDOW_DAYS
+        )
+        historical = max(0, demonstrations - recent)
+        label = _trajectory_label(
+            demonstrations=demonstrations,
+            recent=recent,
+            dated=dated,
+        )
+
+        skill["trajectory"] = label
+        skill["recent_demonstrations"] = recent
+        skill["historical_demonstrations"] = historical
+        skill["trajectory_reason"] = _trajectory_reason(
+            label,
+            recent=recent,
+            historical=historical,
+        )
+
+        name = skill.get("skill")
+        if label == "current-core":
+            current_core.append(name)
+        elif label == "active":
+            active.append(name)
+        elif label == "historical-core":
+            historical_core.append(name)
+        elif label == "recent-emerging":
+            recent_emerging.append(name)
+
+    profile = result.setdefault("career_profile", {})
+    profile["current_core_skills"] = current_core[:4]
+    profile["active_skills"] = active[:4]
+    profile["historical_core_skills"] = historical_core[:4]
+    profile["recent_emerging_skills"] = recent_emerging[:4]
+
+    current_repeated = current_core + active
+    current_themes = [
+        theme.get("theme")
+        for theme in result.get("career_themes") or []
+        if theme.get("signal") in {"established", "strong"} and theme.get("recent")
+    ]
+    current_themes = [theme for theme in current_themes if theme]
+
+    if current_repeated:
+        trajectory_summary = (
+            f"Current repeated signals include {', '.join(current_repeated[:3])}."
+        )
+        if historical_core:
+            trajectory_summary += (
+                f" Historical strengths such as {', '.join(historical_core[:2])} "
+                "remain in the record without being presented as current momentum."
+            )
+    elif historical_core:
+        trajectory_summary = (
+            f"Your strongest repeated signals are currently historical: "
+            f"{', '.join(historical_core[:3])}. Add a fresh example only if those "
+            "skills still reflect your current work."
+        )
+    elif recent_emerging:
+        trajectory_summary = (
+            f"Recent growth is visible in {', '.join(recent_emerging[:3])}, but "
+            "those signals still need repetition before they become current core strengths."
+        )
+    else:
+        trajectory_summary = (
+            "There is not enough dated repeated proof yet to separate current core "
+            "strengths from historical ones."
+        )
+
+    profile["trajectory_summary"] = trajectory_summary
+    if current_themes:
+        profile["headline"] = " · ".join(current_themes[:2])
+    elif current_repeated:
+        profile["headline"] = " · ".join(current_repeated[:3])
+
+    base_summary = _clean_text(profile.get("summary"))
+    if base_summary and trajectory_summary not in base_summary:
+        profile["summary"] = f"{base_summary} {trajectory_summary}"
+    elif not base_summary:
+        profile["summary"] = trajectory_summary
+
+    summary = result.setdefault("summary", {})
+    summary["current_core_skill_count"] = len(current_core)
+    summary["active_skill_count"] = len(active)
+    summary["historical_core_skill_count"] = len(historical_core)
+    summary["recent_emerging_skill_count"] = len(recent_emerging)
+
+    methodology = result.setdefault("methodology", {})
+    methodology["version"] = "career-intelligence-v4"
+    methodology["schema_version"] = "career-intelligence-v4"
+    methodology["trajectory_window_days"] = RECENT_WINDOW_DAYS
+    methodology["description"] = (
+        "Signals summarize user-owned proof. Durability, proof support, and temporal "
+        "trajectory are separate dimensions. Current-core, active, historical-core, "
+        "and recent-emerging labels describe when distinct demonstrations occurred "
+        "without adding recency points. Linked receipts inherit their source work date, "
+        "so late documentation cannot create fake current momentum. BragStack does not "
+        "predict hiring or promotion outcomes."
+    )
+    return result

--- a/backend/app/career_intelligence_trajectory.py
+++ b/backend/app/career_intelligence_trajectory.py
@@ -53,7 +53,7 @@ def _trajectory_reason(label: str, *, recent: int, historical: int) -> str:
     if label == "active":
         return "Repeated strength with at least one recent demonstration."
     if label == "historical-core":
-        return f"Repeated strength supported by {historical} historical demonstrations, with no recent example in the current window."
+        return f"Repeated strength supported by {historical} dated historical demonstrations, with no recent example in the current window."
     if label == "recent-emerging":
         return "Newly demonstrated skill; another distinct example would show whether it is becoming durable."
     if label == "undated":
@@ -123,7 +123,12 @@ def enrich_career_trajectory(
             if observed_at is not None
             and 0 <= (now - observed_at).days <= RECENT_WINDOW_DAYS
         )
-        historical = max(0, demonstrations - recent)
+        historical = sum(
+            1
+            for observed_at in dates
+            if observed_at is not None and (now - observed_at).days > RECENT_WINDOW_DAYS
+        )
+        undated = max(0, demonstrations - dated)
         label = _trajectory_label(
             demonstrations=demonstrations,
             recent=recent,
@@ -133,6 +138,7 @@ def enrich_career_trajectory(
         skill["trajectory"] = label
         skill["recent_demonstrations"] = recent
         skill["historical_demonstrations"] = historical
+        skill["undated_demonstrations"] = undated
         skill["trajectory_reason"] = _trajectory_reason(
             label,
             recent=recent,

--- a/backend/tests/test_career_intelligence_trajectory.py
+++ b/backend/tests/test_career_intelligence_trajectory.py
@@ -1,0 +1,175 @@
+"""Regression tests for Career Intelligence temporal trajectory."""
+from datetime import datetime, timezone
+
+from app.career_intelligence import build_career_intelligence
+from app.career_intelligence_trajectory import enrich_career_trajectory
+
+
+def _build(entries, receipts, *, now):
+    result = build_career_intelligence(entries, receipts, now=now)
+    return enrich_career_trajectory(result, entries, receipts, now=now)
+
+
+def test_trajectory_separates_current_core_historical_core_and_recent_growth():
+    now = datetime(2026, 9, 5, tzinfo=timezone.utc)
+    entries = [
+        {
+            "_id": "linux-old-1",
+            "category": "Systems",
+            "tags": ["Linux"],
+            "impact": "Maintained production systems",
+            "entry_date": "2024-01-01",
+        },
+        {
+            "_id": "linux-old-2",
+            "category": "Systems",
+            "tags": ["Linux"],
+            "impact": "Resolved server incidents",
+            "entry_date": "2024-03-01",
+        },
+        {
+            "_id": "docker-recent-1",
+            "category": "Platform Engineering",
+            "tags": ["Docker"],
+            "impact": "Improved container reliability",
+            "entry_date": "2026-07-01",
+        },
+        {
+            "_id": "docker-recent-2",
+            "category": "Platform Engineering",
+            "tags": ["Docker"],
+            "impact": "Automated container troubleshooting",
+            "entry_date": "2026-08-15",
+        },
+        {
+            "_id": "pi-recent",
+            "category": "Edge Computing",
+            "tags": ["Raspberry Pi"],
+            "impact": "Built a portable field device",
+            "entry_date": "2026-09-01",
+        },
+    ]
+
+    result = _build(entries, [], now=now)
+
+    linux = next(skill for skill in result["skills"] if skill["skill"] == "Linux")
+    docker = next(skill for skill in result["skills"] if skill["skill"] == "Docker")
+    pi = next(skill for skill in result["skills"] if skill["skill"] == "Raspberry Pi")
+
+    assert linux["trajectory"] == "historical-core"
+    assert linux["recent_demonstrations"] == 0
+    assert linux["historical_demonstrations"] == 2
+    assert docker["trajectory"] == "current-core"
+    assert docker["recent_demonstrations"] == 2
+    assert pi["trajectory"] == "recent-emerging"
+
+    profile = result["career_profile"]
+    assert profile["current_core_skills"] == ["Docker"]
+    assert profile["historical_core_skills"] == ["Linux"]
+    assert profile["recent_emerging_skills"] == ["Raspberry Pi"]
+    assert profile["headline"] == "Platform Engineering"
+    assert "Current repeated signals include Docker" in profile["summary"]
+    assert result["methodology"]["version"] == "career-intelligence-v4"
+
+
+def test_one_recent_and_one_old_example_is_active_not_artificially_strong():
+    now = datetime(2026, 9, 5, tzinfo=timezone.utc)
+    entries = [
+        {
+            "category": "Developer Tooling",
+            "tags": ["Python"],
+            "impact": "Built support automation",
+            "entry_date": "2024-01-01",
+        },
+        {
+            "category": "Developer Tooling",
+            "tags": ["Python"],
+            "impact": "Built a new internal tool",
+            "entry_date": "2026-08-01",
+        },
+    ]
+
+    result = _build(entries, [], now=now)
+    python = result["skills"][0]
+
+    assert python["signal"] == "established"
+    assert python["trajectory"] == "active"
+    assert python["recent_demonstrations"] == 1
+    assert python["historical_demonstrations"] == 1
+    assert result["summary"]["active_skill_count"] == 1
+
+
+def test_linked_receipt_does_not_turn_historical_work_into_current_momentum():
+    now = datetime(2026, 9, 5, tzinfo=timezone.utc)
+    entries = [
+        {
+            "_id": "old-entry",
+            "category": "Operations",
+            "tags": ["Troubleshooting"],
+            "impact": "Resolved recurring incidents",
+            "entry_date": "2024-01-01",
+        }
+    ]
+    receipts = [
+        {
+            "_id": "new-receipt",
+            "source_entry_id": "old-entry",
+            "skills": ["Troubleshooting"],
+            "result": "Resolved recurring incidents",
+            "evidence": [{"title": "Historical incident report"}],
+            "created_at": "2026-09-05",
+        }
+    ]
+
+    result = _build(entries, receipts, now=now)
+    skill = result["skills"][0]
+
+    assert skill["demonstrations"] == 1
+    assert skill["trajectory"] == "historical"
+    assert skill["recent_demonstrations"] == 0
+    assert skill["historical_demonstrations"] == 1
+    assert result["summary"]["recent_emerging_skill_count"] == 0
+
+
+def test_undated_proof_is_not_mislabeled_historical():
+    now = datetime(2026, 9, 5, tzinfo=timezone.utc)
+    entries = [
+        {
+            "category": "Operations",
+            "tags": ["Networking"],
+            "impact": "Resolved connectivity issue",
+        }
+    ]
+
+    result = _build(entries, [], now=now)
+    networking = result["skills"][0]
+
+    assert networking["trajectory"] == "undated"
+    assert networking["recent_demonstrations"] == 0
+    assert networking["historical_demonstrations"] == 0
+    assert networking["undated_demonstrations"] == 1
+
+
+def test_trajectory_does_not_change_base_evidence_points():
+    now = datetime(2026, 9, 5, tzinfo=timezone.utc)
+    entries = [
+        {
+            "category": "Platform Engineering",
+            "tags": ["Docker"],
+            "impact": "Reduced deployment time by 20%",
+            "entry_date": "2026-08-01",
+        },
+        {
+            "category": "Platform Engineering",
+            "tags": ["Docker"],
+            "impact": "Improved recovery workflow",
+            "entry_date": "2026-08-15",
+        },
+    ]
+
+    base = build_career_intelligence(entries, [], now=now)
+    points_before = base["skills"][0]["evidence_points"]
+    enriched = enrich_career_trajectory(base, entries, [], now=now)
+
+    assert enriched["skills"][0]["evidence_points"] == points_before
+    assert enriched["skills"][0]["trajectory"] == "current-core"


### PR DESCRIPTION
## Why
Career Intelligence v3 separates durability from proof quality. This follow-up adds a third explicit dimension: **trajectory**. A repeated skill can be durable but historical, while a new skill can be recent but still emerging. The engine should explain both without turning recency into hidden score inflation.

## What changed
- Adds deterministic temporal trajectory enrichment after the v3 proof-quality model.
- Classifies skills as `current-core`, `active`, `historical-core`, `recent-emerging`, `historical`, or `undated`.
- Tracks recent, historical, and undated distinct demonstrations per skill.
- Keeps evidence points and durability labels unchanged; trajectory is descriptive, not another scoring bonus.
- Linked Impact Receipts inherit the source accomplishment date, so documenting old work today cannot create fake current momentum.
- Separates undated proof from historical proof instead of guessing.

## Combined profile
- Adds current-core, active, historical-core, and recent-emerging skill groups.
- Prefers durable **current** career themes for the combined headline when available.
- Adds a trajectory summary that distinguishes current repeated signals from historical strengths and new growth.
- Upgrades methodology metadata to `career-intelligence-v4` with a documented 180-day trajectory window.

## Verification
- Career Intelligence verification now validates trajectory labels and temporal demonstration counts.
- Existing non-predictive employment boundary remains unchanged.

## Regression coverage
- current core vs historical core vs recent emerging
- one recent + one historical example = active
- late-created linked receipt does not refresh old work
- undated work is not mislabeled historical
- trajectory enrichment cannot change evidence points
