### PR TITLE
Grant temporary complimentary Pro access to everyone

### DIFF
--- a/backend/app/billing_routes.py
+++ b/backend/app/billing_routes.py
@@ -13,7 +13,12 @@ from pymongo.errors import DuplicateKeyError
 
 from app.auth import get_current_user
 from app.database import stripe_webhook_events_collection, users_collection
-from app.plans import get_plan_for_user
+from app.plans import (
+    TEMPORARY_PRO_GIFT_CAMPAIGN,
+    TEMPORARY_PRO_GIFT_NOTICE,
+    get_plan_for_user,
+    has_temporary_pro_gift,
+)
 
 router = APIRouter(prefix="/billing", tags=["billing"])
 
@@ -259,20 +264,20 @@ def _find_user_for_invoice(invoice: dict) -> dict | None:
 
 
 def _subscription_status_payload(user: dict) -> dict:
-    """Handle subscription status payload.
-
-    Args:
-        user: Function argument.
-
-    Returns:
-        Function result.
-    """
+    """Return subscription state separately from temporary promotional access."""
+    promotional_access = has_temporary_pro_gift(user)
+    has_subscription = bool(user.get("stripe_subscription_id"))
     return {
         "plan": get_plan_for_user(user),
+        "persisted_plan": user.get("plan", "free"),
         "billing_status": user.get("billing_status", "free"),
         "cancel_at_period_end": bool(user.get("billing_cancel_at_period_end", False)),
         "current_period_end": user.get("billing_current_period_end"),
-        "has_subscription": bool(user.get("stripe_subscription_id")),
+        "has_subscription": has_subscription,
+        "temporary_pro_gift": promotional_access,
+        "access_source": "complimentary_pro" if promotional_access else ("subscription" if has_subscription else "plan"),
+        "promotional_campaign": TEMPORARY_PRO_GIFT_CAMPAIGN if promotional_access else None,
+        "promotional_notice": TEMPORARY_PRO_GIFT_NOTICE if promotional_access else None,
     }
 
 
