### PR TITLE
Make Ops the private governance and access control center

### DIFF
--- a/backend/app/ops_routes.py
+++ b/backend/app/ops_routes.py
@@ -2,14 +2,13 @@
 from __future__ import annotations
 
 import os
-import re
 from collections import Counter
 from datetime import datetime, timedelta, timezone
 from typing import Callable
 
 from bson import ObjectId
 from fastapi import APIRouter, Depends, HTTPException, Query, status
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, EmailStr, Field
 from pymongo.errors import PyMongoError
 
 from app.auth import get_current_user
@@ -30,8 +29,8 @@ from app.plans import PLAN_PRICING, get_entitlements_for_user, get_plan_for_user
 router = APIRouter(prefix="/ops", tags=["ops"])
 
 INTERNAL_ROLES = {"support", "ops", "security", "admin"}
-COMPANY_DOMAIN = os.getenv("OPS_COMPANY_DOMAIN", "usebragstack.com").strip().lower()
-BOOTSTRAP_ADMINS = {
+OWNER_BOOTSTRAP_ADMINS = {"tobias.scott@usebragstack.com"}
+BOOTSTRAP_ADMINS = OWNER_BOOTSTRAP_ADMINS | {
     email.strip().lower()
     for email in os.getenv("OPS_ADMIN_EMAILS", "").split(",")
     if email.strip()
@@ -43,10 +42,15 @@ class InternalRoleUpdate(BaseModel):
     roles: list[str] = Field(default_factory=list, max_length=4)
 
 
-def _email_is_company(email: str) -> bool:
-    """Handle email is company."""
-    normalized = (email or "").strip().lower()
-    return bool(normalized) and normalized.endswith(f"@{COMPANY_DOMAIN}")
+class InternalRoleAssignment(BaseModel):
+    """Assign internal access to an existing verified account by email."""
+    email: EmailStr
+    roles: list[str] = Field(min_length=1, max_length=4)
+
+
+def _user_is_verified(user: dict) -> bool:
+    """Return whether the account has completed the verification required for it."""
+    return bool(user.get("email_verified_at")) or not user.get("email_verification_required", False)
 
 
 def _roles_for_user(user: dict) -> set[str]:
@@ -60,17 +64,16 @@ def _roles_for_user(user: dict) -> set[str]:
 
 
 def require_internal_role(*allowed_roles: str) -> Callable:
-    """Handle require internal role."""
+    """Require an explicitly assigned internal role on a verified account."""
     allowed = {role.lower() for role in allowed_roles}
 
     async def dependency(current_user: dict = Depends(get_current_user)) -> dict:
-        """Handle dependency."""
-        email = (current_user.get("email") or "").strip().lower()
+        """Deny internal route discovery unless the account is explicitly authorized."""
         roles = _roles_for_user(current_user)
-        if not _email_is_company(email) or not roles.intersection(allowed):
+        if not _user_is_verified(current_user) or not roles.intersection(allowed):
             raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail="Internal operations access is not authorized for this account.",
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Not found",
             )
         user = dict(current_user)
         user["_effective_internal_roles"] = sorted(roles)
@@ -86,8 +89,7 @@ def _safe_user(user: dict) -> dict:
         "id": user_id,
         "email": user.get("email", ""),
         "name": user.get("name", ""),
-        "email_verified": bool(user.get("email_verified_at"))
-        or not user.get("email_verification_required", False),
+        "email_verified": _user_is_verified(user),
         "plan": get_plan_for_user(user),
         "entitlements": get_entitlements_for_user(user),
         "created_at": user.get("created_at"),
@@ -108,6 +110,7 @@ def _safe_team_member(user: dict) -> dict:
         "id": str(user.get("_id", "")),
         "email": email,
         "name": user.get("name", ""),
+        "email_verified": _user_is_verified(user),
         "roles": stored_roles,
         "effective_roles": effective_roles,
         "bootstrap_admin": email in BOOTSTRAP_ADMINS,
@@ -472,14 +475,44 @@ def user_diagnostics(
 
 @router.get("/team")
 def list_internal_team(current_user: dict = Depends(require_internal_role("admin"))):
-    """Handle list internal team."""
+    """List only accounts that currently have explicit internal access."""
     del current_user
-    domain_pattern = re.compile(rf"@{re.escape(COMPANY_DOMAIN)}$", re.IGNORECASE)
     members = users_collection.find(
-        {"email": domain_pattern},
-        {"email": 1, "name": 1, "internal_roles": 1},
+        {
+            "$or": [
+                {"internal_roles": {"$exists": True, "$ne": []}},
+                {"email": {"$in": sorted(BOOTSTRAP_ADMINS)}},
+            ]
+        },
+        {"email": 1, "name": 1, "internal_roles": 1, "email_verified_at": 1, "email_verification_required": 1},
     ).sort("email", 1).limit(100)
     return {"members": [_safe_team_member(member) for member in members], "allowed_roles": sorted(INTERNAL_ROLES)}
+
+
+@router.post("/team/assign")
+def assign_internal_roles(
+    payload: InternalRoleAssignment,
+    current_user: dict = Depends(require_internal_role("admin")),
+):
+    """Assign internal roles by email after the account exists and is verified."""
+    normalized_email = str(payload.email).strip().lower()
+    target = users_collection.find_one({"email": normalized_email})
+    if target is None:
+        raise HTTPException(
+            status_code=404,
+            detail="No BragStack account exists for this email yet. Invite them first, then assign access after they register and verify.",
+        )
+    if not _user_is_verified(target):
+        raise HTTPException(status_code=409, detail="Verify this account before granting internal access.")
+
+    next_roles = _normalize_roles(payload.roles)
+    previous_roles = sorted({str(role).strip().lower() for role in target.get("internal_roles", [])} & INTERNAL_ROLES)
+    users_collection.update_one({"_id": target["_id"]}, {"$set": {"internal_roles": next_roles}})
+    _audit_role_change(actor=current_user, target=target, previous_roles=previous_roles, next_roles=next_roles)
+
+    updated = dict(target)
+    updated["internal_roles"] = next_roles
+    return _safe_team_member(updated)
 
 
 @router.patch("/team/{user_id}/roles")
@@ -493,8 +526,10 @@ def update_internal_roles(
         raise HTTPException(status_code=404, detail="Internal team member not found")
 
     target = users_collection.find_one({"_id": ObjectId(user_id)})
-    if target is None or not _email_is_company(target.get("email", "")):
+    if target is None:
         raise HTTPException(status_code=404, detail="Internal team member not found")
+    if not _user_is_verified(target):
+        raise HTTPException(status_code=409, detail="Verify this account before granting internal access.")
 
     next_roles = _normalize_roles(payload.roles)
     previous_roles = sorted({str(role).strip().lower() for role in target.get("internal_roles", [])} & INTERNAL_ROLES)

--- a/backend/tests/test_ops_console.py
+++ b/backend/tests/test_ops_console.py
@@ -56,18 +56,38 @@ def teardown_function():
     clear_for_tests()
 
 
-def test_company_domain_alone_does_not_grant_ops_access():
-    """Verify company domain alone does not grant ops access."""
+def test_unassigned_account_does_not_discover_ops_route():
+    """Verify an unassigned account gets a not-found response for internal routes."""
     _override_user(_user(roles=[]))
     response = client.get("/ops/access")
-    assert response.status_code == 403
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Not found"
 
 
-def test_internal_role_outside_company_domain_does_not_grant_access():
-    """Verify internal role outside company domain does not grant access."""
-    _override_user(_user(email="attacker@example.com", roles=["admin"]))
+def test_explicit_role_can_authorize_verified_account_from_any_domain():
+    """Verify explicit role assignment, not email domain, is the internal access boundary."""
+    _override_user(_user(email="trusted-counsel@example.com", roles=["security"]))
     response = client.get("/ops/access")
-    assert response.status_code == 403
+    assert response.status_code == 200
+    assert response.json()["roles"] == ["security"]
+
+
+def test_unverified_account_cannot_use_internal_role():
+    """Verify internal roles do not activate before required email verification."""
+    user = _user(email="operator@example.com", roles=["ops"])
+    user["email_verification_required"] = True
+    user["email_verified_at"] = None
+    _override_user(user)
+    response = client.get("/ops/access")
+    assert response.status_code == 404
+
+
+def test_owner_email_is_bootstrap_admin():
+    """Verify the founder owner account retains a bootstrap recovery admin role."""
+    _override_user(_user(email="tobias.scott@usebragstack.com", roles=[]))
+    response = client.get("/ops/access")
+    assert response.status_code == 200
+    assert "admin" in response.json()["roles"]
 
 
 def test_explicit_internal_role_grants_access():
@@ -137,11 +157,11 @@ def test_non_admin_cannot_manage_team():
     """Verify non admin cannot manage team."""
     _override_user(_user(roles=["ops"]))
     response = client.get("/ops/team")
-    assert response.status_code == 403
+    assert response.status_code == 404
 
 
-def test_admin_can_update_company_user_roles_and_audit(monkeypatch):
-    """Verify admin can update company user roles and audit.
+def test_admin_can_update_user_roles_and_audit(monkeypatch):
+    """Verify admin can update user roles and audit.
 
     Args:
         monkeypatch: Function argument.
@@ -164,18 +184,35 @@ def test_admin_can_update_company_user_roles_and_audit(monkeypatch):
     assert recorded[0]["next_roles"] == ["ops", "security"]
 
 
-def test_role_management_rejects_outside_domain_target(monkeypatch):
-    """Verify role management rejects outside domain target.
+def test_admin_can_assign_verified_account_by_email(monkeypatch):
+    """Verify an admin can explicitly grant access to an existing verified account."""
+    actor = _user(email="admin@usebragstack.com", roles=["admin"])
+    target = _user(email="trusted-counsel@example.com", roles=[])
+    _override_user(actor)
+    monkeypatch.setattr(ops_routes.users_collection, "find_one", lambda query: target)
+    monkeypatch.setattr(ops_routes.users_collection, "update_one", lambda query, update: None)
+    recorded = []
+    monkeypatch.setattr(ops_routes.ops_audit_collection, "insert_one", lambda event: recorded.append(event))
 
-    Args:
-        monkeypatch: Function argument.
-    """
-    _override_user(_user(roles=["admin"]))
-    target = _user(email="member@example.com", roles=[])
+    response = client.post("/ops/team/assign", json={"email": "trusted-counsel@example.com", "roles": ["security"]})
+    assert response.status_code == 200
+    assert response.json()["email"] == "trusted-counsel@example.com"
+    assert response.json()["roles"] == ["security"]
+    assert recorded[0]["target_email"] == "trusted-counsel@example.com"
+
+
+def test_admin_cannot_assign_unverified_account(monkeypatch):
+    """Verify unverified accounts cannot be granted internal access."""
+    actor = _user(email="admin@usebragstack.com", roles=["admin"])
+    target = _user(email="pending@example.com", roles=[])
+    target["email_verification_required"] = True
+    target["email_verified_at"] = None
+    _override_user(actor)
     monkeypatch.setattr(ops_routes.users_collection, "find_one", lambda query: target)
 
-    response = client.patch(f"/ops/team/{target['_id']}/roles", json={"roles": ["support"]})
-    assert response.status_code == 404
+    response = client.post("/ops/team/assign", json={"email": "pending@example.com", "roles": ["support"]})
+    assert response.status_code == 409
+    assert "verify" in response.json()["detail"].lower()
 
 
 def test_last_database_admin_cannot_be_removed_without_bootstrap(monkeypatch):

--- a/frontend/src/AppSidebar.jsx
+++ b/frontend/src/AppSidebar.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { BarChart3, BrainCircuit, Building2, ChevronDown, FileCheck2, FileText, GraduationCap, Home, ListChecks, LogOut, Menu, ReceiptText, Settings, ShieldCheck, Sparkles, UserRound, Users, Video, X } from "lucide-react";
 import { getCurrentUser } from "./api";
+import { getOpsAccess } from "./opsApi";
 import "./AppShell.css";
 import "./SidebarCollapsible.css";
 
@@ -19,16 +20,20 @@ const CAREER_TOOLS = [
 ];
 
 function AppSidebar() {
-  const [user, setUser] = useState(null); const [mobileOpen, setMobileOpen] = useState(false);
+  const [user, setUser] = useState(null); const [mobileOpen, setMobileOpen] = useState(false); const [internalAccess, setInternalAccess] = useState(null);
   const path = window.location.pathname; const search = window.location.search; const hash = window.location.hash;
   const careerToolsActive = path === "/app/resume-builder" || path === "/app/interview-practice" || path === "/app/reports";
   const [careerToolsOpen, setCareerToolsOpen] = useState(() => careerToolsActive || localStorage.getItem("bragstack_career_tools_nav") !== "closed");
-  useEffect(() => { let mounted = true; (async () => { try { const data = await getCurrentUser(); if (mounted) setUser(data); } catch (error) { if (error.response?.status === 401) { localStorage.removeItem("bragstack_token"); window.location.assign("/login"); } } })(); return () => { mounted = false; }; }, []);
+  useEffect(() => { let mounted = true; (async () => { try { const data = await getCurrentUser(); if (!mounted) return; setUser(data); try { const access = await getOpsAccess(); if (mounted) setInternalAccess(access?.authorized ? access : null); } catch { if (mounted) setInternalAccess(null); } } catch (error) { if (error.response?.status === 401) { localStorage.removeItem("bragstack_token"); window.location.assign("/login"); } } })(); return () => { mounted = false; }; }, []);
   function logout() { localStorage.removeItem("bragstack_token"); window.location.assign("/login"); }
   function toolIsActive(href) { const target = new URL(href, window.location.origin); return path === target.pathname && search === target.search && hash === target.hash; }
   function toggleCareerTools(event) { const open = event.currentTarget.open; setCareerToolsOpen(open); localStorage.setItem("bragstack_career_tools_nav", open ? "open" : "closed"); }
   const isPro = Boolean(user?.entitlements?.advanced_reports);
-  const isCompanyUser = user?.email?.trim().toLowerCase().endsWith("@usebragstack.com") === true;
+  const internalRoles = new Set(internalAccess?.roles || []);
+  const canUseOpsConsole = internalRoles.has("ops") || internalRoles.has("security") || internalRoles.has("admin");
+  const canUseUserAccounts = internalRoles.has("support") || canUseOpsConsole;
+  const canUseGovernance = canUseOpsConsole;
+  const hasAnyInternalAccess = canUseOpsConsole || canUseUserAccounts;
   const hasExecutiveImpact = Boolean(user?.entitlements?.executive_command_center) && ["owner", "admin", "executive"].includes(user?.workspace_role);
 
   return <>
@@ -44,7 +49,7 @@ function AppSidebar() {
         {hasExecutiveImpact && <><p className="sidebar-section-label">Enterprise</p><a className={path === "/app/executive-impact" ? "active" : ""} href="/app/executive-impact"><Building2 size={18}/><span>Executive Impact</span></a></>}
         <p className="sidebar-section-label">Account & tools</p>
         <a className={path.startsWith("/app/settings") || path === "/app/profile" ? "active" : ""} href="/app/settings"><Settings size={18} /><span>Settings</span></a>
-        {isCompanyUser && <><p className="sidebar-section-label">Internal</p><a className={path === "/ops" ? "active" : ""} href="/ops"><ShieldCheck size={18} /><span>Ops Console</span></a><a className={path === "/ops/users" ? "active" : ""} href="/ops/users"><Users size={18} /><span>User Accounts</span></a><a className={path === "/ops/ai-verification" ? "active" : ""} href="/ops/ai-verification"><BrainCircuit size={18} /><span>AI Verification</span></a><a className={path === "/ops/compliance" ? "active" : ""} href="/ops/compliance"><FileCheck2 size={18} /><span>Compliance Audit</span></a></>}
+        {hasAnyInternalAccess && <><p className="sidebar-section-label">Internal</p>{canUseOpsConsole && <a className={path === "/ops" ? "active" : ""} href="/ops"><ShieldCheck size={18} /><span>Ops Console</span></a>}{canUseUserAccounts && <a className={path === "/ops/users" ? "active" : ""} href="/ops/users"><Users size={18} /><span>User Accounts</span></a>}{canUseGovernance && <a className={path === "/ops/ai-verification" ? "active" : ""} href="/ops/ai-verification"><BrainCircuit size={18} /><span>AI Verification</span></a>}{canUseGovernance && <a className={path === "/ops/compliance" ? "active" : ""} href="/ops/compliance"><FileCheck2 size={18} /><span>Governance Reports</span></a>}</>}
         <a href="/docs"><FileText size={18} /><span>Docs & guides</span></a>
         {user && !isPro && <a className="sidebar-upgrade" href="/upgrade"><Sparkles size={18} /><span>Upgrade to Pro</span></a>}
       </nav>

--- a/frontend/src/ComplianceAuditPanel.jsx
+++ b/frontend/src/ComplianceAuditPanel.jsx
@@ -33,11 +33,16 @@ function FindingIcon({ status }) {
   return <AlertTriangle size={18} aria-hidden="true" />;
 }
 
-export default function ComplianceAuditPanel() {
+export default function ComplianceAuditPanel({ onReceiptChange = null }) {
   const [receipt, setReceipt] = useState(null);
   const [history, setHistory] = useState([]);
   const [running, setRunning] = useState(false);
   const [error, setError] = useState("");
+
+  function selectReceipt(nextReceipt) {
+    setReceipt(nextReceipt || null);
+    if (onReceiptChange) onReceiptChange(nextReceipt || null);
+  }
 
   useEffect(() => {
     let active = true;
@@ -45,25 +50,26 @@ export default function ComplianceAuditPanel() {
       .then(([latest, historyResponse]) => {
         if (!active) return;
         setReceipt(latest || null);
+        if (onReceiptChange) onReceiptChange(latest || null);
         setHistory(historyResponse?.receipts || []);
       })
       .catch((err) => {
         if (!active || err.response?.status === 404) return;
-        setError(err.response?.data?.detail || "Compliance receipts could not be loaded.");
+        setError(err.response?.data?.detail || "Governance receipts could not be loaded.");
       });
     return () => { active = false; };
-  }, []);
+  }, [onReceiptChange]);
 
   async function runAudit() {
     setRunning(true);
     setError("");
     try {
       const nextReceipt = await runComplianceAudit();
-      setReceipt(nextReceipt);
+      selectReceipt(nextReceipt);
       const historyResponse = await getComplianceAuditHistory(10);
       setHistory(historyResponse?.receipts || []);
     } catch (err) {
-      setError(err.response?.data?.detail || "Compliance audit could not be completed.");
+      setError(err.response?.data?.detail || "Governance scan could not be completed.");
     } finally {
       setRunning(false);
     }
@@ -81,18 +87,18 @@ export default function ComplianceAuditPanel() {
   return <section className="ops-panel compliance-panel" id="compliance-readiness">
     <div className="ops-panel-heading compliance-heading">
       <div>
-        <p className="ops-kicker">OPS · COMPLIANCE & BUSINESS READINESS</p>
-        <h2><ShieldAlert size={22} aria-hidden="true" /> Whole-business audit</h2>
-        <p>Runs conservative controls across business formation, customer contracting, privacy, billing, vendors, retention, marketing, AI, fundraising, and governance evidence. A pass is evidence—not a legal certification.</p>
+        <p className="ops-kicker">OPS · LEGAL · BUSINESS · SECURITY · SAFETY</p>
+        <h2><ShieldAlert size={22} aria-hidden="true" /> Whole-business governance scan</h2>
+        <p>Runs conservative controls across legal readiness, business formation, privacy, billing, security evidence, retention, vendors, marketing, AI safety, fundraising, and governance. Findings also feed the Ops Inbox. A pass is evidence—not a legal certification.</p>
       </div>
       <div className="compliance-actions">
-        <button type="button" className="compliance-run" disabled={running} onClick={() => void runAudit()}><PlayCircle size={17} /> {running ? "Running audit…" : "Run compliance audit"}</button>
+        <button type="button" className="compliance-run" disabled={running} onClick={() => void runAudit()}><PlayCircle size={17} /> {running ? "Running scan…" : "Run governance scan"}</button>
         <button type="button" disabled={!receipt} onClick={() => downloadReceipt(receipt)}><Download size={17} /> Download receipt</button>
       </div>
     </div>
 
     {error && <p className="ops-error">{error}</p>}
-    {!receipt && !error && <div className="compliance-empty"><FileCheck2 size={30} /><strong>No compliance receipt yet.</strong><span>Run the first audit to establish a timestamped baseline.</span></div>}
+    {!receipt && !error && <div className="compliance-empty"><FileCheck2 size={30} /><strong>No governance receipt yet.</strong><span>Run the first scan to establish a timestamped baseline and populate Ops Inbox findings.</span></div>}
 
     {receipt && <>
       <div className="compliance-receipt-meta">
@@ -131,7 +137,7 @@ export default function ComplianceAuditPanel() {
       <div className="compliance-history">
         <h3>Recent timestamped receipts</h3>
         {history.length === 0 && <p className="ops-empty">No prior receipts.</p>}
-        {history.map((item) => <button type="button" key={item.receipt_id} onClick={() => setReceipt(item)}>
+        {history.map((item) => <button type="button" key={item.receipt_id} onClick={() => selectReceipt(item)}>
           <span>{new Date(item.generated_at).toLocaleString()}</span><strong>{item.summary?.overall?.replaceAll("_", " ") || "audit"}</strong><code>{item.receipt_id}</code>
         </button>)}
       </div>

--- a/frontend/src/OpsConsolePage.jsx
+++ b/frontend/src/OpsConsolePage.jsx
@@ -11,6 +11,8 @@ import {
   Search,
 } from "lucide-react";
 import {
+  assignOpsRolesByEmail,
+  getLatestComplianceAudit,
   getOpsAccess,
   getOpsAudit,
   getOpsObservability,
@@ -20,8 +22,10 @@ import {
   updateOpsRoles,
 } from "./opsApi";
 import BragStackLoader from "./BragStackLoader.jsx";
+import ComplianceAuditPanel from "./ComplianceAuditPanel.jsx";
 import FounderAnalyticsPanel from "./FounderAnalyticsPanel.jsx";
 import "./OpsConsolePage.css";
+import "./ComplianceAuditPanel.css";
 
 const OPS_INBOX_STORAGE_KEY = "bragstack_ops_inbox_state_v1";
 const ATTENTION_PRIORITIES = new Set(["urgent", "action", "warning"]);
@@ -58,8 +62,64 @@ function isFutureTimestamp(value) {
   return Number(value || 0) > Date.now();
 }
 
-function buildOpsMessages({ service = {}, persisted = {}, audit = null }) {
+function governanceArea(finding = {}) {
+  const id = String(finding.control_id || "");
+  const category = String(finding.category || "").toLowerCase();
+  if (id.startsWith("BUS-") || id.startsWith("FUND-") || category.includes("fundraising") || category.includes("corporate") || category.includes("tax")) return "Business";
+  if (id.startsWith("AI-") || id.startsWith("MINORS-") || category.includes("younger") || category.includes("safety")) return "Safety";
+  if (id.startsWith("PRIV-VENDOR") || id.startsWith("PRIV-RETENTION") || id.startsWith("GOV-") || category.includes("data lifecycle") || category.includes("vendor")) return "Security";
+  return "Legal";
+}
+
+function governancePriority(finding = {}) {
+  if (finding.status === "gap" && finding.severity === "blocker") return "urgent";
+  if (finding.status === "gap" || finding.status === "counsel_review" || finding.severity === "high") return "action";
+  if (finding.status === "needs_evidence" || finding.status === "upcoming") return "warning";
+  return "info";
+}
+
+function buildOpsMessages({ service = {}, persisted = {}, audit = null, compliance = null }) {
   const messages = [];
+
+  if (compliance) {
+    const overall = String(compliance.summary?.overall || "action_required");
+    const blockers = compliance.summary?.blockers?.length || 0;
+    messages.push({
+      id: `governance:${compliance.receipt_id}`,
+      source: "Governance",
+      category: "Whole-business report",
+      priority: overall === "blocked" ? "urgent" : overall === "action_required" ? "action" : "info",
+      title: `Governance scan: ${overall.replaceAll("_", " ")}`,
+      summary: `${blockers} blocker${blockers === 1 ? "" : "s"} · ${(compliance.findings || []).length} controls reviewed across legal, business, security, and safety readiness.`,
+      meaning: "This is the latest timestamped governance receipt. It records evidence, gaps, counsel-review items, and upcoming obligations; it is not a legal certification.",
+      nextStep: overall === "ready" ? "Keep the evidence current and rerun the scan after material product, business, vendor, legal, or security changes." : "Open the governance report, start with blockers and high-severity findings, and preserve evidence as each issue is resolved.",
+      detail: `Receipt ${compliance.receipt_id}`,
+      createdAt: compliance.generated_at,
+      syncRecommended: overall !== "ready",
+      externalUrl: "/ops/compliance",
+    });
+
+    (compliance.findings || [])
+      .filter((finding) => !["pass", "not_applicable"].includes(finding.status))
+      .slice(0, 16)
+      .forEach((finding) => {
+        const area = governanceArea(finding);
+        messages.push({
+          id: `governance:${compliance.receipt_id}:${finding.control_id}`,
+          source: "Governance",
+          category: `${area} report`,
+          priority: governancePriority(finding),
+          title: finding.title,
+          summary: finding.summary,
+          meaning: `${area} control ${finding.control_id} is marked ${String(finding.status || "unknown").replaceAll("_", " ")} with ${finding.severity || "unknown"} severity in the latest governance scan.`,
+          nextStep: finding.next_action,
+          detail: finding.counsel_required ? `${finding.control_id} · counsel review` : finding.control_id,
+          createdAt: compliance.generated_at,
+          syncRecommended: finding.severity === "blocker" || finding.severity === "high" || finding.counsel_required,
+          externalUrl: "/ops/compliance#compliance-readiness",
+        });
+      });
+  }
 
   if (service.mongo && service.mongo !== "ok") {
     messages.push({
@@ -187,8 +247,8 @@ function PriorityIcon({ priority }) {
   return <Info size={18} aria-hidden="true" />;
 }
 
-function OpsInbox({ service, persisted, audit }) {
-  const messages = useMemo(() => buildOpsMessages({ service, persisted, audit }), [service, persisted, audit]);
+function OpsInbox({ service, persisted, audit, compliance }) {
+  const messages = useMemo(() => buildOpsMessages({ service, persisted, audit, compliance }), [service, persisted, audit, compliance]);
   const [state, setState] = useState(readInboxState);
   const [expanded, setExpanded] = useState({});
   const [filter, setFilter] = useState("all");
@@ -259,7 +319,7 @@ function OpsInbox({ service, persisted, audit }) {
       <div>
         <p className="ops-kicker">FOUNDER · OPS INBOX</p>
         <h2><Inbox size={22} aria-hidden="true" /> Messages worth reading</h2>
-        <p>Each card is a plain-English Ops alert. Tap <strong>View details</strong> to see what it means and exactly what to do next.</p>
+        <p>Legal, business, security, safety, application, and access-control findings arrive here as plain-English Ops messages. Tap <strong>View details</strong> to see what it means and exactly what to do next.</p>
       </div>
       <div className="ops-inbox-summary" aria-label="Ops inbox summary">
         <div><Bell size={17} /><strong>{unreadCount}</strong><span>Unread</span></div>
@@ -275,7 +335,7 @@ function OpsInbox({ service, persisted, audit }) {
     </div>
 
     <div className="ops-message-list">
-      {filteredMessages.length === 0 && <div className="ops-inbox-empty"><CheckCheck size={30} /><strong>Nothing needs your attention here.</strong><span>Try another filter, or refresh diagnostics.</span></div>}
+      {filteredMessages.length === 0 && <div className="ops-inbox-empty"><CheckCheck size={30} /><strong>Nothing needs your attention here.</strong><span>Try another filter, refresh diagnostics, or run a governance scan.</span></div>}
       {filteredMessages.map((message) => <article className={`ops-message ${message.priority} ${isRead(message.id) ? "read" : "unread"}`} key={message.id}>
         <div className="ops-message-icon"><PriorityIcon priority={message.priority} /></div>
         <div className="ops-message-body">
@@ -288,7 +348,7 @@ function OpsInbox({ service, persisted, audit }) {
           {!isRead(message.id) && <button type="button" onClick={() => markRead(message.id)}><CheckCheck size={15} /> Mark read</button>}
           {!isArchived(message.id) && <button type="button" onClick={() => snoozeMessage(message.id)}><Clock3 size={15} /> Snooze 1h</button>}
           <button type="button" onClick={() => archiveMessage(message.id)}><Archive size={15} /> {isArchived(message.id) ? "Restore" : "Archive"}</button>
-          {message.externalUrl && <a href={message.externalUrl} target="_blank" rel="noreferrer"><ExternalLink size={15} /> Open</a>}
+          {message.externalUrl && <a href={message.externalUrl}><ExternalLink size={15} /> Open report</a>}
         </div>
       </article>)}
     </div>
@@ -314,6 +374,8 @@ function AuditEventRow({ event }) {
 function RoleManager({ team, setTeam, audit, setAudit }) {
   const [saving, setSaving] = useState("");
   const [roleError, setRoleError] = useState("");
+  const [assignEmail, setAssignEmail] = useState("");
+  const [assignRoles, setAssignRoles] = useState(["support"]);
   const roles = team?.allowed_roles || [];
 
   async function toggleRole(member, role) {
@@ -331,12 +393,46 @@ function RoleManager({ team, setTeam, audit, setAudit }) {
     }
   }
 
+  function toggleAssignRole(role) {
+    setAssignRoles((current) => current.includes(role) ? current.filter((item) => item !== role) : [...current, role]);
+  }
+
+  async function assignAccess(event) {
+    event.preventDefault();
+    if (!assignRoles.length) { setRoleError("Choose at least one role."); return; }
+    setSaving("assign");
+    setRoleError("");
+    try {
+      const updated = await assignOpsRolesByEmail(assignEmail, assignRoles);
+      setTeam((current) => {
+        const existing = (current?.members || []).some((item) => item.id === updated.id);
+        const members = existing
+          ? current.members.map((item) => item.id === updated.id ? updated : item)
+          : [updated, ...(current?.members || [])];
+        return { ...current, members };
+      });
+      setAudit(await getOpsAudit());
+      setAssignEmail("");
+      setAssignRoles(["support"]);
+    } catch (err) {
+      setRoleError(err.response?.data?.detail || "Access assignment failed.");
+    } finally {
+      setSaving("");
+    }
+  }
+
   return <>
     {roleError && <p className="ops-error">{roleError}</p>}
+    <form className="ops-user-search" onSubmit={assignAccess}>
+      <input type="email" value={assignEmail} onChange={(event) => setAssignEmail(event.target.value)} placeholder="verified-operator@example.com" required />
+      <div className="ops-role-list">{roles.map((role) => <label key={`assign-${role}`}><input type="checkbox" checked={assignRoles.includes(role)} disabled={saving === "assign"} onChange={() => toggleAssignRole(role)} /><span>{role}</span></label>)}</div>
+      <button type="submit" disabled={saving === "assign"}>{saving === "assign" ? "Assigning…" : "Assign access"}</button>
+    </form>
+    <p className="ops-empty">The person must already have a verified BragStack account. If they do not, invite them first; an invitation alone never grants internal access.</p>
     <div className="ops-team-grid">{(team?.members || []).map((member) => <article className="ops-team-card" key={member.id}>
       <div><strong>{member.name || member.email}</strong><small>{member.email}</small></div>
       {member.bootstrap_admin && <span className="ops-bootstrap-badge">Bootstrap admin</span>}
-      <div className="ops-role-list">{roles.map((role) => <label key={role}><input type="checkbox" checked={member.roles.includes(role)} disabled={saving === member.id} onChange={() => void toggleRole(member, role)} /><span>{role}</span></label>)}</div>
+      <div className="ops-role-list">{roles.map((role) => <label key={role}><input type="checkbox" checked={member.roles.includes(role)} disabled={saving === member.id || member.bootstrap_admin && role === "admin"} onChange={() => void toggleRole(member, role)} /><span>{role}</span></label>)}</div>
       <small>Effective: {(member.effective_roles || []).join(", ") || "none"}</small>
     </article>)}</div>
     <div className="ops-audit-list"><h3>Recent admin actions</h3>{(audit?.events || []).length === 0 && <p className="ops-empty">No admin actions recorded yet.</p>}{(audit?.events || []).map((event, index) => <AuditEventRow event={event} key={`${event.created_at}-${index}`} />)}</div>
@@ -349,6 +445,7 @@ export default function OpsConsolePage() {
   const [observability, setObservability] = useState(null);
   const [team, setTeam] = useState(null);
   const [audit, setAudit] = useState(null);
+  const [compliance, setCompliance] = useState(null);
   const [error, setError] = useState("");
   const [email, setEmail] = useState("");
   const [userResult, setUserResult] = useState(null);
@@ -357,11 +454,11 @@ export default function OpsConsolePage() {
 
   async function loadDiagnostics() {
     const nextAccess = await getOpsAccess();
-    const [nextOverview, nextObservability] = await Promise.all([getOpsOverview(), getOpsObservability()]);
+    const [nextOverview, nextObservability, nextCompliance] = await Promise.all([getOpsOverview(), getOpsObservability(), getLatestComplianceAudit()]);
     let nextTeam = null;
     let nextAudit = null;
     if ((nextAccess.roles || []).includes("admin")) [nextTeam, nextAudit] = await Promise.all([getOpsTeam(), getOpsAudit()]);
-    return { nextAccess, nextOverview, nextObservability, nextTeam, nextAudit };
+    return { nextAccess, nextOverview, nextObservability, nextTeam, nextAudit, nextCompliance };
   }
 
   async function refreshDiagnostics() {
@@ -369,9 +466,9 @@ export default function OpsConsolePage() {
     setError("");
     try {
       const data = await loadDiagnostics();
-      setAccess(data.nextAccess); setOverview(data.nextOverview); setObservability(data.nextObservability); setTeam(data.nextTeam); setAudit(data.nextAudit);
+      setAccess(data.nextAccess); setOverview(data.nextOverview); setObservability(data.nextObservability); setTeam(data.nextTeam); setAudit(data.nextAudit); setCompliance(data.nextCompliance);
     } catch (err) {
-      setError(err.response?.status === 403 ? "This account is not authorized for BragStack Ops." : "Ops diagnostics could not be loaded.");
+      setError(err.response?.status === 404 ? "This account is not authorized for the BragStack Ops Console." : "Ops diagnostics could not be loaded.");
     } finally {
       setLoading(false);
     }
@@ -383,10 +480,10 @@ export default function OpsConsolePage() {
       try {
         const data = await loadDiagnostics();
         if (!active) return;
-        setAccess(data.nextAccess); setOverview(data.nextOverview); setObservability(data.nextObservability); setTeam(data.nextTeam); setAudit(data.nextAudit);
+        setAccess(data.nextAccess); setOverview(data.nextOverview); setObservability(data.nextObservability); setTeam(data.nextTeam); setAudit(data.nextAudit); setCompliance(data.nextCompliance);
       } catch (err) {
         if (!active) return;
-        setError(err.response?.status === 403 ? "This account is not authorized for BragStack Ops." : "Ops diagnostics could not be loaded.");
+        setError(err.response?.status === 404 ? "This account is not authorized for the BragStack Ops Console." : "Ops diagnostics could not be loaded.");
       } finally {
         if (active) setLoading(false);
       }
@@ -400,7 +497,7 @@ export default function OpsConsolePage() {
     catch (err) { setUserError(err.response?.data?.detail || "User diagnostics could not be loaded."); }
   }
 
-  if (loading) return <BragStackLoader compact message="Loading BragStack Ops…" detail="Checking founder analytics, service health, telemetry, database state, and authorized diagnostics." />;
+  if (loading) return <BragStackLoader compact message="Loading BragStack Ops…" detail="Checking governance reports, founder analytics, service health, telemetry, database state, and authorized diagnostics." />;
   if (error) return <main className="ops-page"><section className="ops-denied"><h1>BragStack Ops</h1><p>{error}</p><a href="/app">Return to BragStack</a></section></main>;
 
   const service = overview?.service || {};
@@ -411,24 +508,25 @@ export default function OpsConsolePage() {
   const isAdmin = (access?.roles || []).includes("admin");
 
   return <main className="ops-page">
-    <header className="ops-header"><div><p className="ops-kicker">INTERNAL · CONTROLLED ACCESS</p><h1>BragStack Ops Console</h1><p>Founder analytics, application diagnostics, persistent request tracing, grouped errors, database health, safe user-state debugging, and audited internal access management.</p></div><div className={`ops-env ${service.environment === "production" ? "production" : "nonprod"}`}>{String(service.environment || access?.environment || "unknown").toUpperCase()}</div></header>
-    <div className="ops-toolbar"><span>Roles: {(access?.roles || []).join(", ")}</span><button type="button" onClick={refreshDiagnostics}>Refresh diagnostics</button></div>
+    <header className="ops-header"><div><p className="ops-kicker">INTERNAL · EXPLICIT ACCESS ONLY</p><h1>BragStack Ops Console</h1><p>Whole-business governance scanning, Legal/Business/Security/Safety reports, Ops Inbox alerts, founder analytics, application diagnostics, safe user-state debugging, and audited internal access management.</p></div><div className={`ops-env ${service.environment === "production" ? "production" : "nonprod"}`}>{String(service.environment || access?.environment || "unknown").toUpperCase()}</div></header>
+    <div className="ops-toolbar"><span>Authorized roles: {(access?.roles || []).join(", ")}</span><button type="button" onClick={refreshDiagnostics}>Refresh Ops</button></div>
 
     <section className="ops-grid">
       <article className="ops-card"><span>API</span><strong>{service.name || "bragstack-api"}</strong><small>Commit {service.version || "unknown"}</small></article>
       <article className="ops-card"><span>MongoDB</span><strong className={service.mongo === "ok" ? "healthy" : "degraded"}>{service.mongo || "unknown"}</strong><small>Live ping from API process</small></article>
-      <article className="ops-card"><span>Persisted traces</span><strong>{persisted.sample_size || 0}</strong><small>{persisted.status_classes?.["5xx"] || 0} server errors · {persisted.retention_days || 14}-day retention</small></article>
+      <article className="ops-card"><span>Governance</span><strong>{compliance?.summary?.overall?.replaceAll("_", " ") || "not scanned"}</strong><small>{compliance?.receipt_id || "Run a scan to create a receipt"}</small></article>
       <article className="ops-card"><span>Stored users</span><strong>{database.users ?? "—"}</strong><small>{database.entries ?? "—"} accomplishments · {database.impact_receipts ?? "—"} receipts</small></article>
     </section>
 
+    <ComplianceAuditPanel onReceiptChange={setCompliance} />
+    <OpsInbox service={service} persisted={persisted} audit={isAdmin ? audit : null} compliance={compliance} />
     <FounderAnalyticsPanel analytics={analytics} />
-    <OpsInbox service={service} persisted={persisted} audit={isAdmin ? audit : null} />
+
+    {isAdmin && <section className="ops-panel"><div className="ops-panel-heading"><div><p className="ops-kicker">ADMIN · TEAM & ROLES</p><h2>Invite, assign, and audit internal access</h2><p>Only verified accounts you explicitly assign receive internal access. Grant the minimum role needed; every change is persisted and audit logged.</p></div></div><RoleManager team={team} setTeam={setTeam} audit={audit} setAudit={setAudit} /></section>}
 
     <section className="ops-panel"><div className="ops-panel-heading"><div><p className="ops-kicker">PERSISTENT OBSERVABILITY V2</p><h2>Grouped backend exceptions</h2><p>Sanitized fingerprints survive restarts and deployments without storing request bodies, headers, tokens, query strings, or exception messages.</p></div></div><ErrorGroups rows={persisted.errors} /></section>
     <section className="ops-panel"><div className="ops-panel-heading"><div><p className="ops-kicker">PERSISTENT FAILURES</p><h2>Recent 4xx / 5xx requests</h2></div></div><RequestTable rows={persisted.failures} /></section>
     <section className="ops-panel"><div className="ops-panel-heading"><div><p className="ops-kicker">PERSISTENT PERFORMANCE</p><h2>Slow requests ≥ 500 ms</h2></div></div><RequestTable rows={persisted.slow} /></section>
-
-    {isAdmin && <section className="ops-panel"><div className="ops-panel-heading"><div><p className="ops-kicker">ADMIN · TEAM & ROLES</p><h2>Internal access management</h2><p>Grant only the minimum role needed. Changes are persisted and audit logged.</p></div></div><RoleManager team={team} setTeam={setTeam} audit={audit} setAudit={setAudit} /></section>}
 
     <section className="ops-panel"><div className="ops-panel-heading"><div><p className="ops-kicker">LIVE PROCESS TELEMETRY</p><h2>Current-process failures</h2></div></div><RequestTable rows={requests.failures} /></section>
     <section className="ops-panel"><div className="ops-panel-heading"><div><p className="ops-kicker">LIVE TRAFFIC</p><h2>Recent requests</h2></div></div><RequestTable rows={requests.recent} /></section>

--- a/frontend/src/opsApi.js
+++ b/frontend/src/opsApi.js
@@ -22,6 +22,7 @@ export async function getOpsUserAnalytics(userId) { const response = await opsAp
 export async function resendOpsVerificationEmail(userId) { const response = await opsApi.post(`/ops/user-directory/${userId}/resend-verification`); return response.data; }
 export async function sendOpsUserInvite(payload) { const response = await opsApi.post("/ops/user-invites", payload); return response.data; }
 export async function getOpsTeam() { const response = await opsApi.get("/ops/team"); return response.data; }
+export async function assignOpsRolesByEmail(email, roles) { const response = await opsApi.post("/ops/team/assign", { email, roles }); return response.data; }
 export async function updateOpsRoles(userId, roles) { const response = await opsApi.patch(`/ops/team/${userId}/roles`, { roles }); return response.data; }
 export async function getOpsAudit() { const response = await opsApi.get("/ops/audit"); return response.data; }
 export async function getComplianceCatalog() { const response = await opsApi.get("/ops/compliance/catalog"); return response.data; }


### PR DESCRIPTION
## Summary
- makes `tobias.scott@usebragstack.com` a verified bootstrap owner/admin recovery account
- changes internal authorization to verified-account + explicit-role assignment; unauthorized internal routes return 404
- hides all Internal navigation unless `/ops/access` confirms authorization, with role-specific links
- embeds the whole-business governance scanner directly in `/ops`
- sends Legal, Business, Security, and Safety governance findings into the Ops Inbox
- adds timestamped governance receipt status to the Ops overview
- adds audited `Assign access` by email + roles for existing verified accounts
- keeps invitations separate from authorization: invite does not grant an internal role
- preserves last-admin and bootstrap-admin safeguards

## Access model
1. Ordinary account: no Internal navigation; direct `/ops/*` access is denied as not found.
2. Invited but not assigned: still no internal access.
3. Verified account explicitly assigned `support`, `ops`, `security`, or `admin`: receives only role-authorized internal surfaces.
4. Founder bootstrap owner: `tobias.scott@usebragstack.com` always receives effective `admin` after account verification.

## Governance workflow
`/ops` now runs and displays the whole-business governance scan. The latest receipt is converted into Ops Inbox messages by report area (Legal / Business / Security / Safety), including blockers, counsel-review items, evidence gaps, and next actions. Receipts remain integrity-hashed and downloadable; a pass is evidence/readiness, not a legal certification.