### PR TITLE
Add Career Intelligence v5 canonical skill graph

### DIFF
--- a/backend/app/career_intelligence_graph.py
+++ b/backend/app/career_intelligence_graph.py
@@ -1,0 +1,575 @@
+"""Deterministic skill normalization and evidence-backed career graph enrichment."""
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import datetime, timezone
+from itertools import combinations
+from typing import Iterable
+
+from app.career_intelligence import (
+    RECENT_WINDOW_DAYS,
+    _clean_text,
+    _display_text,
+    _document_datetime,
+    _document_id,
+    _split_skill_values,
+    build_career_intelligence,
+)
+from app.career_intelligence_trajectory import enrich_career_trajectory
+
+TAXONOMY_VERSION = "career-skill-taxonomy-v1"
+GRAPH_VERSION = "career-graph-v1"
+MAX_GRAPH_SKILL_NODES = 16
+MAX_GRAPH_DOMAIN_NODES = 8
+MAX_GRAPH_COOCCURRENCE_EDGES = 24
+
+# Exact, curated aliases only. No fuzzy matching, embeddings, or model guesses.
+# Unknown skills remain exactly what the user entered after whitespace cleanup.
+_CANONICAL_ALIASES: dict[str, tuple[str, ...]] = {
+    "AWS": ("aws", "amazon web services"),
+    "Azure": ("azure", "microsoft azure", "ms azure"),
+    "Bash": ("bash", "bash scripting"),
+    "CI/CD": ("ci/cd", "cicd", "ci cd"),
+    "Docker": ("docker",),
+    "Docker Compose": ("docker compose", "docker-compose"),
+    "FastAPI": ("fastapi", "fast api"),
+    "Git": ("git",),
+    "GitHub": ("github", "git hub"),
+    "GitHub Actions": ("github actions", "github action"),
+    "GitLab": ("gitlab", "git lab"),
+    "GitLab CI": ("gitlab ci", "gitlab ci/cd", "gitlab cicd"),
+    "Google Cloud Platform": ("gcp", "google cloud", "google cloud platform"),
+    "JavaScript": ("javascript", "java script", "js"),
+    "Kubernetes": ("kubernetes", "k8s"),
+    "Linux": ("linux",),
+    "MongoDB": ("mongodb", "mongo db", "mongo"),
+    "Networking": ("networking",),
+    "Node.js": ("node.js", "nodejs", "node js"),
+    "PostgreSQL": ("postgresql", "postgres", "postgres sql"),
+    "Python": ("python",),
+    "Raspberry Pi": ("raspberry pi", "raspberrypi"),
+    "React": ("react", "react.js", "reactjs", "react js"),
+    "SSH": ("ssh", "secure shell"),
+    "SQL": ("sql",),
+    "Terraform": ("terraform",),
+    "TypeScript": ("typescript", "type script", "ts"),
+}
+
+_ALIAS_TO_CANONICAL = {
+    alias.casefold(): canonical
+    for canonical, aliases in _CANONICAL_ALIASES.items()
+    for alias in aliases
+}
+
+# Curated relationships are intentionally broad career domains, not claims that
+# one skill automatically proves mastery of the whole domain. Domain strength is
+# calculated only from the user's distinct demonstrations containing mapped skills.
+SKILL_DOMAINS: dict[str, tuple[str, ...]] = {
+    "Ansible": ("Configuration Management", "Platform Engineering"),
+    "AWS": ("Cloud Infrastructure", "Platform Engineering"),
+    "Azure": ("Cloud Infrastructure", "Platform Engineering"),
+    "Bash": ("Programming & Automation", "Systems Engineering"),
+    "CI/CD": ("Delivery Automation", "Developer Tooling"),
+    "DNS": ("Networking", "Systems Engineering"),
+    "Docker": ("Containers", "Platform Engineering"),
+    "Docker Compose": ("Containers", "Platform Engineering"),
+    "Edge Computing": ("Edge Computing",),
+    "FastAPI": ("Backend Engineering", "Software Engineering"),
+    "Git": ("Developer Tooling", "Version Control"),
+    "GitHub": ("Developer Tooling", "Version Control"),
+    "GitHub Actions": ("Delivery Automation", "Developer Tooling"),
+    "GitLab": ("Developer Tooling", "Version Control"),
+    "GitLab CI": ("Delivery Automation", "Developer Tooling"),
+    "Google Cloud Platform": ("Cloud Infrastructure", "Platform Engineering"),
+    "Grafana": ("Observability", "Platform Engineering"),
+    "Incident Response": ("Reliability Engineering", "Technical Operations"),
+    "JavaScript": ("Software Engineering",),
+    "Kubernetes": ("Containers", "Platform Engineering"),
+    "Linux": ("Systems Engineering",),
+    "MongoDB": ("Databases",),
+    "Networking": ("Networking", "Systems Engineering"),
+    "Node.js": ("Backend Engineering", "Software Engineering"),
+    "Observability": ("Observability", "Platform Engineering"),
+    "Platform Engineering": ("Platform Engineering",),
+    "PostgreSQL": ("Databases",),
+    "Prometheus": ("Observability", "Platform Engineering"),
+    "Python": ("Programming & Automation", "Software Engineering"),
+    "Raspberry Pi": ("Edge Computing", "Systems Engineering"),
+    "React": ("Frontend Engineering", "Software Engineering"),
+    "Shell Scripting": ("Programming & Automation", "Systems Engineering"),
+    "Site Reliability Engineering": ("Reliability Engineering", "Platform Engineering"),
+    "SRE": ("Reliability Engineering", "Platform Engineering"),
+    "SSH": ("Systems Engineering", "Networking"),
+    "SQL": ("Databases",),
+    "Systems Administration": ("Systems Engineering", "Technical Operations"),
+    "Systems Engineering": ("Systems Engineering",),
+    "TCP/IP": ("Networking", "Systems Engineering"),
+    "Terraform": ("Infrastructure as Code", "Platform Engineering"),
+    "Troubleshooting": ("Technical Operations",),
+    "TypeScript": ("Software Engineering",),
+}
+
+
+def canonicalize_skill(value: str) -> str:
+    """Return a canonical skill only when an exact curated alias is known."""
+    display = _display_text(value).strip(" \t-–—")
+    if not display:
+        return ""
+    return _ALIAS_TO_CANONICAL.get(display.casefold(), display)
+
+
+def _skill_values(values) -> list[str]:
+    """Split, canonicalize, and de-duplicate one stored skill collection."""
+    if values is None:
+        return []
+    raw_values = [values] if isinstance(values, str) else values
+    try:
+        iterator = iter(raw_values)
+    except TypeError:
+        iterator = iter([raw_values])
+
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for raw_value in iterator:
+        for raw_skill in _split_skill_values(raw_value):
+            canonical = canonicalize_skill(raw_skill)
+            key = canonical.casefold()
+            if canonical and key not in seen:
+                normalized.append(canonical)
+                seen.add(key)
+    return normalized
+
+
+def normalize_career_documents(
+    entries: Iterable[dict], receipts: Iterable[dict]
+) -> tuple[list[dict], list[dict], list[dict]]:
+    """Normalize skill aliases without mutating the user's stored records."""
+    entries = list(entries)
+    receipts = list(receipts)
+    alias_state: dict[str, dict] = defaultdict(
+        lambda: {"canonical": "", "aliases": set(), "occurrences": 0}
+    )
+
+    def normalize_values(values) -> list[str]:
+        if values is None:
+            return []
+        raw_values = [values] if isinstance(values, str) else values
+        try:
+            iterator = iter(raw_values)
+        except TypeError:
+            iterator = iter([raw_values])
+
+        normalized: list[str] = []
+        seen: set[str] = set()
+        for raw_value in iterator:
+            for raw_skill in _split_skill_values(raw_value):
+                raw_display = _display_text(raw_skill).strip(" \t-–—")
+                canonical = canonicalize_skill(raw_display)
+                if not canonical:
+                    continue
+                key = canonical.casefold()
+                state = alias_state[key]
+                state["canonical"] = canonical
+                state["aliases"].add(raw_display)
+                state["occurrences"] += 1
+                if key not in seen:
+                    normalized.append(canonical)
+                    seen.add(key)
+        return normalized
+
+    normalized_entries = [
+        {**entry, "tags": normalize_values(entry.get("tags", []) or [])}
+        for entry in entries
+    ]
+    normalized_receipts = [
+        {**receipt, "skills": normalize_values(receipt.get("skills", []) or [])}
+        for receipt in receipts
+    ]
+
+    normalization = []
+    for key in sorted(alias_state):
+        state = alias_state[key]
+        aliases = sorted(state["aliases"], key=str.casefold)
+        canonical = state["canonical"]
+        normalized_aliases = [
+            alias for alias in aliases if alias.casefold() != canonical.casefold()
+        ]
+        normalization.append(
+            {
+                "canonical": canonical,
+                "aliases_seen": aliases,
+                "normalized_aliases": normalized_aliases,
+                "occurrences": state["occurrences"],
+                "merged": bool(normalized_aliases) or len({a.casefold() for a in aliases}) > 1,
+            }
+        )
+    return normalized_entries, normalized_receipts, normalization
+
+
+def _proof_key(document: dict, *, kind: str, index: int) -> str:
+    """Build the same stable proof identity used by the base intelligence engine."""
+    document_id = _document_id(document)
+    if document_id:
+        return f"{kind}:{document_id}"
+    return f"{kind}-index:{index}"
+
+
+def _slug(value: str) -> str:
+    """Create a stable graph id component from a display label."""
+    chars = []
+    previous_dash = False
+    for char in value.casefold():
+        if char.isalnum():
+            chars.append(char)
+            previous_dash = False
+        elif not previous_dash:
+            chars.append("-")
+            previous_dash = True
+    return "".join(chars).strip("-") or "unknown"
+
+
+def _domain_trajectory(*, demonstrations: int, recent: int, dated: int) -> str:
+    """Classify domain trajectory using the same semantics as skill trajectory."""
+    if dated == 0:
+        return "undated"
+    if demonstrations >= 2:
+        if recent >= 2:
+            return "current-core"
+        if recent == 1:
+            return "active"
+        return "historical-core"
+    if recent == 1:
+        return "recent-emerging"
+    return "historical"
+
+
+def _domain_signal(demonstrations: int) -> str:
+    """Describe domain durability from distinct demonstrations only."""
+    if demonstrations >= 4:
+        return "strong"
+    if demonstrations >= 2:
+        return "established"
+    return "emerging"
+
+
+def enrich_career_graph(
+    result: dict,
+    entries: Iterable[dict],
+    receipts: Iterable[dict],
+    normalization: list[dict],
+    *,
+    now: datetime | None = None,
+) -> dict:
+    """Build a deterministic graph from canonical skills and distinct proof."""
+    entries = list(entries)
+    receipts = list(receipts)
+    now = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+
+    entry_proof_keys: dict[str, str] = {}
+    entry_dates: dict[str, datetime | None] = {}
+    proof_dates: dict[str, datetime | None] = {}
+    proof_skills: dict[str, set[str]] = defaultdict(set)
+    skill_labels: dict[str, str] = {}
+
+    for index, entry in enumerate(entries):
+        proof_key = _proof_key(entry, kind="entry", index=index)
+        entry_id = _document_id(entry)
+        observed_at = _document_datetime(entry)
+        proof_dates[proof_key] = observed_at
+        if entry_id:
+            entry_proof_keys[entry_id] = proof_key
+            entry_dates[entry_id] = observed_at
+        for skill in _skill_values(entry.get("tags", []) or []):
+            key = skill.casefold()
+            proof_skills[proof_key].add(key)
+            skill_labels[key] = skill
+
+    for index, receipt in enumerate(receipts):
+        source_entry_id = _clean_text(receipt.get("source_entry_id")) or None
+        linked_key = entry_proof_keys.get(source_entry_id or "")
+        proof_key = linked_key or _proof_key(receipt, kind="receipt", index=index)
+        if linked_key is not None and source_entry_id:
+            observed_at = entry_dates.get(source_entry_id) or _document_datetime(receipt)
+        else:
+            observed_at = _document_datetime(receipt)
+        proof_dates.setdefault(proof_key, observed_at)
+        for skill in _skill_values(receipt.get("skills", []) or []):
+            key = skill.casefold()
+            proof_skills[proof_key].add(key)
+            skill_labels[key] = skill
+
+    skill_rows = {
+        _clean_text(skill.get("skill")).casefold(): skill
+        for skill in result.get("skills") or []
+        if _clean_text(skill.get("skill"))
+    }
+    normalization_by_key = {
+        row["canonical"].casefold(): row for row in normalization if row.get("canonical")
+    }
+
+    selected_skill_rows = list(result.get("skills") or [])[:MAX_GRAPH_SKILL_NODES]
+    selected_skill_keys = {
+        _clean_text(skill.get("skill")).casefold()
+        for skill in selected_skill_rows
+        if _clean_text(skill.get("skill"))
+    }
+
+    domain_proofs: dict[str, set[str]] = defaultdict(set)
+    domain_skills: dict[str, set[str]] = defaultdict(set)
+    for proof_key, skill_keys in proof_skills.items():
+        for skill_key in skill_keys:
+            label = skill_labels.get(skill_key) or skill_rows.get(skill_key, {}).get("skill")
+            for domain in SKILL_DOMAINS.get(label, ()):
+                domain_proofs[domain].add(proof_key)
+                domain_skills[domain].add(skill_key)
+
+    domain_rows: list[dict] = []
+    for domain, proof_keys in domain_proofs.items():
+        demonstrations = len(proof_keys)
+        dates = [proof_dates.get(proof_key) for proof_key in proof_keys]
+        dated = sum(1 for observed_at in dates if observed_at is not None)
+        recent = sum(
+            1
+            for observed_at in dates
+            if observed_at is not None
+            and 0 <= (now - observed_at).days <= RECENT_WINDOW_DAYS
+        )
+        ranked_members = sorted(
+            domain_skills[domain],
+            key=lambda key: (
+                int(skill_rows.get(key, {}).get("demonstrations") or 0),
+                int(skill_rows.get(key, {}).get("evidence_points") or 0),
+                (skill_labels.get(key) or key).casefold(),
+            ),
+            reverse=True,
+        )
+        domain_rows.append(
+            {
+                "domain": domain,
+                "demonstrations": demonstrations,
+                "signal": _domain_signal(demonstrations),
+                "trajectory": _domain_trajectory(
+                    demonstrations=demonstrations,
+                    recent=recent,
+                    dated=dated,
+                ),
+                "recent_demonstrations": recent,
+                "skills": [
+                    skill_labels.get(key)
+                    or skill_rows.get(key, {}).get("skill")
+                    or key
+                    for key in ranked_members[:5]
+                ],
+            }
+        )
+
+    trajectory_rank = {
+        "current-core": 6,
+        "active": 5,
+        "recent-emerging": 4,
+        "historical-core": 3,
+        "historical": 2,
+        "undated": 1,
+    }
+    signal_rank = {"strong": 3, "established": 2, "emerging": 1}
+    domain_rows.sort(
+        key=lambda row: (
+            signal_rank[row["signal"]],
+            row["demonstrations"],
+            trajectory_rank[row["trajectory"]],
+            row["domain"].casefold(),
+        ),
+        reverse=True,
+    )
+    selected_domains = domain_rows[:MAX_GRAPH_DOMAIN_NODES]
+    selected_domain_names = {row["domain"] for row in selected_domains}
+
+    nodes: list[dict] = []
+    node_ids: dict[tuple[str, str], str] = {}
+    for skill in selected_skill_rows:
+        label = _clean_text(skill.get("skill"))
+        if not label:
+            continue
+        key = label.casefold()
+        node_id = f"skill:{_slug(label)}"
+        node_ids[("skill", key)] = node_id
+        normalization_row = normalization_by_key.get(key, {})
+        nodes.append(
+            {
+                "id": node_id,
+                "type": "skill",
+                "label": label,
+                "demonstrations": int(skill.get("demonstrations") or 0),
+                "signal": skill.get("signal"),
+                "support_level": skill.get("support_level"),
+                "trajectory": skill.get("trajectory"),
+                "aliases_seen": normalization_row.get("aliases_seen", [label]),
+            }
+        )
+
+    for domain in selected_domains:
+        label = domain["domain"]
+        node_id = f"domain:{_slug(label)}"
+        node_ids[("domain", label)] = node_id
+        nodes.append(
+            {
+                "id": node_id,
+                "type": "domain",
+                "label": label,
+                "demonstrations": domain["demonstrations"],
+                "signal": domain["signal"],
+                "trajectory": domain["trajectory"],
+                "skills": domain["skills"],
+            }
+        )
+
+    edges: list[dict] = []
+    for skill_key in selected_skill_keys:
+        label = skill_labels.get(skill_key) or skill_rows.get(skill_key, {}).get("skill")
+        source_id = node_ids.get(("skill", skill_key))
+        if not label or not source_id:
+            continue
+        skill_proof_count = int(skill_rows.get(skill_key, {}).get("demonstrations") or 0)
+        for domain in SKILL_DOMAINS.get(label, ()):
+            if domain not in selected_domain_names:
+                continue
+            target_id = node_ids.get(("domain", domain))
+            if target_id:
+                edges.append(
+                    {
+                        "source": source_id,
+                        "target": target_id,
+                        "relationship": "supports-domain",
+                        "demonstrations": skill_proof_count,
+                    }
+                )
+
+    cooccurrence_counts: dict[tuple[str, str], int] = defaultdict(int)
+    for skill_keys in proof_skills.values():
+        selected = sorted(skill_keys & selected_skill_keys)
+        for left, right in combinations(selected, 2):
+            cooccurrence_counts[(left, right)] += 1
+
+    ranked_cooccurrences = sorted(
+        cooccurrence_counts.items(),
+        key=lambda item: (
+            item[1],
+            skill_labels.get(item[0][0], item[0][0]).casefold(),
+            skill_labels.get(item[0][1], item[0][1]).casefold(),
+        ),
+        reverse=True,
+    )[:MAX_GRAPH_COOCCURRENCE_EDGES]
+
+    for (left, right), demonstrations in ranked_cooccurrences:
+        source_id = node_ids.get(("skill", left))
+        target_id = node_ids.get(("skill", right))
+        if source_id and target_id:
+            edges.append(
+                {
+                    "source": source_id,
+                    "target": target_id,
+                    "relationship": "co-demonstrated",
+                    "demonstrations": demonstrations,
+                    "strength": "repeated" if demonstrations >= 2 else "observed",
+                }
+            )
+
+    merged_normalizations = [row for row in normalization if row.get("merged")]
+    current_domains = [
+        row
+        for row in selected_domains
+        if row["signal"] in {"established", "strong"}
+        and row["trajectory"] in {"current-core", "active"}
+    ]
+    durable_domains = [
+        row for row in selected_domains if row["signal"] in {"established", "strong"}
+    ]
+    profile_domains = current_domains or durable_domains or selected_domains[:3]
+
+    if profile_domains:
+        top_names = [row["domain"] for row in profile_domains[:3]]
+        graph_summary = (
+            f"Your proof clusters into evidence-backed domains including "
+            f"{', '.join(top_names)}. These domains are derived from canonical skills "
+            "and distinct work demonstrations, not title matching or hiring predictions."
+        )
+    else:
+        graph_summary = (
+            "Add more specifically tagged accomplishments to reveal evidence-backed "
+            "relationships between skills and broader career domains."
+        )
+
+    profile = result.setdefault("career_profile", {})
+    profile["evidence_domains"] = [row["domain"] for row in profile_domains[:4]]
+    profile["graph_summary"] = graph_summary
+
+    summary = result.setdefault("summary", {})
+    summary["canonical_skill_count"] = len(result.get("skills") or [])
+    summary["normalized_alias_group_count"] = len(merged_normalizations)
+    summary["career_domain_count"] = len(domain_rows)
+
+    result["career_graph"] = {
+        "version": GRAPH_VERSION,
+        "taxonomy_version": TAXONOMY_VERSION,
+        "normalization_strategy": "exact-curated-aliases-only",
+        "domains": selected_domains,
+        "normalizations": merged_normalizations,
+        "nodes": nodes,
+        "edges": edges,
+        "summary": {
+            "skill_nodes": sum(1 for node in nodes if node["type"] == "skill"),
+            "domain_nodes": sum(1 for node in nodes if node["type"] == "domain"),
+            "edges": len(edges),
+            "co_demonstration_edges": sum(
+                1 for edge in edges if edge["relationship"] == "co-demonstrated"
+            ),
+            "merged_alias_groups": len(merged_normalizations),
+        },
+    }
+
+    methodology = result.setdefault("methodology", {})
+    methodology["version"] = "career-intelligence-v5"
+    methodology["schema_version"] = "career-intelligence-v5"
+    methodology["taxonomy_version"] = TAXONOMY_VERSION
+    methodology["graph_version"] = GRAPH_VERSION
+    methodology["skill_normalization"] = "exact-curated-aliases-only"
+    methodology["description"] = (
+        "Signals summarize user-owned proof. BragStack separates durability, proof "
+        "support, and temporal trajectory; normalizes only exact curated skill aliases; "
+        "and builds a deterministic career graph from distinct demonstrations, "
+        "co-demonstrated skills, and curated skill-to-domain relationships. Unknown "
+        "skills are preserved rather than fuzzy-matched. Linked receipts remain tied "
+        "to the underlying work, and BragStack does not predict hiring or promotion outcomes."
+    )
+    return result
+
+
+def build_career_intelligence_v5(
+    entries: Iterable[dict],
+    receipts: Iterable[dict],
+    *,
+    now: datetime | None = None,
+) -> dict:
+    """Run the complete v5 deterministic Career Intelligence pipeline."""
+    now = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    normalized_entries, normalized_receipts, normalization = normalize_career_documents(
+        entries, receipts
+    )
+    result = build_career_intelligence(
+        normalized_entries,
+        normalized_receipts,
+        now=now,
+    )
+    result = enrich_career_trajectory(
+        result,
+        normalized_entries,
+        normalized_receipts,
+        now=now,
+    )
+    return enrich_career_graph(
+        result,
+        normalized_entries,
+        normalized_receipts,
+        normalization,
+        now=now,
+    )

