### PR TITLE
Make BragStack documentation explicitly cross-industry

### DIFF
--- a/docs/CROSS_INDUSTRY_DOCUMENTATION_STANDARD.md
+++ b/docs/CROSS_INDUSTRY_DOCUMENTATION_STANDARD.md
@@ -1,0 +1,107 @@
+# BragStack — Cross-Industry Documentation Standard
+
+BragStack is a career evidence system for people in **any profession**. Product documentation, legal/confidentiality guidance, customer education, demos, investor material, onboarding copy, examples, generated sample content, and public positioning must not treat software engineering, technology, or office-based knowledge work as the default user experience.
+
+## Core rule
+
+**The evidence model is profession-neutral.**
+
+Every BragStack explanation should work for a nurse, teacher, warehouse lead, stylist, salesperson, mechanic, customer-service representative, hospitality worker, field technician, nonprofit coordinator, public-service worker, designer, manager, consultant, student, apprentice, developer, or another professional without requiring the reader to translate a software-specific example into their own work.
+
+Technology is an important profession represented by BragStack. It is not the product's default profession.
+
+## Example rotation
+
+When a document or product surface uses multiple examples, rotate across different kinds of work rather than repeating code, tickets, repositories, deployments, incidents, or technical projects.
+
+Representative groups include:
+
+- healthcare and care work;
+- education and training;
+- skilled trades, maintenance, construction, and field service;
+- retail and hospitality;
+- sales and account management;
+- customer service and support;
+- operations, manufacturing, warehouse, and logistics;
+- finance and administrative work;
+- government and public service;
+- nonprofit and community work;
+- creative, design, media, and marketing work;
+- management and leadership;
+- consulting and independent work;
+- technology and engineering;
+- students, apprentices, certification candidates, and career changers.
+
+A single document does not need every profession, but the overall BragStack documentation set should visibly represent different work environments and career paths.
+
+## Profession-neutral evidence examples
+
+Evidence is not synonymous with a GitHub commit or ticket. Depending on the profession and the user's permissions, evidence may include:
+
+- approved work orders or service records;
+- supervisor or manager recognition;
+- customer or client feedback;
+- approved performance summaries;
+- training, certification, or licensure records;
+- public portfolios or credited work samples;
+- lesson materials or school-approved summaries;
+- sanitized project or case references;
+- sales or operational reports that the user is permitted to reuse;
+- public awards, publications, presentations, or project pages;
+- schedules, checklists, quality records, or process documentation where permitted;
+- technical artifacts such as public repositories, code reviews, change records, or incident references where appropriate.
+
+Evidence examples must always be qualified by authorization, confidentiality, privacy, professional duties, and applicable law.
+
+## NDA and confidentiality standard
+
+Confidentiality guidance must address risks across professions, not only proprietary source code.
+
+Examples of restricted information can include:
+
+- patient or health information;
+- student and education records;
+- client or case files;
+- constituent or government records;
+- customer identities and account information;
+- payment or financial information;
+- confidential pricing, contracts, pipeline, or revenue data;
+- personnel and employee information;
+- customer addresses, access codes, facility-security details, or proprietary schematics;
+- unreleased creative work, campaigns, drafts, and brand strategy;
+- proprietary recipes, formulas, methods, procedures, trade secrets, or manufacturing information;
+- source code, credentials, internal systems, incidents, architecture, or unreleased technical work.
+
+The safe pattern is universal: **capture the career signal, not the secret.** Users should generalize sensitive context, use references instead of copies when appropriate, and leave restricted material out when they do not have permission to store it in BragStack.
+
+## Product and investor positioning
+
+Avoid defining BragStack primarily as a tool for “knowledge workers,” “technical workers,” developers, or software teams unless a document is intentionally discussing that one segment.
+
+Preferred umbrella language:
+
+- professionals across industries;
+- people doing meaningful work;
+- workers across office, frontline, field, service, creative, care, trade, and technical settings;
+- students, apprentices, career changers, independent professionals, and employees building evidence of applied work.
+
+Market sequencing may still prioritize specific customer segments based on measured demand, acquisition cost, retention, and willingness to pay. A go-to-market wedge does **not** redefine the product as profession-specific.
+
+## Generated examples and AI
+
+AI-assisted or deterministic examples must be evaluated across professions. Quality gates should detect whether prompts, scoring, coaching, résumé language, interview questions, or evidence suggestions work disproportionately well for software/office careers.
+
+Cross-profession fixtures should include both knowledge-work and non-desk roles. Generated content must never invent credentials, licenses, metrics, outcomes, protected information, or professional claims.
+
+## Review checklist
+
+Before publishing or merging a customer-facing or business-facing BragStack document, ask:
+
+1. Does this copy imply that a BragStack user is probably a software engineer?
+2. Are the examples understandable to people outside technology and corporate office work?
+3. Does “evidence” include profession-appropriate forms of proof beyond tickets, commits, and dashboards?
+4. Does confidentiality guidance cover privacy and professional obligations outside technology?
+5. Could a frontline, care, service, trade, creative, public-sector, or education worker see themselves in the product?
+6. If one profession is emphasized, is that emphasis intentional for the document's specific purpose rather than an accidental default?
+
+If the answer reveals a technology-first default, revise the document before treating it as BragStack's canonical positioning.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -16,9 +16,9 @@
     <link rel="manifest" href="/site.webmanifest" />
     <link rel="stylesheet" href="/bragstack-polish.css" />
 
