### PR TITLE
Add safeguarded Major Explorer to Education

### DIFF
--- a/backend/app/career_intelligence_routes.py
+++ b/backend/app/career_intelligence_routes.py
@@ -7,6 +7,12 @@ from app.career_intelligence_graph import build_career_intelligence_v5
 from app.career_intelligence_trajectory import TRAJECTORY_LABELS
 from app.database import entries_collection, impact_receipts_collection
 from app.education_intelligence import APPLICATION_PROFILES, build_application_intelligence
+from app.major_explorer import (
+    MAJOR_EXPLORER_VERSION,
+    MAJOR_PROFILES,
+    MAX_RECOMMENDATIONS,
+    build_major_explorer,
+)
 
 router = APIRouter(prefix="/career-intelligence", tags=["career-intelligence"])
 
@@ -171,6 +177,106 @@ def _verify_application_intelligence(result: dict, entries: list[dict], receipts
     return sorted(set(violations))
 
 
+def _verify_major_explorer(result: dict, entries: list[dict], receipts: list[dict]) -> list[str]:
+    """Fail closed if Major Explorer drifts into misleading decision language."""
+    violations: list[str] = []
+    summary = result.get("summary") or {}
+    methodology = result.get("methodology") or {}
+    disclaimer = result.get("disclaimer") or {}
+    recommendations = result.get("recommendations") or []
+    expected_total = len(entries) + len(receipts)
+
+    if int(summary.get("proof_records_analyzed") or 0) != expected_total:
+        violations.append("major_explorer_proof_count_mismatch")
+    distinct_demonstrations = int(summary.get("distinct_demonstrations") or 0)
+    if distinct_demonstrations < 0 or distinct_demonstrations > expected_total:
+        violations.append("major_explorer_demonstration_count_invalid")
+    if int(summary.get("recommendations_returned") or 0) != len(recommendations):
+        violations.append("major_explorer_recommendation_count_mismatch")
+    if len(recommendations) > MAX_RECOMMENDATIONS:
+        violations.append("major_explorer_recommendation_overcount")
+    if summary.get("evidence_mode") != "saved-proof-only":
+        violations.append("major_explorer_evidence_mode_invalid")
+    if summary.get("self_reported_interests_included") is not False:
+        violations.append("major_explorer_interest_source_misrepresented")
+
+    valid_fit_labels = {
+        "strong-exploration-candidate",
+        "worth-exploring",
+        "possible-direction",
+    }
+    valid_strength = {"limited", "developing", "supported"}
+    seen_major_ids: set[str] = set()
+    for recommendation in recommendations:
+        major_id = str(recommendation.get("major_id") or "")
+        if major_id not in MAJOR_PROFILES or major_id in seen_major_ids:
+            violations.append("major_explorer_major_id_invalid")
+            break
+        seen_major_ids.add(major_id)
+        if recommendation.get("fit_label") not in valid_fit_labels:
+            violations.append("major_explorer_fit_label_invalid")
+            break
+        if recommendation.get("evidence_strength") not in valid_strength:
+            violations.append("major_explorer_evidence_strength_invalid")
+            break
+        if int(recommendation.get("evidence_signal_count") or 0) <= 0:
+            violations.append("major_explorer_signal_count_invalid")
+            break
+        demonstrations = int(recommendation.get("evidence_demonstrations") or 0)
+        if demonstrations < 0 or demonstrations > distinct_demonstrations:
+            violations.append("major_explorer_evidence_demonstrations_invalid")
+            break
+        if not recommendation.get("why_it_appeared"):
+            violations.append("major_explorer_reason_missing")
+            break
+        if not recommendation.get("next_experiments"):
+            violations.append("major_explorer_experiment_missing")
+            break
+        if not str(recommendation.get("what_we_do_not_know") or "").strip():
+            violations.append("major_explorer_uncertainty_missing")
+            break
+        for forbidden in ("score", "fit_score", "fit_percent", "probability", "odds"):
+            if forbidden in recommendation:
+                violations.append("major_explorer_fake_precision_exposed")
+                break
+
+    if methodology.get("version") != MAJOR_EXPLORER_VERSION:
+        violations.append("major_explorer_version_invalid")
+    if methodology.get("career_intelligence_version") != "career-intelligence-v5":
+        violations.append("major_explorer_engine_version_invalid")
+    if methodology.get("ranking_meaning") != "evidence-alignment-for-exploration-only":
+        violations.append("major_explorer_ranking_meaning_invalid")
+
+    for field in (
+        "fit_percentage",
+        "best_major_claim",
+        "decision_maker",
+        "professional_advice",
+        "acceptance_prediction",
+        "scholarship_prediction",
+        "graduation_prediction",
+        "employment_prediction",
+        "salary_prediction",
+        "licensing_prediction",
+        "career_success_prediction",
+    ):
+        if methodology.get(field) is not False:
+            violations.append(f"major_explorer_{field}_enabled")
+
+    for field in (
+        "title",
+        "scope",
+        "not_advice",
+        "no_guarantees",
+        "verify_requirements",
+        "user_decision",
+    ):
+        if not str(disclaimer.get(field) or "").strip():
+            violations.append(f"major_explorer_disclaimer_{field}_missing")
+
+    return sorted(set(violations))
+
+
 def _load_intelligence(current_user: dict) -> dict:
     """Build, enrich, and verify Career Intelligence from the user's own proof."""
     user_id = str(current_user["_id"])
@@ -247,6 +353,38 @@ def _load_application_intelligence(current_user: dict, application_type: str) ->
     return result
 
 
+def _load_major_explorer(current_user: dict) -> dict:
+    """Build and verify evidence-backed major exploration guidance."""
+    user_id = str(current_user["_id"])
+    entries = list(entries_collection.find({"user_id": user_id}))
+    receipts = list(impact_receipts_collection.find({"user_id": user_id}))
+    result = build_major_explorer(entries, receipts)
+    violations = _verify_major_explorer(result, entries, receipts)
+    record_verification_event(
+        feature="education_intelligence",
+        task="major_explorer",
+        passed=not violations,
+        violation_codes=violations,
+        provider="deterministic",
+        model_id=MAJOR_EXPLORER_VERSION,
+        model_revision="deterministic",
+        schema_version=MAJOR_EXPLORER_VERSION,
+        source_count=len(entries) + len(receipts),
+        generated_item_count=len(result.get("recommendations") or []),
+        user_id=user_id,
+    )
+    if violations:
+        raise HTTPException(
+            status_code=500,
+            detail={
+                "code": "major_explorer_verification_failed",
+                "message": "BragStack withheld Major Explorer guidance because the result did not satisfy its exploration and safety rules.",
+                "violation_codes": violations,
+            },
+        )
+    return result
+
+
 @router.get("")
 def get_career_intelligence(current_user: dict = Depends(get_current_user)):
     """Return verified Career Intelligence."""
@@ -269,6 +407,12 @@ def get_career_intelligence_gaps(current_user: dict = Depends(get_current_user))
         "recommended_actions": intelligence["recommended_actions"],
         "methodology": intelligence["methodology"],
     }
+
+
+@router.get("/major-explorer")
+def get_major_explorer(current_user: dict = Depends(get_current_user)):
+    """Return verified, non-predictive major exploration guidance."""
+    return _load_major_explorer(current_user)
 
 
 @router.get("/applications/{application_type}")