--- a/backend/app/career_intelligence_routes.py
+++ b/backend/app/career_intelligence_routes.py
@@ -3,11 +3,8 @@ from fastapi import APIRouter, Depends, HTTPException
 
 from app.ai.verification import record_verification_event
 from app.auth import get_current_user
-from app.career_intelligence import build_career_intelligence
-from app.career_intelligence_trajectory import (
-    TRAJECTORY_LABELS,
-    enrich_career_trajectory,
-)
+from app.career_intelligence_graph import build_career_intelligence_v5
+from app.career_intelligence_trajectory import TRAJECTORY_LABELS
 from app.database import entries_collection, impact_receipts_collection
 from app.education_intelligence import APPLICATION_PROFILES, build_application_intelligence
 
@@ -107,6 +104,43 @@ def _verify_intelligence(result: dict, entries: list[dict], receipts: list[dict]
     if methodology.get("employment_decision") is not False:
         violations.append("employment_decision_enabled")
 
+    graph = result.get("career_graph") or {}
+    if version == "career-intelligence-v5":
+        if graph.get("version") != methodology.get("graph_version"):
+            violations.append("career_graph_version_mismatch")
+        if graph.get("taxonomy_version") != methodology.get("taxonomy_version"):
+            violations.append("career_graph_taxonomy_version_mismatch")
+        if graph.get("normalization_strategy") != "exact-curated-aliases-only":
+            violations.append("career_graph_normalization_strategy_invalid")
+        if summary.get("canonical_skill_count") != len(result.get("skills") or []):
+            violations.append("canonical_skill_count_mismatch")
+
+        nodes = graph.get("nodes") or []
+        node_ids = [str(node.get("id") or "") for node in nodes]
+        if any(not node_id for node_id in node_ids) or len(node_ids) != len(set(node_ids)):
+            violations.append("career_graph_node_ids_invalid")
+        valid_node_ids = set(node_ids)
+        for node in nodes:
+            if node.get("type") not in {"skill", "domain"}:
+                violations.append("career_graph_node_type_invalid")
+                break
+            demonstrations = int(node.get("demonstrations") or 0)
+            if demonstrations < 0 or demonstrations > distinct_demonstrations:
+                violations.append("career_graph_node_demonstration_count_invalid")
+                break
+
+        for edge in graph.get("edges") or []:
+            if edge.get("relationship") not in {"supports-domain", "co-demonstrated"}:
+                violations.append("career_graph_edge_relationship_invalid")
+                break
+            if edge.get("source") not in valid_node_ids or edge.get("target") not in valid_node_ids:
+                violations.append("career_graph_edge_endpoint_invalid")
+                break
+            demonstrations = int(edge.get("demonstrations") or 0)
+            if demonstrations < 0 or demonstrations > distinct_demonstrations:
+                violations.append("career_graph_edge_demonstration_count_invalid")
+                break
+
     return sorted(set(violations))
 
 
@@ -142,12 +176,12 @@ def _load_intelligence(current_user: dict) -> dict:
     user_id = str(current_user["_id"])
     entries = list(entries_collection.find({"user_id": user_id}))
     receipts = list(impact_receipts_collection.find({"user_id": user_id}))
-    result = build_career_intelligence(entries, receipts)
-    result = enrich_career_trajectory(result, entries, receipts)
+    result = build_career_intelligence_v5(entries, receipts)
     violations = _verify_intelligence(result, entries, receipts)
     methodology = result.get("methodology") or {}
     version = str(methodology.get("version") or "career-intelligence-unknown")
     schema_version = str(methodology.get("schema_version") or version)
+    graph = result.get("career_graph") or {}
     record_verification_event(
         feature="career_intelligence",
         task="analysis",
@@ -162,6 +196,8 @@ def _load_intelligence(current_user: dict) -> dict:
             len(result.get("skills") or [])
             + len(result.get("career_themes") or [])
             + len(result.get("recommended_actions") or [])
+            + len(graph.get("nodes") or [])
+            + len(graph.get("edges") or [])
         ),
         user_id=user_id,
     )