-    <title>BragStack | Resume Accomplishments, Career Portfolio & Job Search Proof</title>
-    <meta name="description" content="BragStack helps professionals capture work accomplishments, build evidence-backed resume bullets, create career portfolios, prepare for interviews, performance reviews, promotions, and job searches." />
-    <meta name="keywords" content="resume builder, resume accomplishments, career portfolio, professional portfolio, job search, interview preparation, performance review, promotion packet, work accomplishments, achievement tracker, brag document, career evidence, hiring, portfolio" />
+    <title>BragStack | Career Proof for Work Across Industries</title>
+    <meta name="description" content="BragStack helps people across industries capture meaningful work, preserve evidence, and build reusable career proof for resumes, portfolios, interviews, reviews, promotions, certifications, and career transitions." />
+    <meta name="keywords" content="career proof, work accomplishments, resume builder, resume accomplishments, career portfolio, professional portfolio, job search, interview preparation, performance review, promotion packet, certification evidence, achievement tracker, brag document, career evidence, hiring, portfolio" />
     <meta name="author" content="BragStack" />
     <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1" />
     <link rel="canonical" href="https://usebragstack.com/" />
@@ -26,8 +26,8 @@
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="BragStack" />
     <meta property="og:locale" content="en_US" />
-    <meta property="og:title" content="BragStack | Turn Work Accomplishments Into Career Proof" />
-    <meta property="og:description" content="Capture accomplishments once and reuse them for resumes, portfolios, interviews, performance reviews, promotions, and job searches." />
+    <meta property="og:title" content="BragStack | Turn Meaningful Work Into Career Proof" />
+    <meta property="og:description" content="For people across industries: capture accomplishments once and reuse them for resumes, portfolios, interviews, reviews, promotions, certifications, and career transitions." />
     <meta property="og:url" content="https://usebragstack.com/" />
     <meta property="og:image" content="https://usebragstack.com/social-card.svg" />
     <meta property="og:image:type" content="image/svg+xml" />
@@ -36,8 +36,8 @@
     <meta property="og:image:alt" content="BragStack — Turn your work into opportunities. Capture accomplishments, attach evidence, and build career proof." />
 
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="BragStack | Career Proof for Resumes, Portfolios & Hiring" />
-    <meta name="twitter:description" content="Build evidence-backed career proof for resumes, portfolios, interviews, reviews, promotions, and job searches." />
+    <meta name="twitter:title" content="BragStack | Career Proof Across Professions" />
+    <meta name="twitter:description" content="Build evidence-backed career proof from real work for resumes, portfolios, interviews, reviews, promotions, certifications, and career transitions." />
     <meta name="twitter:image" content="https://usebragstack.com/social-card.svg" />
     <meta name="twitter:image:alt" content="BragStack — Turn your work into opportunities." />
 
@@ -70,7 +70,7 @@
             "name": "BragStack",
             "alternateName": "BragStack Career Proof",
             "publisher": { "@id": "https://usebragstack.com/#organization" },