--- a/backend/app/major_explorer.py
+++ b/backend/app/major_explorer.py
@@ -1,0 +1,564 @@
+"""Evidence-backed major exploration built on BragStack Career Intelligence v5.
+
+Major Explorer is intentionally a decision-support tool, not a decision-maker.
+It surfaces academic directions worth exploring from the user's own saved proof.
+It does not predict admission, scholarships, graduation, employment, salary,
+licensing, or career success, and it never claims that one major is objectively
+"best" for the user.
+"""
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Iterable
+
+from app.career_intelligence_graph import build_career_intelligence_v5
+
+MAJOR_EXPLORER_VERSION = "major-explorer-v1"
+MAX_RECOMMENDATIONS = 6
+
+# Profiles are deliberately broad and deterministic. They connect demonstrated
+# skills/domains to directions worth investigating; they are not occupational
+# aptitude tests and are not intended to reproduce institutional requirements.
+MAJOR_PROFILES: dict[str, dict] = {
+    "computer-science": {
+        "major": "Computer Science",
+        "domains": {
+            "Software Engineering": 4,
+            "Backend Engineering": 3,
+            "Frontend Engineering": 3,
+            "Programming & Automation": 3,
+            "Developer Tooling": 2,
+            "Databases": 2,
+        },
+        "skills": {
+            "Python": 4,
+            "JavaScript": 4,
+            "TypeScript": 3,
+            "Java": 4,
+            "C++": 4,
+            "React": 2,
+            "Node.js": 3,
+            "FastAPI": 2,
+            "SQL": 2,
+            "Git": 2,
+        },
+        "keywords": (
+            "programming",
+            "coding",
+            "algorithm",
+            "software",
+            "application",
+            "computer science",
+            "data structure",
+        ),
+        "exploration_question": "Do you enjoy both building software and learning the theory behind how computation works?",
+        "next_experiments": (
+            "Try one introductory algorithms or data-structures exercise and notice whether the theory is engaging.",
+            "Build a small software project from scratch and compare how much you enjoy design, implementation, and debugging.",
+        ),
+        "unknowns": "Your saved proof cannot tell us by itself how much you would enjoy theory-heavy computing coursework, discrete math, or a particular program's curriculum.",
+    },
+    "information-systems": {
+        "major": "Information Systems",
+        "domains": {
+            "Technical Operations": 4,
+            "Systems Engineering": 4,
+            "Developer Tooling": 3,
+            "Databases": 3,
+            "Platform Engineering": 3,
+            "Software Engineering": 2,
+        },
+        "skills": {
+            "SQL": 4,
+            "Linux": 3,
+            "Networking": 3,
+            "Python": 2,
+            "Git": 2,
+            "PostgreSQL": 3,
+            "MongoDB": 2,
+            "Troubleshooting": 4,
+        },
+        "keywords": (
+            "information systems",
+            "business system",
+            "workflow",
+            "process",
+            "operations",
+            "database",
+            "technology",
+        ),
+        "exploration_question": "Do you like using technology to improve how organizations, teams, and real-world processes work?",
+        "next_experiments": (
+            "Compare an introductory Information Systems course with a Computer Science course and note which problems feel more natural.",
+            "Model a real workflow or small database and decide whether connecting people, process, and technology is satisfying.",
+        ),
+        "unknowns": "Your evidence does not establish whether you prefer business-process coursework, technical depth, or the specific balance offered by a school's Information Systems program.",
+    },
+    "computer-engineering": {
+        "major": "Computer Engineering",
+        "domains": {
+            "Edge Computing": 4,
+            "Systems Engineering": 4,
+            "Software Engineering": 2,
+            "Networking": 2,
+            "Programming & Automation": 2,
+        },
+        "skills": {
+            "Raspberry Pi": 5,
+            "C": 4,
+            "C++": 4,
+            "Linux": 3,
+            "Networking": 2,
+            "Python": 2,
+            "SSH": 2,
+        },
+        "keywords": (
+            "embedded",
+            "microcontroller",
+            "hardware",
+            "raspberry pi",
+            "computer engineering",
+            "electronics",
+            "firmware",
+        ),
+        "exploration_question": "Do you enjoy problems where software meets physical hardware and electronics?",
+        "next_experiments": (
+            "Try a small embedded or microcontroller project that requires both code and basic electronics.",
+            "Preview an introductory digital-logic or circuits lesson and compare it with a pure programming task.",
+        ),
+        "unknowns": "Your saved proof cannot determine whether you would enjoy calculus, circuits, digital logic, or the hardware-heavy parts of a Computer Engineering curriculum.",
+    },
+    "electrical-engineering": {
+        "major": "Electrical Engineering",
+        "domains": {
+            "Edge Computing": 2,
+            "Systems Engineering": 2,
+            "Networking": 2,
+        },
+        "skills": {
+            "Raspberry Pi": 2,
+            "C": 2,
+            "C++": 2,
+        },
+        "keywords": (
+            "circuit",
+            "electronics",
+            "electrical",
+            "signal",
+            "sensor",
+            "power",
+            "microcontroller",
+        ),
+        "exploration_question": "Are you curious about circuits, signals, electronics, and how physical systems are designed?",
+        "next_experiments": (
+            "Complete a beginner circuit or sensor lab and note whether the physical troubleshooting is enjoyable.",
+            "Review the math and physics prerequisites for one real Electrical Engineering program before treating this as a strong direction.",
+        ),
+        "unknowns": "Software or hardware tinkering alone is not enough to establish interest in Electrical Engineering's mathematics, physics, circuits, and signals coursework.",
+    },
+    "data-science-statistics": {
+        "major": "Data Science / Statistics",
+        "domains": {
+            "Databases": 3,
+            "Programming & Automation": 3,
+            "Software Engineering": 2,
+        },
+        "skills": {
+            "Python": 4,
+            "SQL": 4,
+            "PostgreSQL": 2,
+            "MongoDB": 2,
+            "R": 5,
+        },
+        "keywords": (
+            "statistics",
+            "statistical",
+            "data analysis",
+            "dataset",
+            "analytics",
+            "visualization",
+            "machine learning",
+            "probability",
+        ),
+        "exploration_question": "Do you enjoy turning messy data into explanations, models, or decisions?",
+        "next_experiments": (
+            "Analyze a public dataset and write down whether cleaning, exploring, and interpreting the data feels rewarding.",
+            "Try a short probability or statistics lesson and compare that experience with ordinary programming.",
+        ),
+        "unknowns": "Programming evidence alone does not show whether you enjoy probability, statistics, mathematical modeling, or careful interpretation of uncertainty.",
+    },
+    "mathematics": {
+        "major": "Mathematics",
+        "domains": {},
+        "skills": {},
+        "keywords": (
+            "mathematics",
+            "math",
+            "calculus",
+            "algebra",
+            "geometry",
+            "proof",
+            "theorem",
+            "olympiad",
+        ),
+        "exploration_question": "Do you enjoy abstract reasoning and understanding why a result is true, not only applying a formula?",
+        "next_experiments": (
+            "Try one proof-based math exercise rather than only a computational worksheet.",
+            "Look at the required courses for a real Mathematics major and identify which topics genuinely interest you.",
+        ),
+        "unknowns": "General quantitative ability or technical work does not establish that you would enjoy proof-based, abstract mathematics.",
+    },
+    "biology": {
+        "major": "Biology",
+        "domains": {},
+        "skills": {},
+        "keywords": (
+            "biology",
+            "biological",
+            "genetics",
+            "cell",
+            "ecology",
+            "anatomy",
+            "physiology",
+            "microbiology",
+            "lab",
+        ),
+        "exploration_question": "Do you enjoy investigating living systems through observation, experimentation, and scientific evidence?",
+        "next_experiments": (
+            "Try a hands-on biology lab, field activity, or small research exercise and reflect on which part you enjoy most.",
+            "Compare the course requirements for Biology with a neighboring field such as Chemistry, Neuroscience, or Environmental Science.",
+        ),
+        "unknowns": "A few science-related experiences cannot establish whether you would enjoy the breadth of laboratory, quantitative, and theory coursework in a Biology degree.",
+    },
+    "chemistry": {
+        "major": "Chemistry",
+        "domains": {},
+        "skills": {},
+        "keywords": (
+            "chemistry",
+            "chemical",
+            "molecule",
+            "reaction",
+            "organic chemistry",
+            "inorganic chemistry",
+            "lab",
+        ),
+        "exploration_question": "Do you enjoy explaining matter and reactions at the molecular level and working carefully in laboratory settings?",
+        "next_experiments": (
+            "Try an introductory chemistry lab or problem set and note whether the combination of math, models, and experimentation is appealing.",
+            "Review a real Chemistry curriculum, including organic and physical chemistry, before deciding this direction fits your interests.",
+        ),
+        "unknowns": "General science interest is not enough to predict whether you would enjoy Chemistry's laboratory workload, mathematics, and molecular theory.",
+    },
+    "psychology": {
+        "major": "Psychology",
+        "domains": {},
+        "skills": {},
+        "keywords": (
+            "psychology",
+            "behavior",
+            "cognition",
+            "mental",
+            "human behavior",
+            "research participant",
+            "survey",
+        ),
+        "exploration_question": "Are you interested in studying human behavior and cognition using research methods rather than intuition alone?",
+        "next_experiments": (
+            "Read or summarize one peer-reviewed psychology study and see whether research design and evidence interest you.",
+            "Preview an introductory statistics requirement, because research methods are a meaningful part of many Psychology programs.",
+        ),
+        "unknowns": "Enjoying people-oriented work does not by itself show that you would enjoy experimental methods, statistics, or the scientific study of behavior.",
+    },
+    "business-administration": {
+        "major": "Business Administration",
+        "domains": {
+            "Technical Operations": 2,
+        },
+        "skills": {},
+        "keywords": (
+            "business",
+            "leadership",
+            "managed",
+            "management",
+            "entrepreneur",
+            "customer",
+            "marketing",
+            "operations",
+            "finance",
+            "sales",
+        ),
+        "exploration_question": "Do you enjoy coordinating people, resources, customers, and decisions to make an organization work better?",
+        "next_experiments": (
+            "Take responsibility for a small real project with a budget, timeline, customers, or team coordination and reflect on which part you enjoy.",
+            "Compare introductory management, accounting, marketing, and economics material before treating 'business' as one single kind of work.",
+        ),
+        "unknowns": "Leadership or project experience does not establish which business discipline—if any—you would prefer, and it does not predict business career outcomes.",
+    },
+    "communications": {
+        "major": "Communications",
+        "domains": {},
+        "skills": {},
+        "keywords": (
+            "communication",
+            "communications",
+            "presentation",
+            "presented",
+            "public speaking",
+            "media",
+            "journalism",
+            "writing",
+            "campaign",
+        ),
+        "exploration_question": "Do you enjoy understanding audiences and shaping clear messages through writing, speaking, media, or research?",
+        "next_experiments": (
+            "Create the same message for two different audiences and notice whether adapting tone, structure, and medium is interesting.",
+            "Compare coursework in Communications, Journalism, Public Relations, and Marketing because their emphases can differ substantially.",
+        ),
+        "unknowns": "Being a good presenter or writer does not determine whether you would enjoy communications theory, media research, or a specific professional pathway.",
+    },
+    "mechanical-engineering": {
+        "major": "Mechanical Engineering",
+        "domains": {},
+        "skills": {},
+        "keywords": (
+            "mechanical",
+            "cad",
+            "design",
+            "prototype",
+            "robotics",
+            "manufacturing",
+            "thermodynamics",
+            "mechanism",
+        ),
+        "exploration_question": "Do you enjoy designing, modeling, building, and testing physical systems and mechanisms?",
+        "next_experiments": (
+            "Try a simple CAD, mechanism, robotics, or physical prototyping project and reflect on whether iteration is enjoyable.",
+            "Preview calculus, physics, statics, and thermodynamics requirements from a real Mechanical Engineering program.",
+        ),
+        "unknowns": "General building or maker experience does not establish interest in the math, physics, mechanics, and analysis required by Mechanical Engineering.",
+    },
+}
+
+
+def _text(value) -> str:
+    return str(value or "").strip()
+
+
+def _entry_text(entry: dict) -> str:
+    values = [
+        entry.get("title"),
+        entry.get("category"),
+        entry.get("entry_type"),
+        entry.get("situation"),
+        entry.get("action"),
+        entry.get("impact"),
+        entry.get("lesson"),
+        *(entry.get("tags") or []),
+    ]
+    return " ".join(_text(value) for value in values if _text(value)).casefold()
+
+
+def _fit_label(*, points: int, distinct_signals: int, demonstrations: int) -> str:
+    """Return a qualitative exploration label without fake percentage precision."""
+    if points >= 24 and distinct_signals >= 3 and demonstrations >= 2:
+        return "strong-exploration-candidate"
+    if points >= 10 and distinct_signals >= 2:
+        return "worth-exploring"
+    return "possible-direction"
+
+
+def _evidence_strength(*, distinct_signals: int, demonstrations: int) -> str:
+    if distinct_signals >= 4 and demonstrations >= 3:
+        return "supported"
+    if distinct_signals >= 2 and demonstrations >= 2:
+        return "developing"
+    return "limited"
+
+
+def build_major_explorer(
+    entries: Iterable[dict],
+    receipts: Iterable[dict],
+) -> dict:
+    """Return major directions worth exploring from user-owned evidence only."""
+    entries = list(entries)
+    receipts = list(receipts)
+    career = build_career_intelligence_v5(entries, receipts)
+
+    skills = {
+        _text(row.get("skill")): row
+        for row in career.get("skills") or []
+        if _text(row.get("skill"))
+    }
+    domains = {
+        _text(row.get("domain")): row
+        for row in career.get("evidence_domains") or []
+        if _text(row.get("domain"))
+    }
+    entry_texts = [_entry_text(entry) for entry in entries]
+    distinct_demonstrations = int(
+        (career.get("summary") or {}).get("distinct_demonstrations") or 0
+    )
+
+    recommendations: list[dict] = []
+    for major_id, profile in MAJOR_PROFILES.items():
+        points = 0
+        evidence_reasons: list[str] = []
+        matched_signal_keys: set[str] = set()
+        supporting_demo_keys: set[str] = set()
+
+        for domain, weight in profile["domains"].items():
+            row = domains.get(domain)
+            if not row:
+                continue
+            demonstrations = int(row.get("demonstrations") or 0)
+            if demonstrations <= 0:
+                continue
+            points += weight * min(demonstrations, 4)
+            matched_signal_keys.add(f"domain:{domain.casefold()}")
+            evidence_reasons.append(
+                f"Your saved proof repeatedly connects to {domain} ({demonstrations} distinct demonstration{'s' if demonstrations != 1 else ''})."
+            )
+            supporting_demo_keys.add(f"domain:{domain.casefold()}:{demonstrations}")
+
+        for skill, weight in profile["skills"].items():
+            row = skills.get(skill)
+            if not row:
+                continue
+            demonstrations = int(row.get("demonstrations") or 0)
+            if demonstrations <= 0:
+                continue
+            points += weight * min(demonstrations, 4)
+            matched_signal_keys.add(f"skill:{skill.casefold()}")
+            evidence_reasons.append(
+                f"You have demonstrated {skill} across {demonstrations} distinct example{'s' if demonstrations != 1 else ''}."
+            )
+            supporting_demo_keys.add(f"skill:{skill.casefold()}:{demonstrations}")
+
+        keyword_entries: dict[str, int] = defaultdict(int)
+        for text in entry_texts:
+            for keyword in profile["keywords"]:
+                if keyword.casefold() in text:
+                    keyword_entries[keyword] += 1
+
+        if keyword_entries:
+            top_keywords = sorted(
+                keyword_entries.items(),
+                key=lambda item: (item[1], len(item[0]), item[0]),
+                reverse=True,
+            )[:3]
+            for keyword, count in top_keywords:
+                points += min(count, 3) * 2
+                matched_signal_keys.add(f"keyword:{keyword.casefold()}")
+            readable = ", ".join(keyword for keyword, _ in top_keywords)
+            evidence_reasons.append(
+                f"Your accomplishments include subject signals related to {readable}."
+            )
+
+        distinct_signals = len(matched_signal_keys)
+        if distinct_signals == 0:
+            continue
+
+        # We intentionally cap the demonstration count at the user's real number
+        # of distinct demonstrations. This is descriptive evidence breadth, not a
+        # prediction or aptitude score.
+        inferred_demo_breadth = min(
+            distinct_demonstrations,
+            max(
+                [
+                    int(domains.get(domain, {}).get("demonstrations") or 0)
+                    for domain in profile["domains"]
+                ]
+                + [
+                    int(skills.get(skill, {}).get("demonstrations") or 0)
+                    for skill in profile["skills"]
+                ]
+                + [max(keyword_entries.values()) if keyword_entries else 0]
+            ),
+        )
+
+        recommendations.append(
+            {
+                "major_id": major_id,
+                "major": profile["major"],
+                "fit_label": _fit_label(
+                    points=points,
+                    distinct_signals=distinct_signals,
+                    demonstrations=inferred_demo_breadth,
+                ),
+                "evidence_strength": _evidence_strength(
+                    distinct_signals=distinct_signals,
+                    demonstrations=inferred_demo_breadth,
+                ),
+                "evidence_signal_count": distinct_signals,
+                "evidence_demonstrations": inferred_demo_breadth,
+                "why_it_appeared": evidence_reasons[:4],
+                "exploration_question": profile["exploration_question"],
+                "next_experiments": list(profile["next_experiments"]),
+                "what_we_do_not_know": profile["unknowns"],
+                "_points": points,
+            }
+        )
+
+    label_rank = {
+        "strong-exploration-candidate": 3,
+        "worth-exploring": 2,
+        "possible-direction": 1,
+    }
+    recommendations.sort(
+        key=lambda item: (
+            label_rank[item["fit_label"]],
+            item["_points"],
+            item["evidence_signal_count"],
+            item["major"].casefold(),
+        ),
+        reverse=True,
+    )
+    for row in recommendations:
+        row.pop("_points", None)
+
+    disclaimer = {
+        "title": "Major Explorer is for exploration, not a decision about your future.",
+        "scope": "Recommendations reflect only the information and evidence currently available in BragStack and may be incomplete.",
+        "not_advice": "Major Explorer is an educational decision-support tool, not academic, career, financial, legal, licensing, or professional advice.",
+        "no_guarantees": "It does not predict or guarantee admission, scholarships, academic performance, graduation, employment, salary, licensing, or career success.",
+        "verify_requirements": "Verify prerequisites, accreditation, transfer rules, program availability, costs, graduation requirements, and licensing requirements with the relevant institution or authority.",
+        "user_decision": "You remain responsible for major and education decisions; consider a qualified academic or career advisor for consequential choices.",
+    }
+
+    summary = career.get("summary") or {}
+    selected = recommendations[:MAX_RECOMMENDATIONS]
+    return {
+        "summary": {
+            "proof_records_analyzed": int(summary.get("total_proof_records") or 0),
+            "distinct_demonstrations": distinct_demonstrations,
+            "canonical_skills": len(career.get("skills") or []),
+            "evidence_domains": len(career.get("evidence_domains") or []),
+            "recommendations_returned": len(selected),
+            "evidence_mode": "saved-proof-only",
+            "self_reported_interests_included": False,
+        },
+        "recommendations": selected,
+        "disclaimer": disclaimer,
+        "methodology": {
+            "version": MAJOR_EXPLORER_VERSION,
+            "deterministic": True,
+            "career_intelligence_version": (
+                (career.get("methodology") or {}).get("version")
+                or "career-intelligence-v5"
+            ),
+            "ranking_meaning": "evidence-alignment-for-exploration-only",
+            "fit_percentage": False,
+            "best_major_claim": False,
+            "decision_maker": False,
+            "professional_advice": False,
+            "acceptance_prediction": False,
+            "scholarship_prediction": False,
+            "graduation_prediction": False,
+            "employment_prediction": False,
+            "salary_prediction": False,
+            "licensing_prediction": False,
+            "career_success_prediction": False,
+            "description": "Uses deterministic mappings from the user's saved accomplishments, Impact Receipts, canonical skills, and evidence domains to surface majors worth exploring. It does not infer aptitude or predict outcomes.",
+        },
+    }