--- a/backend/tests/test_career_intelligence_graph.py
+++ b/backend/tests/test_career_intelligence_graph.py
@@ -1,0 +1,189 @@
+"""Regression tests for Career Intelligence v5 normalization and career graph."""
+from datetime import datetime, timezone
+
+from app.career_intelligence_graph import (
+    build_career_intelligence_v5,
+    canonicalize_skill,
+)
+from app.career_intelligence_routes import _verify_intelligence
+
+
+def test_curated_aliases_merge_before_durability_scoring():
+    """K8s and Kubernetes should become one repeated canonical skill."""
+    now = datetime(2026, 9, 5, tzinfo=timezone.utc)
+    entries = [
+        {
+            "_id": "e1",
+            "category": "Platform Engineering",
+            "tags": ["K8s", "Docker"],
+            "impact": "Deployed a service",
+            "entry_date": "2026-07-01",
+        },
+        {
+            "_id": "e2",
+            "category": "Platform Engineering",
+            "tags": ["Kubernetes", "Terraform"],
+            "impact": "Improved deployment reliability by 20%",
+            "entry_date": "2026-08-01",
+        },
+    ]
+
+    result = build_career_intelligence_v5(entries, [], now=now)
+
+    kubernetes = next(
+        skill for skill in result["skills"] if skill["skill"] == "Kubernetes"
+    )
+    assert kubernetes["demonstrations"] == 2
+    assert kubernetes["signal"] == "established"
+    assert not any(skill["skill"] == "K8s" for skill in result["skills"])
+    assert result["summary"]["normalized_alias_group_count"] == 1
+    assert result["methodology"]["version"] == "career-intelligence-v5"
+
+    normalizations = result["career_graph"]["normalizations"]
+    kubernetes_aliases = next(
+        row for row in normalizations if row["canonical"] == "Kubernetes"
+    )
+    assert set(kubernetes_aliases["aliases_seen"]) == {"K8s", "Kubernetes"}
+
+
+def test_unknown_skills_are_not_fuzzy_merged():
+    """The engine should preserve unknown near-matches rather than guess equivalence."""
+    result = build_career_intelligence_v5(
+        [
+            {
+                "_id": "e1",
+                "category": "Data",
+                "tags": ["Data Engineer"],
+                "impact": "Built a pipeline",
+                "entry_date": "2026-07-01",
+            },
+            {
+                "_id": "e2",
+                "category": "Data",
+                "tags": ["Data Engineering"],
+                "impact": "Documented a platform",
+                "entry_date": "2026-08-01",
+            },
+        ],
+        [],
+        now=datetime(2026, 9, 5, tzinfo=timezone.utc),
+    )
+
+    names = {skill["skill"] for skill in result["skills"]}
+    assert "Data Engineer" in names
+    assert "Data Engineering" in names
+    assert result["summary"]["normalized_alias_group_count"] == 0
+    assert result["career_graph"]["normalization_strategy"] == "exact-curated-aliases-only"
+
+
+def test_career_graph_builds_domains_from_distinct_demonstrations():
+    """Mapped canonical skills should form evidence-backed career domains."""
+    result = build_career_intelligence_v5(
+        [
+            {
+                "_id": "e1",
+                "category": "Operations",
+                "tags": ["Docker", "K8s", "Linux"],
+                "impact": "Shipped a containerized service",
+                "entry_date": "2026-07-01",
+            },
+            {
+                "_id": "e2",
+                "category": "Infrastructure",
+                "tags": ["Kubernetes", "Terraform", "Linux"],
+                "impact": "Automated infrastructure changes",
+                "entry_date": "2026-08-01",
+            },
+        ],
+        [],
+        now=datetime(2026, 9, 5, tzinfo=timezone.utc),
+    )
+
+    domains = {row["domain"]: row for row in result["career_graph"]["domains"]}
+    assert domains["Platform Engineering"]["demonstrations"] == 2
+    assert domains["Platform Engineering"]["signal"] == "established"
+    assert domains["Systems Engineering"]["demonstrations"] == 2
+    assert "Platform Engineering" in result["career_profile"]["evidence_domains"]
+    assert result["summary"]["career_domain_count"] >= 3
+
+
+def test_graph_co_demonstration_edges_use_underlying_work_not_receipt_volume():
+    """A linked receipt should enrich one skill relationship, not duplicate it."""
+    entries = [
+        {
+            "_id": "e1",
+            "category": "Platform Engineering",
+            "tags": ["K8s", "Docker"],
+            "impact": "Deployed a service",
+            "entry_date": "2026-07-01",
+        },
+        {
+            "_id": "e2",
+            "category": "Platform Engineering",
+            "tags": ["Kubernetes", "Docker"],
+            "impact": "Improved a deployment",
+            "entry_date": "2026-08-01",
+        },
+    ]
+    receipts = [
+        {
+            "_id": "r1",
+            "source_entry_id": "e1",
+            "skills": ["Kubernetes", "Docker"],
+            "evidence": [
+                {"title": "Runbook"},
+                {"title": "Dashboard"},
+                {"title": "Ticket"},
+            ],
+            "created_at": "2026-09-05",
+        }
+    ]
+
+    result = build_career_intelligence_v5(
+        entries,
+        receipts,
+        now=datetime(2026, 9, 5, tzinfo=timezone.utc),
+    )
+
+    nodes = {node["label"]: node["id"] for node in result["career_graph"]["nodes"]}
+    pair = {nodes["Kubernetes"], nodes["Docker"]}
+    edges = [
+        edge
+        for edge in result["career_graph"]["edges"]
+        if edge["relationship"] == "co-demonstrated"
+        and {edge["source"], edge["target"]} == pair
+    ]
+    assert len(edges) == 1
+    assert edges[0]["demonstrations"] == 2
+    assert edges[0]["strength"] == "repeated"
+
+
+def test_v5_graph_passes_route_invariants():
+    """The full v5 payload should satisfy the API's fail-closed verification."""
+    entries = [
+        {
+            "_id": "e1",
+            "category": "Platform Engineering",
+            "tags": ["Postgres", "Python", "Docker"],
+            "impact": "Reduced deployment time by 30%",
+            "entry_date": "2026-07-01",
+        },
+        {
+            "_id": "e2",
+            "category": "Platform Engineering",
+            "tags": ["PostgreSQL", "Python", "K8s"],
+            "impact": "Improved reliability",
+            "entry_date": "2026-08-01",
+        },
+    ]
+    receipts = []
+
+    result = build_career_intelligence_v5(
+        entries,
+        receipts,
+        now=datetime(2026, 9, 5, tzinfo=timezone.utc),
+    )
+
+    assert _verify_intelligence(result, entries, receipts) == []
+    assert canonicalize_skill("Postgres") == "PostgreSQL"
+    assert canonicalize_skill("PostgreSQL") == "PostgreSQL"