-            "description": "Career proof software for resumes, portfolios, job searches, interviews, performance reviews, promotions, and hiring conversations.",
+            "description": "Career evidence software for people across professions to preserve accomplishments, outcomes, evidence, skills, and recognition for resumes, portfolios, interviews, reviews, promotions, certifications, and career transitions.",
             "inLanguage": "en-US"
           },
           {
@@ -82,7 +82,7 @@
             "url": "https://usebragstack.com/",
             "image": "https://usebragstack.com/social-card.svg",
             "publisher": { "@id": "https://usebragstack.com/#organization" },
-            "description": "Capture work accomplishments and evidence, then turn them into resume material, career portfolios, interview stories, performance-review packets, and promotion proof.",
+            "description": "Capture meaningful work and safe evidence across professions, then turn it into resume material, portfolios, interview stories, performance-review packets, promotion proof, certification evidence, and other career assets.",
             "offers": [
               { "@type": "Offer", "name": "Free", "price": "0", "priceCurrency": "USD" },
               { "@type": "Offer", "name": "Pro", "price": "9", "priceCurrency": "USD" }

--- a/frontend/src/NDAGuidancePage.jsx
+++ b/frontend/src/NDAGuidancePage.jsx
@@ -7,64 +7,96 @@ function NDAGuidancePage() {
       <article className="legal-card">
         <p className="legal-eyebrow">BragStack Safety Guidance</p>
         <h1>Using BragStack with NDAs and confidential work</h1>
-        <p className="legal-intro">BragStack can help you document career impact without turning confidential employer or client information into public content. Your NDA, confidentiality agreement, employer policy, client agreement, security rule, or legal obligation always comes first.</p>
+        <p className="legal-intro">BragStack can help people in any profession document career impact without turning confidential employer, client, patient, student, customer, constituent, or third-party information into public content. Your NDA, confidentiality agreement, professional duty, employer policy, client agreement, security rule, privacy obligation, or legal requirement always comes first.</p>
         <div className="legal-callout">Capture the career signal, not the secret. When work is confidential, generalize context, keep sensitive proof private, and do not upload material you are not authorized to store outside its original system.</div>
 
-        <section><h2>1. Your NDA still applies</h2><p>BragStack does not override any confidentiality agreement, employment policy, client contract, security obligation, or law. You are responsible for understanding what you may store and share.</p></section>
+        <section><h2>1. Your obligations still apply</h2><p>BragStack does not override any confidentiality agreement, employment policy, client contract, professional duty, privacy rule, security obligation, or law. You are responsible for understanding what you may store, reference, reuse, and share.</p></section>
 
-        <section><h2>2. Generalize sensitive context</h2><p>Prefer descriptions such as “enterprise customer,” “internal platform,” or “regulated workload” instead of confidential names, code names, internal URLs, repository names, architecture details, customer identifiers, unreleased product information, or private incident details.</p></section>
+        <section><h2>2. Generalize sensitive context</h2><p>Prefer descriptions such as “customer,” “client,” “patient-care workflow,” “student-support process,” “internal operation,” “field-service assignment,” “regulated workload,” or “confidential project” instead of restricted names, case identifiers, addresses, account details, internal URLs, repository names, unreleased products, private incidents, proprietary methods, or other identifying details.</p></section>
 
         <section>
-          <h2>3. Examples: describe the engineering outcome, not the private implementation</h2>
-          <p><strong>Private architecture work — avoid:</strong> “Migrated every router into handlers across all application routes.”</p>
-          <p><strong>Safer version:</strong> “Contributed to a cross-cutting backend refactoring initiative that improved consistency, maintainability, and extensibility while preserving existing behavior.”</p>
-          <p><strong>Why:</strong> The safer version captures the engineering signal without disclosing the private codebase's internal routing structure or implementation method.</p>
+          <h2>3. Examples across different kinds of work</h2>
+          <p>The goal is the same in every profession: preserve what your work demonstrates without copying restricted information into BragStack.</p>
 
-          <p><strong>Private operational tooling — avoid:</strong> “Built a UI that shows the state of the company's large-data ingestion system.”</p>
-          <p><strong>Safer version:</strong> “Developed user-facing functionality for an internal engineering tool that improved visibility into long-running operational workflows.”</p>
-          <p><strong>Why:</strong> The safer version preserves the accomplishment without exposing internal system names, workflow states, data characteristics, architecture, or operational details.</p>
+          <h3>Healthcare and care work</h3>
+          <p><strong>Avoid:</strong> patient names, dates of birth, medical-record numbers, diagnoses, treatment details, photos, or other protected health information unless you are specifically authorized to use it.</p>
+          <p><strong>Safer version:</strong> “Helped improve consistency in a patient-care handoff process, reducing avoidable follow-up work while following required privacy and safety procedures.”</p>
+          <p><strong>Why:</strong> The accomplishment shows coordination, reliability, and process improvement without identifying a patient or revealing protected clinical details.</p>
 
-          <p><strong>Private testing work — avoid:</strong> naming an unreleased feature, internal screen, ticket, repository, or exact implementation detail.</p>
-          <p><strong>Safer version:</strong> “Added cross-platform automated coverage for an internal engineering change and surfaced a defect before broader release.”</p>
+          <h3>Education</h3>
+          <p><strong>Avoid:</strong> student names, grades tied to identifiable students, disability or accommodation information, disciplinary records, family details, or private school-system records.</p>
+          <p><strong>Safer version:</strong> “Adapted instruction and family communication to improve participation and engagement across a group of learners.”</p>
+          <p><strong>Why:</strong> The safer version communicates teaching and communication impact without exposing individual student records.</p>
+
+          <h3>Retail, hospitality, and customer service</h3>
+          <p><strong>Avoid:</strong> customer names, payment details, loyalty-account information, private complaints, security footage, employee records, or internal loss-prevention details.</p>
+          <p><strong>Safer version:</strong> “Resolved a recurring service issue, coordinated the right internal support, and helped preserve the customer relationship.”</p>
+          <p><strong>Why:</strong> The career signal is service recovery, judgment, and coordination—not the customer's identity or private account history.</p>
+
+          <h3>Sales and account management</h3>
+          <p><strong>Avoid:</strong> confidential client names, contract terms, nonpublic pricing, pipeline details, margin data, renewal negotiations, or private revenue figures.</p>
+          <p><strong>Safer version:</strong> “Managed a complex account conversation, aligned stakeholders around the customer's needs, and contributed to a successful retention outcome.”</p>
+          <p><strong>Why:</strong> The contribution and outcome stay useful without revealing confidential commercial terms.</p>
+
+          <h3>Skilled trades, maintenance, and field service</h3>
+          <p><strong>Avoid:</strong> customer addresses, access codes, alarm details, facility vulnerabilities, private work-order notes, proprietary schematics, or security-sensitive site information.</p>
+          <p><strong>Safer version:</strong> “Diagnosed a difficult field issue, completed a safe repair, and restored normal operation while meeting required procedures.”</p>
+          <p><strong>Why:</strong> The safer version captures troubleshooting, craftsmanship, safety, and reliability without exposing a customer's property or security information.</p>
+
+          <h3>Finance, legal, government, and nonprofit work</h3>
+          <p><strong>Avoid:</strong> account numbers, tax information, case details, legal strategy, constituent information, donor records, benefits information, investigative material, or nonpublic government records.</p>
+          <p><strong>Safer version:</strong> “Improved a high-volume review process so time-sensitive requests were handled more consistently and accurately.”</p>
+          <p><strong>Why:</strong> The process improvement remains visible without disclosing protected records or the people behind them.</p>
+
+          <h3>Creative, media, and marketing work</h3>
+          <p><strong>Avoid:</strong> unreleased campaigns, client strategy, embargoed assets, unlicensed source material, private audience data, unpublished drafts, or confidential brand plans.</p>
+          <p><strong>Safer version:</strong> “Developed and refined creative work for a confidential campaign, incorporating stakeholder feedback and improving delivery readiness.”</p>
+          <p><strong>Why:</strong> The accomplishment demonstrates creative execution and collaboration without leaking unreleased client work.</p>
+
+          <h3>Technology and engineering</h3>
+          <p><strong>Avoid:</strong> private source code, repository names, credentials, internal URLs, unreleased architecture, private incidents, customer identifiers, or implementation details that your employer treats as confidential.</p>
+          <p><strong>Safer version:</strong> “Contributed to a cross-cutting system improvement that increased maintainability and reliability while preserving existing behavior.”</p>
+          <p><strong>Why:</strong> The safer version captures the engineering signal without exposing the private codebase or implementation method.</p>
         </section>
 
         <section>
           <h2>4. Public evidence creates a useful boundary</h2>
-          <p>If the employer or client has already made a merge request, release note, public repository change, conference talk, documentation page, or similar material public, you may be able to reference what that public source actually shows. Do not add extra private context merely because part of the work is public.</p>
-          <div className="legal-callout">Treat the public source as the ceiling: describe what it proves, not additional internal details you happen to know.</div>
-          <p><strong>Example:</strong> A public merge request showing support for an additional cloud-storage provider can support an accomplishment about adding that integration. It does not automatically authorize disclosure of private customers, architecture, deployment details, usage levels, incidents, or internal performance data.</p>
+          <p>If an employer, client, school, agency, organization, publication, licensing body, portfolio site, public repository, press release, public report, conference presentation, award listing, or other authorized source has already made information public, you may be able to reference what that public source actually shows. Do not add extra private context merely because part of the work is public.</p>
+          <div className="legal-callout">Treat the public source as the ceiling: describe what it proves, not additional confidential details you happen to know.</div>
+          <p><strong>Examples:</strong> a public award can support that the award was received; a public campaign can support your credited role; a public project page can support the published result; a public repository change can support the contribution visible there. None of those automatically authorize disclosure of private customers, patients, students, internal processes, financials, incidents, or unpublished work.</p>
         </section>
 
-        <section><h2>5. Redact restricted evidence</h2><p>Do not upload screenshots, tickets, logs, source code, documents, messages, contracts, credentials, customer data, or attachments unless you are authorized to store and reuse them outside the original system.</p></section>
+        <section><h2>5. Redact restricted evidence</h2><p>Do not upload screenshots, records, case files, charts, tickets, logs, source code, student work, medical information, contracts, messages, credentials, customer information, client files, employee records, or attachments unless you are authorized to store and reuse them outside the original system.</p></section>
 
         <section>
-          <h2>6. Evidence can be a reference</h2>
-          <p>When appropriate, record a private reference such as “internal code review,” “manager feedback,” or “project record” without copying restricted content into BragStack.</p>
-          <p><strong>Public evidence example:</strong> link to the public merge request and describe only what is visible there.</p>
-          <p><strong>Private evidence example:</strong> use “Private internal engineering contribution” with no repository URL, screenshot, ticket text, source code, customer information, or proprietary attachment.</p>
+          <h2>6. Evidence can be a reference instead of a copy</h2>
+          <p>When appropriate, record a private reference without copying restricted content into BragStack.</p>
+          <p><strong>Possible references:</strong> “manager feedback,” “supervisor recognition,” “approved work order,” “internal project record,” “training completion,” “public portfolio item,” “customer commendation on file,” “school-approved summary,” “internal case record,” or “private code review.”</p>
+          <p><strong>Public evidence:</strong> link only to material you are permitted to reuse and describe only what the source actually shows.</p>
+          <p><strong>Private evidence:</strong> use a generalized reference such as “Private internal contribution” without copying restricted names, identifiers, screenshots, records, proprietary attachments, or sensitive content.</p>
         </section>
 
         <section>
           <h2>7. Be conservative with metrics</h2>
-          <p>If exact metrics are sensitive, use only an approved public figure, an authorized abstraction, or a qualitative outcome that is truthful and permitted. Never invent or alter a result to get around a confidentiality restriction.</p>
-          <p><strong>Avoid:</strong> private route counts, customer counts, dataset sizes, transaction volumes, incident totals, processing times, internal error rates, unreleased performance gains, or revenue figures.</p>
-          <p><strong>Safer:</strong> “Improved maintainability,” “restored a workflow,” “added cross-platform test coverage,” or another truthful qualitative result when the exact internal measurement is not approved for disclosure.</p>
+          <p>If exact metrics are sensitive, use only an approved public figure, an authorized abstraction, or a truthful qualitative outcome. Never invent or alter a result to get around a confidentiality restriction.</p>
+          <p><strong>Avoid when private:</strong> patient counts, student-level results, customer counts, revenue, margins, donor amounts, caseload details, incident totals, transaction volumes, internal error rates, productivity targets, unreleased performance gains, property addresses, or system-specific technical measurements.</p>
+          <p><strong>Safer:</strong> “improved consistency,” “reduced avoidable rework,” “restored service,” “increased participation,” “strengthened customer retention,” “improved turnaround,” “expanded coverage,” or another truthful qualitative result when the exact internal measurement is not approved for disclosure.</p>
         </section>
 
         <section>
           <h2>8. Public, generalized, or private?</h2>
-          <p><strong>Usually lower risk:</strong> accomplishments whose wording and evidence are fully supported by information already lawfully public.</p>
-          <p><strong>Use caution:</strong> generalized descriptions of private work that communicate your skills without revealing how the employer's systems, products, operations, customers, or internal processes work.</p>
-          <p><strong>Keep private:</strong> source code, unpublished architecture, internal tool names, screenshots, tickets, logs, credentials, customer data, proprietary metrics, incident details, unreleased features, or other information your agreement or employer treats as confidential.</p>
+          <p><strong>Usually lower risk:</strong> accomplishments whose wording and evidence are fully supported by information already lawfully public or specifically approved for reuse.</p>
+          <p><strong>Use caution:</strong> generalized descriptions of private work that communicate your skills without revealing how an employer, client, school, healthcare organization, agency, customer, facility, product, or internal process operates.</p>
+          <p><strong>Keep private:</strong> protected health or student information, account records, confidential client or constituent data, personnel information, private customer details, source code, unpublished designs, internal tool names, credentials, proprietary metrics, incident details, unreleased products, trade secrets, or other information your agreement, profession, employer, or law treats as confidential.</p>
         </section>
 
-        <section><h2>9. Keep confidential proof private</h2><p>Do not make an accomplishment or Impact Receipt public unless you are permitted to disclose every detail it contains. Private-by-default controls do not replace your contractual or workplace obligations.</p></section>
+        <section><h2>9. Keep confidential proof private</h2><p>Do not make an accomplishment or Impact Receipt public unless you are permitted to disclose every detail it contains. Private-by-default controls do not replace contractual, professional, workplace, privacy, or legal obligations.</p></section>
 
-        <section><h2>10. Generated outputs inherit source sensitivity</h2><p>A resume bullet, review packet, interview story, or other generated output can still reveal confidential information if the underlying evidence contains it. Review every output before exporting, publishing, or sending it to someone else.</p></section>
+        <section><h2>10. Generated outputs inherit source sensitivity</h2><p>A resume bullet, review packet, interview story, portfolio statement, certification packet, client-facing summary, or other generated output can still reveal confidential information if the underlying evidence contains it. Review every output before exporting, publishing, or sending it to someone else.</p></section>
 
-        <section><h2>11. When not to store something</h2><p>If an agreement or policy says information may not be stored in third-party systems, do not put that information in BragStack. Use a sanitized description or leave the restricted evidence out entirely.</p></section>
+        <section><h2>11. When not to store something</h2><p>If an agreement, professional rule, employer policy, school policy, healthcare policy, client requirement, agency rule, or law says information may not be stored in third-party systems, do not put that information in BragStack. Use a sanitized description or leave the restricted evidence out entirely.</p></section>
 
-        <section><h2>12. This is not legal advice</h2><p>BragStack does not review or interpret your NDA. If you are unsure what is permitted, consult the agreement, your employer or client policy, an authorized security or legal contact, or qualified counsel. Product questions can be sent to <a href="mailto:Tobias.scott@usebragstack.com">Tobias.scott@usebragstack.com</a>.</p></section>
+        <section><h2>12. This is not legal advice</h2><p>BragStack does not review or interpret your NDA, employment agreement, professional obligations, privacy duties, or other restrictions. If you are unsure what is permitted, consult the governing agreement or policy, an authorized privacy/security/legal/compliance contact, your professional guidance where applicable, or qualified counsel. Product questions can be sent to <a href="mailto:Tobias.scott@usebragstack.com">Tobias.scott@usebragstack.com</a>.</p></section>
       </article>
     </main>
   );

--- a/frontend/src/SecurityPage.jsx
+++ b/frontend/src/SecurityPage.jsx
@@ -21,7 +21,7 @@ function SecurityPage() {
         <div className="security-hero-copy">
           <span className="security-kicker"><ShieldCheck size={16} /> BRAGSTACK SECURITY</span>
           <h1>Your career proof deserves careful protection.</h1>
-          <p>BragStack is designed around a simple idea: your private career evidence should stay private unless you decide otherwise. This page explains our security approach in plain English.</p>
+          <p>BragStack is designed around a simple idea: your private career evidence should stay private unless you decide otherwise. This page explains our security approach in plain English for people across professions and work settings.</p>
           <div className="security-actions"><a className="security-primary" href="/docs#privacy">Read privacy & NDA guidance</a><a className="security-secondary" href="mailto:security@usebragstack.com?subject=BragStack%20security%20report">Report a security concern</a></div>
         </div>
         <div className="security-lock-card"><ShieldCheck size={42} /><strong>Private by default</strong><span>You decide what becomes public.</span></div>
@@ -40,11 +40,11 @@ function SecurityPage() {
       </section>
 
       <section className="security-guidance">
-        <article><h2>What you should never put into BragStack</h2><ul><li>Passwords, API keys, access tokens, or authentication secrets</li><li>Customer data or personal information you are not authorized to retain</li><li>Restricted source code, internal logs, confidential documents, or trade secrets</li><li>Anything your employer, client, contract, or NDA says cannot leave its systems</li></ul><a href="/nda-safety">See our confidential-work guide →</a></article>
-        <article><h2>Report a security issue</h2><p>If you notice unexpected account activity, a suspicious sign-in that may indicate compromise, a privacy or data-exposure problem, or a possible vulnerability, contact the security address with enough detail to investigate. Do not email passwords, access tokens, card details, or confidential evidence.</p><a href="mailto:security@usebragstack.com?subject=BragStack%20security%20report">security@usebragstack.com →</a></article>
+        <article><h2>What you should never put into BragStack</h2><ul><li>Passwords, API keys, access tokens, access codes, or authentication secrets</li><li>Patient or health information, student records, case files, constituent records, customer data, payment information, or other personal information you are not authorized to retain</li><li>Restricted source code, internal logs, personnel records, private financials, confidential contracts, proprietary schematics, unreleased creative work, trade secrets, or other protected material</li><li>Anything your employer, client, school, healthcare organization, agency, professional rules, contract, NDA, privacy obligations, or applicable law says cannot be stored in a third-party system</li></ul><a href="/nda-safety">See our confidential-work guide →</a></article>
+        <article><h2>Report a security issue</h2><p>If you notice unexpected account activity, a suspicious sign-in that may indicate compromise, a privacy or data-exposure problem, or a possible vulnerability, contact the security address with enough detail to investigate. Do not email passwords, access tokens, card details, protected records, or confidential evidence.</p><a href="mailto:security@usebragstack.com?subject=BragStack%20security%20report">security@usebragstack.com →</a></article>
       </section>
 
-      <section className="security-note"><TriangleAlert size={20} /><div><strong>No online service can promise absolute security.</strong><p>BragStack uses reasonable safeguards designed to protect your information, but good account hygiene still matters: use strong credentials, protect your Google or GitHub account, and be careful about what workplace material you retain.</p></div></section>
+      <section className="security-note"><TriangleAlert size={20} /><div><strong>No online service can promise absolute security.</strong><p>BragStack uses reasonable safeguards designed to protect your information, but good account hygiene still matters: use strong credentials, protect your sign-in provider account, and be careful about what workplace, client, patient, student, customer, case, or other restricted material you retain.</p></div></section>
       <PublicFooter />
     </main>
   );

--- a/frontend/src/useSearchAppearanceMeta.js
+++ b/frontend/src/useSearchAppearanceMeta.js
@@ -4,7 +4,7 @@ import { PRIMARY_SITELINKS } from "./primarySitelinks.js";
 const PUBLIC_META = {
   "/": {
     title: "BragStack | Career Proof, Resume Builder & Interview Practice",
-    description: "BragStack turns everyday wins into reusable career proof for resumes, interviews, reviews, promotions, and your next opportunity.",
+    description: "BragStack helps people across industries turn everyday wins into reusable career proof for resumes, interviews, reviews, promotions, portfolios, certifications, and their next opportunity.",
   },
   "/login": {
     title: "Sign In to BragStack | Career Proof",
@@ -12,15 +12,15 @@ const PUBLIC_META = {
   },
   "/register": {
     title: "Sign up for BragStack | Start Free",
-    description: "Create a free BragStack account and start turning your accomplishments into career proof for resumes, interviews, reviews, and promotions.",
+    description: "Create a free BragStack account and start turning your accomplishments into career proof for resumes, interviews, reviews, promotions, portfolios, and career transitions.",
   },
   "/how-it-works": {
     title: "How BragStack Works | Capture, Prove & Reuse Career Evidence",
-    description: "See how BragStack helps you capture accomplishments, create Impact Receipts, reuse evidence for career moments, share selectively, and keep private work private.",
+    description: "See how BragStack helps people in any profession capture accomplishments, create Impact Receipts, reuse evidence for career moments, share selectively, and keep private work private.",
   },
   "/use-cases": {
     title: "BragStack Use Cases | Reviews, Promotions, Resumes & Interviews",
-    description: "Explore practical BragStack use cases for performance reviews, promotions, resumes, interviews, career changes, freelancers, founders, and education-to-career proof.",
+    description: "Explore BragStack use cases across professions for reviews, promotions, resumes, interviews, certifications, career changes, freelancers, founders, students, and education-to-career proof.",
   },
   "/contact": {
     title: "Contact BragStack | Support, Privacy, Security & Billing",
@@ -48,7 +48,7 @@ const PUBLIC_META = {
   },
   "/nda-safety": {
     title: "NDA & Confidential Work Guidance | BragStack",
-    description: "Learn how to document professional accomplishments in BragStack without overriding NDAs, employer policies, client agreements, or confidentiality obligations.",
+    description: "Learn how people across healthcare, education, trades, service, sales, creative, public-sector, technology, and other work can document accomplishments without overriding NDAs, privacy duties, professional obligations, employer policies, or client agreements.",
   },
   "/education": {
     title: "BragStack Education | Turn Learning into Career Proof",
@@ -56,7 +56,7 @@ const PUBLIC_META = {
   },
   "/docs": {
     title: "BragStack Docs | How to Use Career Proof",
-    description: "Learn how to use BragStack, Impact Receipts, Resume Builder, Practice Interviewer, privacy controls, and career proof workflows.",
+    description: "Learn how people across professions can use BragStack, Impact Receipts, Resume Builder, Practice Interviewer, privacy controls, and career proof workflows.",
   },
   "/docs/education": {
     title: "BragStack Education Guide | Learning & Career Proof",


### PR DESCRIPTION
## Summary
- rewrites NDA/confidential-work guidance so technology is one profession among many rather than the default
- adds concrete confidentiality examples for healthcare/care work, education, retail/hospitality/customer service, sales/account management, skilled trades/field service, finance/legal/government/nonprofit, creative/media/marketing, and technology
- expands safe-evidence examples beyond tickets, commits, repositories, and deployments
- adds a canonical cross-industry documentation standard for future product, legal, investor, demo, and AI-generated examples
- broadens homepage/search metadata to describe BragStack as career evidence for people across industries

## Positioning rule
BragStack's evidence model is profession-neutral. A GTM wedge may target one early segment based on measured demand, but that does not redefine the product around software engineers, technical workers, or office-based knowledge workers.

## Confidentiality boundary
The new guidance does not weaken NDA/privacy obligations. It broadens them to profession-specific risks such as patient information, student records, case files, financial/customer records, constituent data, facility/security details, unreleased creative work, trade secrets, and technical secrets. The rule remains: capture the career signal, not the secret.

## Google Drive canonical docs updated in place
- Product Overview
- Company Snapshot
- Impact Receipts Overview
- Brand Guide
- Product Roadmap
- Sales & GTM Playbook
- Pre-Seed Scorecard
- Investor Pushbacks & Answers

Internal engineering documents remain intentionally technical where their subject is BragStack engineering/operations.