--- a/backend/app/major_explorer.py
+++ b/backend/app/major_explorer.py
@@ -384,6 +384,7 @@ def build_major_explorer(
     entries = list(entries)
     receipts = list(receipts)
     career = build_career_intelligence_v5(entries, receipts)
+    career_graph = career.get("career_graph") or {}
 
     skills = {
         _text(row.get("skill")): row
@@ -392,7 +393,7 @@ def build_major_explorer(
     }
     domains = {
         _text(row.get("domain")): row
-        for row in career.get("evidence_domains") or []
+        for row in career_graph.get("domains") or []
         if _text(row.get("domain"))
     }
     entry_texts = [_entry_text(entry) for entry in entries]
@@ -405,7 +406,6 @@ def build_major_explorer(
         points = 0
         evidence_reasons: list[str] = []
         matched_signal_keys: set[str] = set()
-        supporting_demo_keys: set[str] = set()
 
         for domain, weight in profile["domains"].items():
             row = domains.get(domain)
@@ -419,7 +419,6 @@ def build_major_explorer(
             evidence_reasons.append(
                 f"Your saved proof repeatedly connects to {domain} ({demonstrations} distinct demonstration{'s' if demonstrations != 1 else ''})."
             )
-            supporting_demo_keys.add(f"domain:{domain.casefold()}:{demonstrations}")
 
         for skill, weight in profile["skills"].items():
             row = skills.get(skill)
@@ -433,7 +432,6 @@ def build_major_explorer(
             evidence_reasons.append(
                 f"You have demonstrated {skill} across {demonstrations} distinct example{'s' if demonstrations != 1 else ''}."
             )
-            supporting_demo_keys.add(f"skill:{skill.casefold()}:{demonstrations}")
 
         keyword_entries: dict[str, int] = defaultdict(int)
         for text in entry_texts:
@@ -459,9 +457,8 @@ def build_major_explorer(
         if distinct_signals == 0:
             continue
 
-        # We intentionally cap the demonstration count at the user's real number
-        # of distinct demonstrations. This is descriptive evidence breadth, not a
-        # prediction or aptitude score.
+        # Keep breadth conservative: it can never exceed the user's real count of
+        # distinct demonstrations, and it is not exposed as a success probability.
         inferred_demo_breadth = min(
             distinct_demonstrations,
             max(
@@ -533,7 +530,7 @@ def build_major_explorer(
             "proof_records_analyzed": int(summary.get("total_proof_records") or 0),
             "distinct_demonstrations": distinct_demonstrations,
             "canonical_skills": len(career.get("skills") or []),
-            "evidence_domains": len(career.get("evidence_domains") or []),
+            "evidence_domains": len(career_graph.get("domains") or []),
             "recommendations_returned": len(selected),
             "evidence_mode": "saved-proof-only",
             "self_reported_interests_included": False,

--- a/backend/tests/test_major_explorer.py
+++ b/backend/tests/test_major_explorer.py
@@ -1,0 +1,144 @@
+from datetime import datetime, timezone
+
+from app.career_intelligence_routes import _verify_major_explorer
+from app.major_explorer import build_major_explorer
+
+
+def test_major_explorer_surfaces_directions_from_saved_proof_without_percentages():
+    entries = [
+        {
+            "_id": "e1",
+            "category": "Academic Project",
+            "entry_type": "College / University",
+            "title": "Linux automation project",
+            "action": "Built a Python service and automated Linux workflows",
+            "impact": "Reduced manual setup time by 40%",
+            "tags": ["Python", "Linux", "Git"],
+            "entry_date": "2026-01-15",
+        },
+        {
+            "_id": "e2",
+            "category": "Academic Project",
+            "entry_type": "College / University",
+            "title": "Database-backed web app",
+            "action": "Designed an application using PostgreSQL and FastAPI",
+            "impact": "Delivered a working class project",
+            "tags": ["Postgres", "FastAPI", "Python", "SQL"],
+            "entry_date": "2026-03-20",
+        },
+        {
+            "_id": "e3",
+            "category": "Learning / Certification",
+            "entry_type": "Learning / Certification",
+            "title": "Systems troubleshooting lab",
+            "action": "Troubleshot networking and Linux services",
+            "impact": "Completed the lab successfully",
+            "tags": ["Linux", "Networking", "Troubleshooting"],
+            "entry_date": "2026-05-10",
+        },
+    ]
+
+    result = build_major_explorer(entries, [])
+
+    names = [row["major"] for row in result["recommendations"]]
+    assert "Computer Science" in names
+    assert "Information Systems" in names
+    assert result["summary"]["proof_records_analyzed"] == 3
+    assert result["summary"]["self_reported_interests_included"] is False
+    assert result["methodology"]["fit_percentage"] is False
+    assert result["methodology"]["best_major_claim"] is False
+    assert all("score" not in row for row in result["recommendations"])
+    assert all("probability" not in row for row in result["recommendations"])
+
+
+def test_major_explorer_keeps_evidence_strength_separate_from_future_outcomes():
+    entries = [
+        {
+            "_id": "pi-1",
+            "category": "STEM / Competition",
+            "entry_type": "College / University",
+            "title": "Portable computing project",
+            "action": "Built and troubleshot a Raspberry Pi Linux system",
+            "impact": "Created a working prototype",
+            "tags": ["Raspberry Pi", "Linux", "Python", "SSH", "Networking"],
+            "entry_date": "2026-09-01",
+        }
+    ]
+
+    result = build_major_explorer(entries, [])
+    computer_engineering = next(
+        row for row in result["recommendations"] if row["major"] == "Computer Engineering"
+    )
+
+    assert computer_engineering["fit_label"] in {
+        "possible-direction",
+        "worth-exploring",
+        "strong-exploration-candidate",
+    }
+    assert computer_engineering["evidence_strength"] in {"limited", "developing", "supported"}
+    assert computer_engineering["what_we_do_not_know"]
+    assert len(computer_engineering["next_experiments"]) == 2
+    assert result["methodology"]["acceptance_prediction"] is False
+    assert result["methodology"]["employment_prediction"] is False
+    assert result["methodology"]["salary_prediction"] is False
+    assert result["methodology"]["licensing_prediction"] is False
+    assert result["methodology"]["career_success_prediction"] is False
+
+
+def test_major_explorer_disclaimer_is_part_of_the_payload():
+    result = build_major_explorer([], [])
+    disclaimer = result["disclaimer"]
+
+    assert "exploration" in disclaimer["title"].lower()
+    assert "not academic" in disclaimer["not_advice"].lower()
+    assert "does not predict or guarantee" in disclaimer["no_guarantees"].lower()
+    assert "verify" in disclaimer["verify_requirements"].lower()
+    assert "responsible" in disclaimer["user_decision"].lower()
+    assert result["recommendations"] == []
+    assert result["summary"]["recommendations_returned"] == 0
+
+
+def test_major_explorer_route_verifier_accepts_safe_payload():
+    entries = [
+        {
+            "_id": "e1",
+            "category": "Academic Project",
+            "entry_type": "College / University",
+            "title": "Programming project",
+            "action": "Built software using Python",
+            "tags": ["Python"],
+            "entry_date": datetime(2026, 9, 1, tzinfo=timezone.utc),
+        }
+    ]
+    result = build_major_explorer(entries, [])
+
+    assert _verify_major_explorer(result, entries, []) == []
+
+
+def test_major_explorer_route_verifier_rejects_prediction_or_fake_precision():
+    entries = [
+        {
+            "_id": "e1",
+            "title": "Programming project",
+            "action": "Built software using Python",
+            "tags": ["Python"],
+        }
+    ]
+    unsafe = build_major_explorer(entries, [])
+    unsafe["methodology"]["employment_prediction"] = True
+    if unsafe["recommendations"]:
+        unsafe["recommendations"][0]["fit_percent"] = 94
+
+    violations = _verify_major_explorer(unsafe, entries, [])
+
+    assert "major_explorer_employment_prediction_enabled" in violations
+    assert "major_explorer_fake_precision_exposed" in violations
+
+
+def test_major_explorer_route_verifier_rejects_missing_disclaimer():
+    result = build_major_explorer([], [])
+    result["disclaimer"]["verify_requirements"] = ""
+
+    violations = _verify_major_explorer(result, [], [])
+
+    assert "major_explorer_disclaimer_verify_requirements_missing" in violations

--- a/docs/MAJOR_EXPLORER.md
+++ b/docs/MAJOR_EXPLORER.md
@@ -1,0 +1,119 @@
+# BragStack Major Explorer v1
+
+Major Explorer is an Education Intelligence feature that uses a user's own BragStack evidence to surface academic directions worth **exploring**. It is not an aptitude test, admissions predictor, career-success predictor, or automated academic decision-maker.
+
+## Product purpose
+
+Major Explorer answers a narrow question:
+
+> Based on the real experiences and skills currently documented in BragStack, which majors may be worth investigating next, and what small experiments could reduce uncertainty?
+
+It does **not** answer:
+
+> What is the objectively best major for this person?
+
+The feature is built on Career Intelligence v5 canonical skills and evidence domains, then applies deterministic major-profile mappings. It does not use fuzzy matching, embeddings, hidden psychometric scoring, or an LLM to invent a major recommendation.
+
+## Required customer-facing disclaimer
+
+The Major Explorer UI must display a visible disclaimer before or alongside recommendations. The API also returns the disclaimer as structured fields so clients cannot silently omit the product boundary.
+
+Required meaning:
+
+- Major Explorer is an educational exploration and decision-support tool, not academic, career, financial, legal, licensing, or professional advice.
+- Recommendations reflect only the information and evidence currently available in BragStack and may be incomplete.
+- Major Explorer does not predict or guarantee admission, scholarships, academic performance, graduation, employment, salary, licensing, or career success.
+- Users must verify prerequisites, accreditation, transfer rules, program availability, costs, graduation requirements, and licensing requirements with the relevant institution or authority.
+- The user remains responsible for education decisions and should consider a qualified academic or career advisor for consequential choices.
+
+These disclaimers are risk-reduction controls. They do not guarantee legal compliance or immunity from claims, and final public language should be reviewed by qualified counsel as part of BragStack's legal process.
+
+## No fake precision
+
+Major Explorer must not expose:
+
+- a fit percentage;
+- admissions odds;
+- scholarship odds;
+- salary odds;
+- a success probability;
+- a readiness score;
+- a claim that a major is the user's "best" major.
+
+Customer-facing recommendation labels are qualitative:
+
+- **Strong exploration candidate**
+- **Worth exploring**
+- **Possible direction**
+
+Those labels describe evidence alignment only. They are not predictions of aptitude or future outcomes.
+
+## Evidence vs. interest
+
+Major Explorer v1 uses saved BragStack proof only. It does not currently mix self-reported interests into demonstrated evidence.
+
+This distinction is intentional:
+
+- **Demonstrated evidence** means the user documented an experience, accomplishment, project, skill, or other proof record.
+- **Self-reported interest** would mean the user says they are curious about or enjoy something.
+
+If a future guided-interest flow is added, self-reported interests should remain explicitly labeled and should not silently become demonstrated proof.
+
+## Uncertainty is a first-class output
+
+Every recommendation should explain:
+
+1. why it appeared;
+2. what Major Explorer still does not know; and
+3. one or more low-stakes experiments the user can try before making a major decision.
+
+Examples include comparing two introductory courses, trying a small project, previewing prerequisite math or science, or reviewing the actual curriculum of a real program.
+
+Major Explorer should prefer **"not enough information"** over manufacturing certainty.
+
+## Verification gate
+
+The API route fail-closes if the payload violates Major Explorer safeguards. Verification checks include:
+
+- evidence counts reconcile to saved proof;
+- recommendation counts stay bounded;
+- major IDs come from the deterministic profile registry;
+- qualitative labels use the allowed vocabulary;
+- exposed recommendations do not contain score/probability/odds fields;
+- all outcome-prediction and professional-advice flags remain false;
+- the disclaimer fields are present;
+- the engine reports `saved-proof-only` evidence mode;
+- Career Intelligence v5 remains the declared underlying evidence engine.
+
+A failed verification returns an error instead of serving potentially misleading guidance.
+
+## Major Explorer v1 methodology metadata
+
+- Major Explorer: `major-explorer-v1`
+- Underlying evidence engine: `career-intelligence-v5`
+- Ranking meaning: `evidence-alignment-for-exploration-only`
+- Fit percentage: disabled
+- Best-major claim: disabled
+- Decision-maker: disabled
+- Professional advice: disabled
+- Admission prediction: disabled
+- Scholarship prediction: disabled
+- Graduation prediction: disabled
+- Employment prediction: disabled
+- Salary prediction: disabled
+- Licensing prediction: disabled
+- Career-success prediction: disabled
+
+## Legal review follow-up
+
+Before BragStack relies on Major Explorer as a broadly marketed education-decision product, qualified counsel should review at least:
+
+- the final disclaimer and Terms language;
+- consumer-protection and advertising claims;
+- education/student privacy obligations that may apply to the actual user population and data flows;
+- state, federal, and international rules applicable to recommendations or profiling;
+- accessibility and nondiscrimination implications;
+- data-retention/vendor practices; and
+- any future school, counselor, parent/guardian, or institutional integrations.
+
+Major Explorer's engineering safeguards are designed to keep the product conservative while that legal work is completed; they are not a substitute for legal review.

--- a/frontend/src/ApplicationsHubPage.jsx
+++ b/frontend/src/ApplicationsHubPage.jsx
@@ -14,6 +14,7 @@ import {
 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import BragStackLoader from "./BragStackLoader.jsx";
+import MajorExplorerPanel from "./MajorExplorerPanel.jsx";
 import { getApplicationIntelligence } from "./applicationIntelligenceApi.js";
 import "./ApplicationsHubPage.css";
 
@@ -81,6 +82,14 @@ const EDUCATION_FEATURES = [
     icon: Sparkles,
     blurb: "Capture what you actually did in class, research, clubs, service, or training so BragStack can reuse it as career evidence.",
     href: "/app/accomplishments?create=1&education_feature=experience-translator",
+  },
+  {
+    id: "major-explorer",
+    group: "career",
+    title: "Major Explorer",
+    icon: Lightbulb,
+    blurb: "Explore possible majors from your demonstrated evidence without fit percentages, admissions odds, or a fake 'best major' verdict.",
+    href: "#major-explorer",
   },
   {
     id: "impact-receipts",
@@ -316,6 +325,8 @@ function ApplicationsHubPage() {
 
     <FeatureGrid group="record" title="Build your education record" description="Start with the kind of learning or achievement you want to capture." />
     <FeatureGrid group="career" title="Turn education into career proof" description="Reuse what you saved instead of starting from a blank page every time." />
+
+    <MajorExplorerPanel />
 
     <section className="education-application-section" aria-label="Application tools">
       <div className="education-feature-heading"><div><p className="applications-kicker"><Target size={15} /> Application tools</p><h2>Find the real wins that fit the opportunity in front of you.</h2></div><span>Built from your saved evidence</span></div>

--- a/frontend/src/MajorExplorerPanel.css
+++ b/frontend/src/MajorExplorerPanel.css
@@ -1,0 +1,286 @@
+.major-explorer {
+  margin-top: 28px;
+  padding: 24px;
+  border: 1px solid rgba(255, 255, 255, 0.09);
+  border-radius: 24px;
+  background: rgba(12, 18, 31, 0.72);
+}
+
+.major-explorer-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: 18px;
+}
+
+.major-explorer-heading h2 {
+  margin: 8px 0 10px;
+  max-width: 760px;
+}
+
+.major-explorer-heading > div > p:last-child {
+  max-width: 780px;
+  margin: 0;
+  color: var(--text-muted, #aab3c4);
+}
+
+.major-explorer-trust {
+  min-width: 260px;
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+  padding: 14px;
+  border-radius: 16px;
+  background: rgba(77, 119, 255, 0.09);
+  border: 1px solid rgba(114, 145, 255, 0.18);
+}
+
+.major-explorer-trust span {
+  display: grid;
+  gap: 3px;
+}
+
+.major-explorer-trust small {
+  color: var(--text-muted, #aab3c4);
+  line-height: 1.35;
+}
+
+.major-explorer-disclaimer {
+  display: flex;
+  gap: 12px;
+  padding: 18px;
+  margin: 16px 0 22px;
+  border-radius: 18px;
+  border: 1px solid rgba(245, 184, 75, 0.32);
+  background: rgba(245, 184, 75, 0.08);
+}
+
+.major-explorer-disclaimer > svg {
+  flex: 0 0 auto;
+  margin-top: 2px;
+}
+
+.major-explorer-disclaimer strong {
+  display: block;
+  margin-bottom: 7px;
+}
+
+.major-explorer-disclaimer p {
+  margin: 5px 0;
+  color: var(--text-muted, #b6becc);
+  line-height: 1.5;
+}
+
+.major-explorer-summary {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+  margin: 20px 0 14px;
+}
+
+.major-explorer-summary > div {
+  display: grid;
+  gap: 3px;
+  padding: 14px;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.07);
+}
+
+.major-explorer-summary strong {
+  font-size: 1.45rem;
+}
+
+.major-explorer-summary span {
+  color: var(--text-muted, #aab3c4);
+  font-size: 0.85rem;
+}
+
+.major-explorer-source-note,
+.major-explorer-methodology {
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+  padding: 14px 16px;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.035);
+  border: 1px solid rgba(255, 255, 255, 0.07);
+}
+
+.major-explorer-source-note p,
+.major-explorer-methodology p {
+  margin: 0;
+  color: var(--text-muted, #aab3c4);
+  line-height: 1.5;
+}
+
+.major-explorer-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+  margin-top: 18px;
+}
+
+.major-explorer-card {
+  padding: 19px;
+  border-radius: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.035);
+}
+
+.major-explorer-card-top {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.major-explorer-fit,
+.major-explorer-strength {
+  display: inline-flex;
+  align-items: center;
+  min-height: 26px;
+  padding: 4px 9px;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+}
+
+.major-explorer-fit.strong-exploration-candidate {
+  background: rgba(79, 196, 133, 0.14);
+  border: 1px solid rgba(79, 196, 133, 0.28);
+}
+
+.major-explorer-fit.worth-exploring {
+  background: rgba(104, 141, 255, 0.14);
+  border: 1px solid rgba(104, 141, 255, 0.28);
+}
+
+.major-explorer-fit.possible-direction {
+  background: rgba(255, 255, 255, 0.07);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.major-explorer-strength {
+  color: var(--text-muted, #b1bbca);
+  background: rgba(255, 255, 255, 0.045);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.major-explorer-card h3 {
+  margin: 0 0 7px;
+  font-size: 1.25rem;
+}
+
+.major-explorer-question {
+  margin: 0 0 15px;
+  color: var(--text-muted, #aab3c4);
+  line-height: 1.5;
+}
+
+.major-explorer-card-section {
+  margin-top: 14px;
+}
+
+.major-explorer-card-section > strong {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 7px;
+}
+
+.major-explorer-card-section ul,
+.major-explorer-card-section ol {
+  margin: 0;
+  padding-left: 20px;
+  color: var(--text-muted, #b2bbc9);
+}
+
+.major-explorer-card-section li {
+  margin: 6px 0;
+  line-height: 1.45;
+}
+
+.major-explorer-card-section.experiment {
+  padding: 13px;
+  border-radius: 14px;
+  background: rgba(105, 128, 255, 0.07);
+}
+
+.major-explorer-unknown {
+  margin-top: 14px;
+  padding-top: 13px;
+  border-top: 1px solid rgba(255, 255, 255, 0.07);
+}
+
+.major-explorer-unknown p {
+  margin: 6px 0 0;
+  color: var(--text-muted, #aab3c4);
+  line-height: 1.45;
+}
+
+.major-explorer-methodology {
+  margin-top: 18px;
+}
+
+.major-explorer-empty,
+.major-explorer-error {
+  display: grid;
+  justify-items: start;
+  gap: 9px;
+  margin-top: 18px;
+  padding: 20px;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.035);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.major-explorer-empty p,
+.major-explorer-error span {
+  margin: 0;
+  color: var(--text-muted, #aab3c4);
+  line-height: 1.5;
+}
+
+.major-explorer-empty a,
+.major-explorer-error button {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  margin-top: 3px;
+}
+
+@media (max-width: 900px) {
+  .major-explorer-heading {
+    display: grid;
+  }
+
+  .major-explorer-trust {
+    min-width: 0;
+  }
+
+  .major-explorer-summary {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .major-explorer-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 560px) {
+  .major-explorer {
+    padding: 16px;
+    border-radius: 18px;
+  }
+
+  .major-explorer-summary {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .major-explorer-disclaimer {
+    padding: 15px;
+  }
+}

--- a/frontend/src/MajorExplorerPanel.jsx
+++ b/frontend/src/MajorExplorerPanel.jsx
@@ -1,0 +1,148 @@
+import {
+  BookOpenCheck,
+  ChevronRight,
+  Compass,
+  FlaskConical,
+  RefreshCw,
+  ShieldCheck,
+  Sparkles,
+} from "lucide-react";
+import { useEffect, useState } from "react";
+import BragStackLoader from "./BragStackLoader.jsx";
+import { getMajorExplorer } from "./majorExplorerApi.js";
+import "./MajorExplorerPanel.css";
+
+function explorationLabel(value) {
+  if (value === "strong-exploration-candidate") return "Strong exploration candidate";
+  if (value === "worth-exploring") return "Worth exploring";
+  return "Possible direction";
+}
+
+function evidenceLabel(value) {
+  if (value === "supported") return "Supported by several signals";
+  if (value === "developing") return "Developing evidence";
+  return "Limited evidence so far";
+}
+
+function MajorExplorerPanel() {
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [refreshKey, setRefreshKey] = useState(0);
+
+  useEffect(() => {
+    let active = true;
+    getMajorExplorer()
+      .then((result) => {
+        if (!active) return;
+        setData(result);
+        setError("");
+        setLoading(false);
+      })
+      .catch((requestError) => {
+        if (!active) return;
+        if (requestError.status === 401) {
+          localStorage.removeItem("bragstack_token");
+          window.location.assign("/login");
+          return;
+        }
+        setData(null);
+        setError(requestError.message || "Major Explorer could not be loaded.");
+        setLoading(false);
+      });
+    return () => { active = false; };
+  }, [refreshKey]);
+
+  function retry() {
+    setLoading(true);
+    setError("");
+    setRefreshKey((current) => current + 1);
+  }
+
+  const summary = data?.summary || {};
+  const disclaimer = data?.disclaimer || {};
+  const recommendations = data?.recommendations || [];
+
+  return <section className="major-explorer" id="major-explorer" aria-labelledby="major-explorer-title">
+    <div className="major-explorer-heading">
+      <div>
+        <p className="applications-kicker"><Compass size={15} /> Major Explorer</p>
+        <h2 id="major-explorer-title">Not sure what to major in? Explore directions from your real evidence.</h2>
+        <p>BragStack looks for patterns in the coursework, projects, activities, skills, and accomplishments you actually saved, then suggests academic directions worth investigating.</p>
+      </div>
+      <div className="major-explorer-trust"><ShieldCheck size={19} /><span><strong>No “best major” verdict.</strong><small>No fit percentage · no admissions odds · no career-success prediction</small></span></div>
+    </div>
+
+    <div className="major-explorer-disclaimer" role="note" aria-label="Major Explorer important disclaimer">
+      <ShieldCheck size={21} />
+      <div>
+        <strong>{disclaimer.title || "Major Explorer is for exploration, not a decision about your future."}</strong>
+        <p>{disclaimer.scope || "Recommendations may be incomplete because they reflect only the information available in BragStack."}</p>
+        <p>{disclaimer.not_advice || "This is an educational decision-support tool, not academic, career, financial, legal, licensing, or professional advice."}</p>
+        <p>{disclaimer.no_guarantees || "It does not predict or guarantee admission, scholarships, graduation, employment, salary, licensing, or career success."}</p>
+        <p>{disclaimer.verify_requirements || "Verify program requirements with the relevant institution or authority."}</p>
+        <p>{disclaimer.user_decision || "You remain responsible for your education decisions and may want guidance from a qualified advisor."}</p>
+      </div>
+    </div>
+
+    {loading && <BragStackLoader compact message="Connecting your evidence to possible majors…" detail="Looking for exploration signals without turning them into a prediction or aptitude score." />}
+
+    {!loading && error && <div className="major-explorer-error">
+      <strong>Major Explorer could not load.</strong>
+      <span>{error}</span>
+      <button type="button" onClick={retry}><RefreshCw size={15} /> Try again</button>
+    </div>}
+
+    {!loading && data && <>
+      <div className="major-explorer-summary" aria-label="Major Explorer evidence summary">
+        <div><strong>{summary.proof_records_analyzed ?? 0}</strong><span>proof records reviewed</span></div>
+        <div><strong>{summary.distinct_demonstrations ?? 0}</strong><span>distinct demonstrations</span></div>
+        <div><strong>{summary.canonical_skills ?? 0}</strong><span>canonical skills</span></div>
+        <div><strong>{summary.evidence_domains ?? 0}</strong><span>evidence domains</span></div>
+      </div>
+
+      <div className="major-explorer-source-note">
+        <Sparkles size={17} />
+        <p><strong>Evidence source:</strong> this version uses saved BragStack proof only. Self-reported interests are not mixed into demonstrated evidence, so the product does not pretend that “I like this” and “I have demonstrated this” are the same thing.</p>
+      </div>
+
+      {recommendations.length === 0 ? <div className="major-explorer-empty">
+        <BookOpenCheck size={30} />
+        <h3>There is not enough saved evidence to suggest a direction yet.</h3>
+        <p>Add coursework, projects, clubs, research, volunteering, jobs, training, or other real experiences. Major Explorer would rather say “not enough information” than invent a recommendation.</p>
+        <a href="/app/accomplishments?create=1&education_feature=major-explorer">Add an experience <ChevronRight size={15} /></a>
+      </div> : <div className="major-explorer-grid">
+        {recommendations.map((item) => <article className="major-explorer-card" key={item.major_id}>
+          <div className="major-explorer-card-top">
+            <span className={`major-explorer-fit ${item.fit_label}`}>{explorationLabel(item.fit_label)}</span>
+            <span className={`major-explorer-strength ${item.evidence_strength}`}>{evidenceLabel(item.evidence_strength)}</span>
+          </div>
+          <h3>{item.major}</h3>
+          <p className="major-explorer-question">{item.exploration_question}</p>
+
+          <div className="major-explorer-card-section">
+            <strong>Why this appeared</strong>
+            <ul>{(item.why_it_appeared || []).map((reason) => <li key={reason}>{reason}</li>)}</ul>
+          </div>
+
+          <div className="major-explorer-card-section experiment">
+            <strong><FlaskConical size={15} /> Reduce the uncertainty</strong>
+            <ol>{(item.next_experiments || []).map((experiment) => <li key={experiment}>{experiment}</li>)}</ol>
+          </div>
+
+          <div className="major-explorer-unknown">
+            <strong>What this does not tell us</strong>
+            <p>{item.what_we_do_not_know}</p>
+          </div>
+        </article>)}
+      </div>}
+
+      <div className="major-explorer-methodology">
+        <ShieldCheck size={17} />
+        <p><strong>Major Explorer v1</strong> ranks evidence alignment for exploration only. It does not determine aptitude, recommend a “best” major, replace an advisor, or predict educational or career outcomes.</p>
+      </div>
+    </>}
+  </section>;
+}
+
+export default MajorExplorerPanel;

--- a/frontend/src/applicationsHubSource.test.js
+++ b/frontend/src/applicationsHubSource.test.js
@@ -23,6 +23,8 @@ test("Education workspace exposes application goals and a feature launcher", () 
   assert.match(source, /Group Project Contributions/);
   assert.match(source, /Graduation Progress/);
   assert.match(source, /Experience Translator/);
+  assert.match(source, /Major Explorer/);
+  assert.match(source, /href: "#major-explorer"/);
   assert.match(source, /Education Impact Receipts/);
   assert.match(source, /Skills from Education/);
   assert.match(source, /Career Match & Skill Gaps/);
@@ -32,6 +34,25 @@ test("Education workspace exposes application goals and a feature launcher", () 
   assert.match(source, /Career Path Explorer/);
   assert.match(source, /no admissions score/i);
   assert.match(source, /real evidence/i);
+});
+
+test("Major Explorer is embedded in Education with visible non-predictive safeguards", () => {
+  const hub = read("./ApplicationsHubPage.jsx");
+  const explorer = read("./MajorExplorerPanel.jsx");
+  const api = read("./majorExplorerApi.js");
+
+  assert.match(hub, /MajorExplorerPanel/);
+  assert.match(explorer, /id="major-explorer"/);
+  assert.match(explorer, /No “best major” verdict/);
+  assert.match(explorer, /No fit percentage/);
+  assert.match(explorer, /no admissions odds/i);
+  assert.match(explorer, /not academic, career, financial, legal, licensing, or professional advice/i);
+  assert.match(explorer, /does not predict or guarantee admission, scholarships, graduation, employment, salary, licensing, or career success/i);
+  assert.match(explorer, /Verify program requirements/i);
+  assert.match(explorer, /You remain responsible/i);
+  assert.match(explorer, /Self-reported interests are not mixed into demonstrated evidence/i);
+  assert.match(explorer, /does not determine aptitude/i);
+  assert.match(api, /career-intelligence\/major-explorer/);
 });
 
 test("Education removes the adult-only and middle-school roadmap framing", () => {

--- a/frontend/src/majorExplorerApi.js
+++ b/frontend/src/majorExplorerApi.js
@@ -1,0 +1,19 @@
+function apiBase() {
+  if (window.location.hostname.endsWith(".app.github.dev")) return "/api";
+  return import.meta.env.VITE_API_BASE_URL || import.meta.env.VITE_API_URL || "http://localhost:8000";
+}
+
+export async function getMajorExplorer() {
+  const token = localStorage.getItem("bragstack_token");
+  const response = await fetch(`${apiBase()}/career-intelligence/major-explorer`, {
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+    cache: "no-store",
+  });
+  if (!response.ok) {
+    const payload = await response.json().catch(() => ({}));
+    const error = new Error(payload?.detail?.message || payload?.detail || "Major Explorer could not be loaded.");
+    error.status = response.status;
+    throw error;
+  }
+  return response.json();
+}


### PR DESCRIPTION
## Why
Students who do not know what to major in need a different product question from ordinary Career Intelligence. Major Explorer reuses BragStack's Career Intelligence v5 evidence foundation but turns it into a separate education decision-support experience: *which academic directions are worth exploring, why did they appear, and what low-stakes experiment could reduce uncertainty?*

This PR treats legal/product safeguards as part of the feature architecture rather than a footer added later.

## Major Explorer engine
- Adds deterministic `major-explorer-v1` on top of Career Intelligence v5 canonical skills and evidence domains.
- Uses saved BragStack proof only in v1; self-reported interests are explicitly not mixed into demonstrated evidence.
- Surfaces qualitative labels only: `Strong exploration candidate`, `Worth exploring`, and `Possible direction`.
- Shows why each direction appeared, what BragStack still does not know, and two practical experiments to reduce uncertainty.
- Prefers no recommendation when evidence is insufficient rather than inventing certainty.

## Safeguards / company protection
- No fit percentage or aptitude score.
- No "best major" claim.
- No admissions, scholarship, graduation, employment, salary, licensing, or career-success prediction.
- No claim that Major Explorer replaces an academic/career advisor or other professional advice.
- API returns structured disclaimer fields and route verification fail-closes if required disclaimer language or safety flags disappear.
- Customer-facing disclaimer tells users results may be incomplete, to verify prerequisites/accreditation/transfer/cost/graduation/licensing requirements with the relevant institution or authority, and that they remain responsible for the decision.
- Engineering docs explicitly say these controls reduce risk but do not replace qualified legal review.

## Education UI
- Adds **Major Explorer** as a button in the existing Education feature launcher.
- Embeds the Major Explorer experience in `/app/applications` so it stays inside the Education workspace.
- Separates saved-proof evidence from self-reported interest.
- Makes uncertainty and "what this does not tell us" visible on every recommendation.
- Adds mobile-responsive styling and clear empty/error states.

## Verification / tests
- Backend regression tests cover qualitative recommendations, no fake precision, outcome-prediction flags, required disclaimers, and fail-closed verification.
- Frontend source regression tests require the launcher, visible disclaimers, no-best-major language, no admissions odds, and the evidence-vs-interest distinction.
- Documents the Major Explorer methodology and legal-review follow-up in `docs/MAJOR_EXPLORER.md`.

## Legal note
This PR intentionally does **not** claim legal compliance, attorney approval, or immunity from claims. The safeguards are conservative product controls while qualified counsel review remains necessary.