### PR DESCRIPTION
## Why
Career Intelligence v4 separates durability, proof support, and trajectory, but exact aliases such as `K8s` vs `Kubernetes` or `Postgres` vs `PostgreSQL` can still fragment the same underlying skill. v5 adds conservative normalization before scoring and builds an evidence-backed career graph from the user's own distinct demonstrations.

## Skill normalization
- Adds an exact curated alias taxonomy for common engineering aliases.
- Normalizes aliases **before** durability/proof scoring so `K8s` + `Kubernetes` become one repeated signal.
- Keeps unknown skills untouched instead of fuzzy matching or guessing equivalence.
- Preserves alias provenance in the graph so users can see what was merged.
- Continues splitting historical compound tag strings and de-duplicating a canonical skill within one proof record.

## Evidence-backed career graph
- Adds canonical skill nodes and broader evidence-domain nodes.
- Adds deterministic `supports-domain` relationships from a curated skill-to-domain map.
- Adds `co-demonstrated` skill relationships based only on distinct underlying work demonstrations.
- Linked Impact Receipts enrich their source accomplishment and do not duplicate graph relationships.
- Caps graph node/edge volume to keep payloads useful and inspectable.
- Adds profile-level `evidence_domains` and a graph summary without making hiring/promotion predictions.

## Methodology / safety
- Introduces `career-intelligence-v5`, `career-skill-taxonomy-v1`, and `career-graph-v1` metadata.
- Normalization strategy is explicitly `exact-curated-aliases-only`.
- No embeddings, fuzzy matching, inferred credentials, or employment outcome predictions.
- Route verification now fail-closes on malformed graph node IDs, relationships, endpoints, counts, or methodology mismatches.

## Regression coverage
- K8s + Kubernetes merge before durability scoring
- unknown near-matches remain separate
- evidence domains aggregate across distinct demonstrations
- linked receipts and attachment volume cannot inflate co-demonstration edges
- full v5 payload satisfies API invariants