@@ -305,6 +310,17 @@ async def _update_stripe_subscription(subscription_id: str, *, cancel_at_period_
 @router.post("/checkout-session")
 async def create_checkout_session(current_user: dict = Depends(get_current_user)):
     """Create a Stripe Checkout subscription session for BragStack Pro."""
+    if has_temporary_pro_gift(current_user):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "code": "complimentary_pro_active",
+                "message": "BragStack Pro is temporarily complimentary for this account, so a new paid checkout is not required right now.",
+                "campaign": TEMPORARY_PRO_GIFT_CAMPAIGN,
+                "notice": TEMPORARY_PRO_GIFT_NOTICE,
+            },
+        )
+
     _require_stripe_checkout_config()
 
     if get_plan_for_user(current_user) == "pro" and current_user.get("billing_status") in {

--- a/backend/app/plans.py
+++ b/backend/app/plans.py
@@ -7,6 +7,7 @@ reimplementing plan checks so pricing and entitlement behavior stays consistent.
 
 from __future__ import annotations
 
+import os
 from typing import Any
 
 from fastapi import HTTPException, status
@@ -14,6 +15,22 @@ from fastapi import HTTPException, status
 FREE_ENTRY_LIMIT = 5
 FREE_IMPACT_RECEIPT_LIMIT = 1
 INTERNAL_EMAIL_DOMAIN = "usebragstack.com"
+
+# Temporary early-access gift. This intentionally changes effective access only;
+# it does not rewrite a user's persisted plan, create a Stripe subscription, or
+# authorize a future charge. Set BRAGSTACK_TEMPORARY_PRO_GIFT_ENABLED=false to
+# return entitlement resolution to persisted plans.
+TEMPORARY_PRO_GIFT_ENABLED = os.getenv(
+    "BRAGSTACK_TEMPORARY_PRO_GIFT_ENABLED", "true"
+).strip().lower() in {"1", "true", "yes", "on"}
+TEMPORARY_PRO_GIFT_CAMPAIGN = "early-access-pro-gift-v1"
+TEMPORARY_PRO_GIFT_NOTICE = (
+    "BragStack Pro is temporarily complimentary as an early-access gift. "
+    "This promotional access does not create a paid subscription, does not "
+    "authorize recurring charges, and may be changed or ended in the future. "
+    "If paid Pro access is offered later, BragStack will require a separate "
+    "purchase flow and billing consent before charging you."
+)
 
 PLAN_PRICING: dict[str, dict[str, Any]] = {
     "free": {"monthly": 0, "label": "Free"},
@@ -115,92 +132,85 @@ PLAN_FEATURES: dict[str, dict[str, Any]] = {
 
 
 def normalize_plan(plan: str | None) -> str:
-    """Normalize an arbitrary plan value to a supported plan key.
-
-    Args:
-        plan: User-supplied or persisted plan value.
-
-    Returns:
-        A valid key from ``PLAN_FEATURES``. Unknown or missing values fall back
-        to ``free``.
-    """
+    """Normalize an arbitrary plan value to a supported plan key."""
     normalized = (plan or "free").strip().lower()
     return normalized if normalized in PLAN_FEATURES else "free"
 
 
 def is_internal_user(user: dict) -> bool:
-    """Determine whether a user is a verified BragStack internal identity.
-
-    Args:
-        user: User document containing email and verification fields.
-
-    Returns:
-        ``True`` for verified identities on the BragStack company domain.
-    """
+    """Determine whether a user is a verified BragStack internal identity."""
     email = (user.get("email") or "").strip().lower()
     if not email.endswith(f"@{INTERNAL_EMAIL_DOMAIN}"):
         return False
     return bool(user.get("email_verified_at")) or not user.get("email_verification_required", False)
 
 
+def has_active_paid_subscription(user: dict) -> bool:
+    """Return whether the account currently carries an active Stripe subscription."""
+    return bool(user.get("stripe_subscription_id")) and str(
+        user.get("billing_status") or ""
+    ).strip().lower() in {"active", "trialing", "past_due"}
+
+
+def has_temporary_pro_gift(user: dict) -> bool:
+    """Return whether this user is receiving the temporary complimentary Pro grant.
+
+    Paid subscribers keep their ordinary subscription state. Team/Enterprise and
+    internal accounts also retain their existing higher-order access rather than
+    being relabeled as promotional Pro.
+    """
+    if not TEMPORARY_PRO_GIFT_ENABLED or is_internal_user(user):
+        return False
+    if has_active_paid_subscription(user):
+        return False
+    return normalize_plan(user.get("plan")) in {"free", "pro"}
+
+
 def get_plan_for_user(user: dict) -> str:
     """Resolve the effective UI-facing plan for a user.
 
-    Internal users present as Pro so existing UI checks remain compatible while
-    entitlement resolution can still grant the complete internal feature set.
-
-    Args:
-        user: User document containing plan and identity fields.
-
-    Returns:
-        The effective plan key used by product UI and plan messaging.
+    During the temporary early-access gift, ordinary Free accounts receive Pro
+    access without changing their stored plan or creating a billing relationship.
+    Existing Team/Enterprise plans and internal access are preserved.
     """
     if is_internal_user(user):
         return "pro"
-    return normalize_plan(user.get("plan"))
+
+    persisted_plan = normalize_plan(user.get("plan"))
+    if TEMPORARY_PRO_GIFT_ENABLED and persisted_plan not in {"team", "enterprise"}:
+        return "pro"
+    return persisted_plan
 
 
 def get_entitlements_for_user(user: dict) -> dict[str, Any]:
-    """Return a copy of the feature entitlements available to a user.
-
-    Args:
-        user: User document containing plan and identity fields.
-
-    Returns:
-        A copy of the resolved entitlement mapping. Internal users receive the
-        enterprise feature set for staff testing and operations.
-    """
+    """Return a copy of the feature entitlements available to a user."""
     if is_internal_user(user):
         return dict(PLAN_FEATURES["enterprise"])
-    return dict(PLAN_FEATURES[get_plan_for_user(user)])
+
+    persisted_plan = normalize_plan(user.get("plan"))
+    if TEMPORARY_PRO_GIFT_ENABLED and persisted_plan not in {"team", "enterprise"}:
+        return dict(PLAN_FEATURES["pro"])
+    return dict(PLAN_FEATURES[persisted_plan])
 
 
 def get_pricing_for_user(user: dict) -> dict[str, Any]:
-    """Return display pricing for a user's effective plan.
-
-    Args:
-        user: User document containing plan and identity fields.
-
-    Returns:
-        A pricing mapping suitable for API or UI serialization. Internal users
-        receive a zero-cost ``Internal`` representation.
-    """
+    """Return display pricing for a user's effective access state."""
     if is_internal_user(user):
         return {"monthly": 0, "label": "Internal"}
+    if has_temporary_pro_gift(user):
+        return {
+            "monthly": 0,
+            "label": "Complimentary Pro",
+            "promotional": True,
+            "standard_monthly": PLAN_PRICING["pro"]["monthly"],
+            "campaign": TEMPORARY_PRO_GIFT_CAMPAIGN,
+            "notice": TEMPORARY_PRO_GIFT_NOTICE,
+        }
     return dict(PLAN_PRICING[get_plan_for_user(user)])
 
 
 def require_feature(user: dict, feature_name: str) -> None:
-    """Require a boolean feature entitlement for the current user.
-
-    Args:
-        user: User document used to resolve entitlements.
-        feature_name: Entitlement key that must evaluate to a truthy value.
-
-    Raises:
-        HTTPException: With status 403 when the feature is unavailable on the
-            user's current plan.
-    """
+    """Require a boolean feature entitlement for the current user."""
     entitlements = get_entitlements_for_user(user)
     if entitlements.get(feature_name):
         return
@@ -216,18 +226,7 @@ def require_feature(user: dict, feature_name: str) -> None:
 
 
 def enforce_usage_limit(*, user: dict, entitlement_name: str, current_count: int, resource_name: str) -> None:
-    """Enforce a numeric plan limit before creating another resource.
-
-    Args:
-        user: User document used to resolve plan entitlements.
-        entitlement_name: Entitlement key containing the numeric limit.
-        current_count: Number of resources the user currently owns.
-        resource_name: Human-readable resource label used in the error payload.
-
-    Raises:
-        HTTPException: With status 403 when the configured finite limit has
-            already been reached.
-    """
+    """Enforce a numeric plan limit before creating another resource."""
     entitlements = get_entitlements_for_user(user)
     limit = entitlements.get(entitlement_name)
     if limit is None or current_count < limit:

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,18 @@
+"""Shared pytest policy fixtures.
+
+Most historical entitlement tests intentionally verify the underlying paid-plan
+contract. Keep the temporary Pro promotion disabled for those tests so they
+continue to protect the base-plan gates. Tests that exercise the promotional
+grant explicitly opt back in by monkeypatching ``TEMPORARY_PRO_GIFT_ENABLED``
+to ``True`` in their test body.
+"""
+
+import pytest
+
+import app.plans as plans
+
+
+@pytest.fixture(autouse=True)
+def base_plan_policy_by_default(monkeypatch):
+    """Test underlying plan rules unless a test explicitly enables the gift."""
+    monkeypatch.setattr(plans, "TEMPORARY_PRO_GIFT_ENABLED", False)

--- a/backend/tests/test_temporary_pro_gift.py
+++ b/backend/tests/test_temporary_pro_gift.py
@@ -1,0 +1,96 @@
+"""Temporary complimentary Pro access regression coverage."""
+import asyncio
+
+import pytest
+from fastapi import HTTPException
+
+import app.billing_routes as billing_routes
+import app.plans as plans
+
+
+def _free_user() -> dict:
+    return {
+        "_id": "507f1f77bcf86cd799439011",
+        "email": "early-user@example.com",
+        "plan": "free",
+        "billing_status": "free",
+    }
+
+
+def test_free_accounts_receive_pro_without_mutating_persisted_plan(monkeypatch):
+    monkeypatch.setattr(plans, "TEMPORARY_PRO_GIFT_ENABLED", True)
+    user = _free_user()
+
+    assert plans.get_plan_for_user(user) == "pro"
+    assert plans.get_entitlements_for_user(user)["max_entries"] is None
+    assert plans.get_entitlements_for_user(user)["interview_practice"] is True
+    assert plans.has_temporary_pro_gift(user) is True
+    assert user["plan"] == "free"
+
+
+def test_complimentary_pricing_is_zero_and_requires_separate_future_consent(monkeypatch):
+    monkeypatch.setattr(plans, "TEMPORARY_PRO_GIFT_ENABLED", True)
+    pricing = plans.get_pricing_for_user(_free_user())
+
+    assert pricing["monthly"] == 0
+    assert pricing["label"] == "Complimentary Pro"
+    assert pricing["promotional"] is True
+    assert pricing["standard_monthly"] == 9
+    assert "does not create a paid subscription" in pricing["notice"]
+    assert "separate" in pricing["notice"]
+    assert "billing consent" in pricing["notice"]
+
+
+def test_paid_pro_subscription_is_not_relabelled_as_promotional(monkeypatch):
+    monkeypatch.setattr(plans, "TEMPORARY_PRO_GIFT_ENABLED", True)
+    user = {
+        **_free_user(),
+        "plan": "pro",
+        "billing_status": "active",
+        "stripe_subscription_id": "sub_existing",
+    }
+
+    assert plans.get_plan_for_user(user) == "pro"
+    assert plans.has_temporary_pro_gift(user) is False
+    assert plans.get_pricing_for_user(user)["monthly"] == 9
+
+
+def test_team_and_internal_access_are_not_downgraded(monkeypatch):
+    monkeypatch.setattr(plans, "TEMPORARY_PRO_GIFT_ENABLED", True)
+    team_user = {**_free_user(), "plan": "team"}
+    internal_user = {
+        **_free_user(),
+        "email": "staff@usebragstack.com",
+        "email_verification_required": False,
+    }
+
+    assert plans.get_plan_for_user(team_user) == "team"
+    assert plans.get_entitlements_for_user(team_user)["team_review_packets"] is True
+    assert plans.has_temporary_pro_gift(team_user) is False
+    assert plans.get_entitlements_for_user(internal_user)["sso"] is True
+
+
+def test_checkout_is_blocked_for_complimentary_pro_before_stripe(monkeypatch):
+    monkeypatch.setattr(plans, "TEMPORARY_PRO_GIFT_ENABLED", True)
+    # billing_routes imports the function, which reads the plans module flag.
+    user = _free_user()
+
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(billing_routes.create_checkout_session(current_user=user))
+
+    assert exc_info.value.status_code == 409
+    assert exc_info.value.detail["code"] == "complimentary_pro_active"
+    assert "not required" in exc_info.value.detail["message"]
+
+
+def test_billing_status_separates_gift_from_subscription(monkeypatch):
+    monkeypatch.setattr(plans, "TEMPORARY_PRO_GIFT_ENABLED", True)
+    payload = billing_routes._subscription_status_payload(_free_user())
+
+    assert payload["plan"] == "pro"
+    assert payload["persisted_plan"] == "free"
+    assert payload["billing_status"] == "free"
+    assert payload["has_subscription"] is False
+    assert payload["temporary_pro_gift"] is True
+    assert payload["access_source"] == "complimentary_pro"
+    assert payload["promotional_notice"]

--- a/frontend/src/InterimLegalNotice.jsx
+++ b/frontend/src/InterimLegalNotice.jsx
@@ -55,6 +55,13 @@ export function InterimTermsNotice() {
       </section>
 
       <section>
+        <h3>Temporary complimentary Pro access</h3>
+        <p>During early access, BragStack may temporarily grant Pro features to eligible accounts at no charge as a promotional gift. Complimentary Pro access is not a paid subscription, does not require a payment method, does not authorize recurring charges, and does not by itself create any obligation to purchase Pro later.</p>
+        <p>This promotional access may be modified or ended in the future. If BragStack later offers paid Pro access, the applicable price, billing interval, renewal behavior, and cancellation terms will be presented separately, and BragStack will require a separate purchase flow and billing consent before charging an account that only received complimentary access.</p>
+        <p>Existing paid subscriptions are separate from complimentary promotional access and remain governed by the billing and cancellation terms that apply to those subscriptions unless BragStack expressly changes them in accordance with applicable law.</p>
+      </section>
+
+      <section>
         <h3>Billing and subscriptions</h3>
         <p>When a paid plan is offered, the price, billing interval, renewal behavior, material limits, and cancellation terms presented at checkout control the purchase. A recurring subscription continues until canceled as disclosed at purchase. Cancellation stops future renewal subject to the terms shown at purchase and applicable law; cancellation does not automatically create a refund for time already paid unless BragStack states otherwise or law requires one.</p>
       </section>

--- a/frontend/src/LandingPage.jsx
+++ b/frontend/src/LandingPage.jsx
@@ -42,21 +42,22 @@ const plans = [
   {
     name: "Free",
     price: "$0",
-    tagline: "Start your evidence record",
+    tagline: "The standard base plan after promotional access",
+    badge: "Base plan",
     features: ["5 proof entries", "1 Impact Receipt", "Basic reports", "Basic Proof Profile", "Skill tracking"],
-    cta: "Start free",
+    cta: "Create account — Pro gift included",
     href: "/register",
   },
   {
     name: "Pro",
-    price: "$9",
-    suffix: "/month",
-    tagline: "Turn your evidence into career leverage",
+    price: "$0",
+    suffix: " for now",
+    tagline: "Temporary complimentary early-access gift",
     featured: true,
-    badge: "Best for your career",
+    badge: "Complimentary Pro gift",
     features: ["Unlimited proof + Impact Receipts", "Advanced career analytics", "Performance Review Builder", "Promotion Packet", "PDF and career exports", "Advanced profile capabilities"],
-    cta: "Unlock BragStack Pro",
-    href: "/upgrade",
+    cta: "Get Pro free for now",
+    href: "/register",
   },
   {
     name: "Team",
@@ -249,9 +250,9 @@ function LandingPage() {
       </section>
 
       <section className="landing-pricing" id="pricing">
-        <div className="landing-section-heading"><p>PRICING</p><h2>Start your evidence record free.</h2><span>Upgrade when you want to package, analyze, and reuse more of the proof you have already captured.</span></div>
+        <div className="landing-section-heading"><p>PRICING</p><h2>Everyone gets Pro for now.</h2><span>BragStack Pro is temporarily complimentary as an early-access gift. No payment method is required and receiving the gift does not create a paid subscription or authorize future recurring charges.</span></div>
         <div className="pricing-grid pricing-grid-four">{plans.map((plan) => <article className={`pricing-card ${plan.featured ? "pricing-card-featured pricing-card-pro" : ""}`} key={plan.name}>{plan.badge && <div className="pricing-popular-label">{plan.badge}</div>}<div className="pricing-card-header"><div><p>{plan.name}</p><h3>{plan.price}{plan.suffix && <span>{plan.suffix}</span>}</h3></div></div><p className="pricing-tagline">{plan.tagline}</p><ul>{plan.features.map((feature) => <li key={feature}><Check size={17} />{feature}</li>)}</ul><a className={`landing-btn pricing-button ${plan.featured ? "" : "landing-btn-secondary"}`} href={plan.href}>{plan.cta}{plan.featured && <ArrowRight size={17} />}</a></article>)}</div>
-        <div className="pricing-conversion-note"><Zap size={20} /><div><strong>Your existing proof stays yours.</strong><span>Start with capture and Impact Receipts. Upgrade when you are ready to do more with the evidence.</span></div></div>
+        <div className="pricing-conversion-note"><Zap size={20} /><div><strong>Temporary gift, not automatic billing.</strong><span>Complimentary Pro access may change or end later. If paid Pro is offered again, BragStack will require a separate checkout and billing consent before charging you. Existing paid subscriptions remain governed by their current billing terms.</span></div></div>
       </section>
 
       <section className="landing-final-cta"><div><p>YOUR WORK IS ALREADY HAPPENING.</p><h2>Give the proof somewhere to live.</h2><span>Capture it now, keep it under your control, and have the right evidence ready when the next review, interview, promotion, client, or opportunity arrives.</span></div><a className="landing-btn landing-final-button" href="/register">Build my BragStack <ArrowRight size={18} /></a></section>

--- a/frontend/src/UpgradePage.jsx
+++ b/frontend/src/UpgradePage.jsx
@@ -1,103 +1,39 @@
-import { useState } from "react";
-import { ArrowLeft, CreditCard, ShieldCheck, Sparkles, Video } from "lucide-react";
-import BragStackLoader from "./BragStackLoader.jsx";
-
-function getApiBaseUrl() {
-  if (window.location.hostname.endsWith(".app.github.dev")) return "/api";
-  if (window.location.hostname === "usebragstack.com" || window.location.hostname === "www.usebragstack.com") {
-    return import.meta.env.VITE_API_BASE_URL || import.meta.env.VITE_API_URL || "https://api.usebragstack.com";
-  }
-  return import.meta.env.VITE_API_BASE_URL || import.meta.env.VITE_API_URL || "http://localhost:8000";
-}
+import { ArrowLeft, Gift, ShieldCheck, Sparkles, Video } from "lucide-react";
 
 function UpgradePage() {
-  const [status, setStatus] = useState("");
-  const [error, setError] = useState("");
-  const [loading, setLoading] = useState(false);
-  const [billingAcknowledged, setBillingAcknowledged] = useState(false);
   const token = localStorage.getItem("bragstack_token");
-
-  async function startCheckout() {
-    if (!token) {
-      setStatus("Sign in first to upgrade your BragStack account.");
-      return;
-    }
-    if (!billingAcknowledged) {
-      setError("Please confirm the recurring billing terms before continuing to Stripe.");
-      return;
-    }
-
-    setLoading(true);
-    setError("");
-    setStatus("Opening secure Stripe Checkout…");
-
-    try {
-      const apiBase = getApiBaseUrl().replace(/\/$/, "");
-      const response = await fetch(`${apiBase}/billing/checkout-session`, {
-        method: "POST",
-        headers: { Authorization: `Bearer ${token}` },
-      });
-      const data = await response.json().catch(() => ({}));
-
-      if (response.status === 401) {
-        localStorage.removeItem("bragstack_token");
-        window.location.replace("/login");
-        return;
-      }
-
-      if (!response.ok || !data.url) {
-        throw new Error(data.detail || "Stripe Checkout is unavailable right now.");
-      }
-
-      window.location.assign(data.url);
-    } catch (checkoutError) {
-      setLoading(false);
-      setStatus("Checkout did not open.");
-      setError(checkoutError.message || "Please try again.");
-    }
-  }
-
-  if (loading) {
-    return <BragStackLoader message="Opening secure checkout…" detail="Connecting BragStack to Stripe. You'll continue in a secure checkout window." />;
-  }
 
   return (
     <main style={{ minHeight: "100vh", display: "grid", placeItems: "center", padding: 24 }}>
       <section style={{ width: "min(100%, 660px)", padding: 32, borderRadius: 28, border: "1px solid rgba(148,163,184,.2)", background: "rgba(15,23,42,.88)" }}>
         <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 14 }}>
           <Sparkles size={22} />
-          <strong>BragStack Pro · $9/month</strong>
+          <strong>BragStack Pro · complimentary for now</strong>
         </div>
-        <h1>Unlock your full career proof system.</h1>
-        <p>Unlimited proof and Impact Receipts, the Practice Interviewer, advanced career analytics, performance-review and promotion packets, PDF exports, integrations, and advanced public profile features.</p>
+        <h1>Pro is our gift while BragStack is in early access.</h1>
+        <p>Every eligible account currently receives BragStack Pro access, including unlimited proof and Impact Receipts, the Practice Interviewer, advanced career analytics, performance-review and promotion packets, PDF exports, integrations, and advanced public profile features.</p>
 
         <div style={{ display: "grid", gap: 10, margin: "24px 0" }}>
           <span><Video size={17} style={{ verticalAlign: "middle", marginRight: 8 }} />Practice role-aware interviews with adaptive answer coaching</span>
-          <span><ShieldCheck size={17} style={{ verticalAlign: "middle", marginRight: 8 }} />Secure Stripe-hosted checkout</span>
-          <span><CreditCard size={17} style={{ verticalAlign: "middle", marginRight: 8 }} />Subscription access updates through verified billing events</span>
+          <span><Gift size={17} style={{ verticalAlign: "middle", marginRight: 8 }} />Temporary complimentary Pro access for early users</span>
+          <span><ShieldCheck size={17} style={{ verticalAlign: "middle", marginRight: 8 }} />No payment method or paid checkout required for the gift</span>
         </div>
 
         <div style={{ margin: "24px 0", padding: 18, borderRadius: 18, border: "1px solid rgba(166,220,255,.24)", background: "rgba(2,6,23,.48)" }}>
-          <strong style={{ display: "block", marginBottom: 8 }}>Recurring subscription terms</strong>
-          <p style={{ margin: "0 0 10px", lineHeight: 1.6 }}><strong>$9 per month.</strong> BragStack Pro automatically renews every month until you cancel. Cancel future renewal from BragStack billing settings. Cancellation normally leaves Pro access active through the period already paid for. Fees already paid are non-refundable except where required by law or expressly stated at purchase.</p>
-          <p style={{ margin: "0 0 12px", lineHeight: 1.6 }}>Review the <a href="/terms" target="_blank" rel="noreferrer">Terms</a>, <a href="/privacy" target="_blank" rel="noreferrer">Privacy Policy</a>, and <a href="/legal/georgia-consumer-notice.html" target="_blank" rel="noreferrer">Georgia Billing & Privacy Notice</a>.</p>
-          <label style={{ display: "flex", gap: 10, alignItems: "flex-start", cursor: "pointer", lineHeight: 1.5 }}>
-            <input type="checkbox" checked={billingAcknowledged} onChange={(event) => setBillingAcknowledged(event.target.checked)} style={{ marginTop: 4 }} />
-            <span>I understand this is a <strong>$9/month automatically renewing subscription</strong> and that I can cancel future renewal using BragStack billing settings.</span>
-          </label>
+          <strong style={{ display: "block", marginBottom: 8 }}>Temporary promotional access</strong>
+          <p style={{ margin: "0 0 10px", lineHeight: 1.6 }}>BragStack Pro is temporarily complimentary as an early-access gift. Receiving this access does <strong>not</strong> create a paid subscription, does not authorize recurring charges, and does not require a payment method.</p>
+          <p style={{ margin: "0 0 10px", lineHeight: 1.6 }}>This promotional access may change or end later. If BragStack offers paid Pro access again, you will be shown the price and recurring-billing terms and must separately complete checkout and consent before BragStack charges you.</p>
+          <p style={{ margin: 0, lineHeight: 1.6 }}>Existing paid subscriptions remain governed by their current billing and cancellation terms. Review the <a href="/terms" target="_blank" rel="noreferrer">Terms</a> and <a href="/privacy" target="_blank" rel="noreferrer">Privacy Policy</a>.</p>
         </div>
-
-        {status && <p><strong>{status}</strong></p>}
-        {error && <p style={{ color: "#fecaca" }}>{error}</p>}
 
         <div style={{ display: "flex", gap: 12, flexWrap: "wrap", marginTop: 22 }}>
           {!token ? (
             <>
-              <a className="btn primary" href="/login">Sign in</a>
-              <a className="btn secondary" href="/register">Create account</a>
+              <a className="btn primary" href="/register">Create account with Pro gift</a>
+              <a className="btn secondary" href="/login">Sign in</a>
             </>
           ) : (
-            <button className="btn primary" type="button" onClick={startCheckout} disabled={!billingAcknowledged}>Continue to secure Stripe checkout</button>
+            <a className="btn primary" href="/app">Use my Pro access</a>
           )}
           <a className="btn secondary" href="/#pricing"><ArrowLeft size={16} /> Back to pricing</a>
         </div>

--- a/frontend/src/temporaryProGiftSource.test.js
+++ b/frontend/src/temporaryProGiftSource.test.js
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+function read(relativePath) {
+  return fs.readFileSync(fileURLToPath(new URL(relativePath, import.meta.url)), "utf8");
+}
+
+test("landing page clearly describes temporary complimentary Pro access", () => {
+  const source = read("./LandingPage.jsx");
+  assert.match(source, /Everyone gets Pro for now/);
+  assert.match(source, /Complimentary Pro gift/);
+  assert.match(source, /does not create a paid subscription/i);
+  assert.match(source, /does not.*authorize future recurring charges/i);
+  assert.match(source, /separate checkout and billing consent/i);
+});
+
+test("upgrade page does not solicit a new paid checkout during the gift", () => {
+  const source = read("./UpgradePage.jsx");
+  assert.match(source, /complimentary for now/i);
+  assert.match(source, /does not create a paid subscription/i);
+  assert.match(source, /does not authorize recurring charges/i);
+  assert.match(source, /must separately complete checkout and consent/i);
+  assert.doesNotMatch(source, /checkout-session/);
+  assert.doesNotMatch(source, /automatically renewing subscription/);
+});
+
+test("interim terms distinguish the gift from future paid subscriptions", () => {
+  const source = read("./InterimLegalNotice.jsx");
+  assert.match(source, /Temporary complimentary Pro access/);
+  assert.match(source, /not a paid subscription/i);
+  assert.match(source, /does not authorize recurring charges/i);
+  assert.match(source, /separate purchase flow and billing consent/i);
+  assert.match(source, /Existing paid subscriptions are separate/i);
+});


### PR DESCRIPTION
## What changed
- Grants every ordinary BragStack account effective Pro access while keeping the persisted billing plan unchanged.
- Preserves Team/Enterprise entitlements and BragStack internal staff access.
- Adds an explicit early-access promotional campaign flag that can later be disabled with `BRAGSTACK_TEMPORARY_PRO_GIFT_ENABLED=false`.
- Separates complimentary access from Stripe billing state in `/billing/status`.
- Blocks new Stripe checkout for accounts receiving the complimentary Pro gift so the gift cannot accidentally become a paid recurring subscription.
- Leaves existing paid subscriptions intact and manageable through existing cancel/resume flows.

## Customer messaging / legal guardrail
- Landing pricing now says everyone gets Pro for now and clearly describes it as temporary promotional access.
- Upgrade page no longer solicits a new paid checkout during the gift.
- Interim Terms state that complimentary Pro is not a paid subscription, does not require a payment method, does not authorize recurring charges, may end later, and any future paid Pro requires separate checkout and billing consent.
- Existing paid subscriptions are explicitly described as separate from the gift.

## Tests
- Backend tests verify Free → effective Pro, no stored-plan mutation, zero promotional pricing, Team/Internal preservation, paid-subscriber separation, blocked new checkout, and billing-status metadata.
- Frontend source tests require the gift disclaimer and ensure the upgrade page no longer contains a checkout-session path or automatic-renewal solicitation during the gift.

## Important operational note
This PR intentionally does **not** cancel or alter existing Stripe subscriptions. There are existing subscription records, so stopping or crediting those subscriptions should be handled as a separate explicit billing decision rather than silently changing customer billing.