### PR TITLE
Show Pro as a free gift with no card required

### DIFF
--- a/backend/app/billing_details_routes.py
+++ b/backend/app/billing_details_routes.py
@@ -7,7 +7,7 @@ import httpx
 from fastapi import APIRouter, Depends
 
 from app.auth import get_current_user
-from app.plans import PLAN_PRICING, get_plan_for_user
+from app.plans import get_plan_for_user, get_pricing_for_user, has_temporary_pro_gift
 
 router = APIRouter(prefix="/billing", tags=["billing"])
 STRIPE_API_BASE = "https://api.stripe.com/v1"
@@ -16,18 +16,26 @@ STRIPE_SECRET_KEY = os.getenv("STRIPE_SECRET_KEY", "")
 
 def _fallback_payload(user: dict) -> dict:
     plan = get_plan_for_user(user)
-    pricing = PLAN_PRICING.get(plan, {})
+    pricing = get_pricing_for_user(user)
+    promotional = has_temporary_pro_gift(user)
     monthly = pricing.get("monthly")
+    has_subscription = bool(user.get("stripe_subscription_id"))
     return {
         "plan": plan,
+        "persisted_plan": user.get("plan", "free"),
         "status": user.get("billing_status", "free"),
         "cancel_at_period_end": bool(user.get("billing_cancel_at_period_end", False)),
         "current_period_end": user.get("billing_current_period_end"),
         "amount": monthly,
         "currency": "usd" if monthly is not None else None,
-        "interval": "month" if monthly is not None else None,
+        "interval": None if promotional else ("month" if monthly is not None else None),
         "payment_method": None,
         "stripe_live": False,
+        "temporary_pro_gift": promotional,
+        "has_subscription": has_subscription,
+        "access_source": "complimentary_pro" if promotional else ("subscription" if has_subscription else "plan"),
+        "standard_monthly": pricing.get("standard_monthly"),
+        "promotional_notice": pricing.get("notice"),
     }
 
 
@@ -78,6 +86,11 @@ async def billing_details(current_user: dict = Depends(get_current_user)):
             "interval": recurring.get("interval") or payload["interval"],
             "payment_method": _payment_method(subscription.get("default_payment_method")),
             "stripe_live": True,
+            "has_subscription": True,
+            "access_source": "subscription",
+            "temporary_pro_gift": False,
+            "standard_monthly": None,
+            "promotional_notice": None,
         })
         return payload
     except Exception:

--- a/backend/tests/test_billing_details_gift.py
+++ b/backend/tests/test_billing_details_gift.py
@@ -1,0 +1,46 @@
+"""Billing-detail behavior for temporary complimentary Pro access."""
+
+import app.plans as plans
+from app.billing_details_routes import _fallback_payload
+
+
+def test_complimentary_pro_billing_details_are_card_free(monkeypatch):
+    monkeypatch.setattr(plans, "TEMPORARY_PRO_GIFT_ENABLED", True)
+    user = {
+        "email": "gift@example.com",
+        "plan": "free",
+        "billing_status": "free",
+    }
+
+    payload = _fallback_payload(user)
+
+    assert payload["plan"] == "pro"
+    assert payload["persisted_plan"] == "free"
+    assert payload["temporary_pro_gift"] is True
+    assert payload["has_subscription"] is False
+    assert payload["access_source"] == "complimentary_pro"
+    assert payload["amount"] == 0
+    assert payload["standard_monthly"] == 9
+    assert payload["interval"] is None
+    assert payload["payment_method"] is None
+    assert payload["stripe_live"] is False
+
+
+def test_existing_paid_subscription_stays_separate_from_gift(monkeypatch):
+    monkeypatch.setattr(plans, "TEMPORARY_PRO_GIFT_ENABLED", True)
+    user = {
+        "email": "paid@example.com",
+        "plan": "pro",
+        "billing_status": "active",
+        "stripe_subscription_id": "sub_existing",
+    }
+
+    payload = _fallback_payload(user)
+
+    assert payload["plan"] == "pro"
+    assert payload["temporary_pro_gift"] is False
+    assert payload["has_subscription"] is True
+    assert payload["access_source"] == "subscription"
+    assert payload["amount"] == 9
+    assert payload["interval"] == "month"
+    assert payload["standard_monthly"] is None

--- a/frontend/src/BillingSettingsPage.jsx
+++ b/frontend/src/BillingSettingsPage.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { ArrowLeft, CheckCircle2, CreditCard, RefreshCcw, XCircle } from "lucide-react";
+import { ArrowLeft, CheckCircle2, CreditCard, Gift, RefreshCcw, XCircle } from "lucide-react";
 import BragStackLoader from "./BragStackLoader.jsx";
 import { cancelSubscription, resumeSubscription } from "./api.js";
 import "./BillingSettingsPage.css";
@@ -12,9 +12,13 @@ function cardLabel(payment){if(!payment)return "Payment method not available";if
 export default function BillingSettingsPage(){
   const[billing,setBilling]=useState(null),[loading,setLoading]=useState(true),[action,setAction]=useState(""),[error,setError]=useState("");
   const periodEnd=useMemo(()=>formatPeriodEnd(billing?.current_period_end),[billing]);
+  const isGift=Boolean(billing?.temporary_pro_gift);
+  const hasSubscription=Boolean(billing?.has_subscription);
   const isPro=billing?.plan==="pro";
-  const cancelling=Boolean(isPro&&billing?.cancel_at_period_end);
+  const isPaidPro=Boolean(isPro&&hasSubscription&&!isGift);
+  const cancelling=Boolean(isPaidPro&&billing?.cancel_at_period_end);
   const amount=formatMoney(billing?.amount,billing?.currency);
+  const standardAmount=formatMoney(billing?.standard_monthly,"usd");
 
   async function loadBilling(){
     const token=localStorage.getItem("bragstack_token");
@@ -26,22 +30,28 @@ export default function BillingSettingsPage(){
   useEffect(()=>{let active=true;(async()=>{try{const data=await loadBilling();if(active)setBilling(data);}catch{if(active)setError("We couldn't load your billing details.");}finally{if(active)setLoading(false);}})();return()=>{active=false};},[]);
 
   async function runAction(kind){setAction(kind);setError("");try{if(kind==="cancel")await cancelSubscription();else await resumeSubscription();setBilling(await loadBilling());}catch(requestError){setError(requestError.response?.data?.detail||"We couldn't update your subscription. Please try again.");}finally{setAction("");}}
-  if(loading)return <BragStackLoader compact message="Loading billing…" detail="Checking your plan, renewal, and payment details securely."/>;
+  if(loading)return <BragStackLoader compact message="Loading plan…" detail="Checking your Pro gift or paid subscription status securely."/>;
 
   return <main className="billing-settings-page">
     <a className="billing-back" href="/app/settings"><ArrowLeft size={18}/> Settings</a>
-    <header className="billing-header"><p>ACCOUNT</p><h1>Plan & billing</h1><span>See what you're paying, when the next charge happens, which payment method is on file, and your subscription controls.</span></header>
+    <header className="billing-header"><p>ACCOUNT</p><h1>Plan & billing</h1><span>{isGift?"Your complimentary Pro gift does not require a card, payment method, or paid checkout.":"See your plan, renewal details, payment method, and subscription controls."}</span></header>
     {billing?<>
-      <section className="billing-card billing-plan-card"><div className="billing-plan-icon"><CreditCard size={24}/></div><div className="billing-plan-copy"><div className="billing-plan-heading"><div><span className="billing-kicker">Current plan</span><h2>{isPro?"BragStack Pro":"BragStack Free"}</h2></div><span className={`billing-badge ${isPro?"billing-badge-pro":""}`}>{isPro?"Pro":"Free"}</span></div>{isPro&&!cancelling?<p>{periodEnd?`Your next renewal is ${periodEnd}.`:"Your Pro subscription is active and set to renew."}</p>:null}{cancelling?<div className="billing-status-panel billing-status-cancelled"><XCircle size={20}/><div><strong>Your Pro plan is canceled.</strong><span>{periodEnd?`You'll keep all Pro features until ${periodEnd}. You won't be charged again unless you resume renewal.`:"You'll keep Pro access through the end of your current paid billing period, then automatically switch to Free."}</span></div></div>:null}{!isPro?<div className="billing-status-panel"><CheckCircle2 size={20}/><div><strong>You're on the Free plan.</strong><span>Upgrade whenever you want access to BragStack Pro features.</span></div></div>:null}</div></section>
-      {isPro?<section className="billing-detail-grid" aria-label="Billing details">
+      <section className="billing-card billing-plan-card"><div className="billing-plan-icon">{isGift?<Gift size={24}/>:<CreditCard size={24}/>}</div><div className="billing-plan-copy"><div className="billing-plan-heading"><div><span className="billing-kicker">Current plan</span><h2>{isGift?"BragStack Pro · Free Gift":isPro?"BragStack Pro":"BragStack Free"}</h2></div><span className={`billing-badge ${isPro?"billing-badge-pro":""}`}>{isGift?"Gift":isPro?"Pro":"Free"}</span></div>{isGift?<div className="billing-status-panel"><CheckCircle2 size={20}/><div><strong>Pro is complimentary for now.</strong><span>No card is required, no payment method is collected for this gift, and receiving it does not create a paid subscription or authorize future recurring charges.</span></div></div>:null}{isPaidPro&&!cancelling?<p>{periodEnd?`Your next renewal is ${periodEnd}.`:"Your Pro subscription is active and set to renew."}</p>:null}{cancelling?<div className="billing-status-panel billing-status-cancelled"><XCircle size={20}/><div><strong>Your Pro plan is canceled.</strong><span>{periodEnd?`You'll keep all Pro features until ${periodEnd}. You won't be charged again unless you resume renewal.`:"You'll keep Pro access through the end of your current paid billing period, then automatically switch to Free."}</span></div></div>:null}{!isPro?<div className="billing-status-panel"><CheckCircle2 size={20}/><div><strong>You're on the Free plan.</strong><span>Upgrade whenever paid Pro becomes available.</span></div></div>:null}</div></section>
+      {isGift?<section className="billing-detail-grid" aria-label="Complimentary Pro details">
+        <article><span>Current access price</span><strong>FREE GIFT</strong><small>{standardAmount?<><del>{standardAmount} / month</del> while the early-access gift is active</>:"Temporary complimentary access"}</small></article>
+        <article><span>Payment method</span><strong>Not required</strong><small>BragStack does not ask for a card for this gift</small></article>
+        <article><span>Renewal</span><strong>No paid renewal</strong><small>This gift does not create automatic billing</small></article>
+        <article><span>Access source</span><strong>Early-access gift</strong><small>Future paid Pro would require separate checkout and consent</small></article>
+      </section>:null}
+      {isPaidPro?<section className="billing-detail-grid" aria-label="Billing details">
         <article><span>Next charge / renewal</span><strong>{cancelling?"No future charge":periodEnd||"Pending"}</strong><small>{cancelling?"Renewal is turned off":billing.stripe_live?"Synced from Stripe":"Based on your current billing record"}</small></article>
         <article><span>Subscription price</span><strong>{amount||"—"}{amount&&billing.interval?` / ${billing.interval}`:""}</strong><small>{String(billing.currency||"USD").toUpperCase()} · Taxes, if applicable, may be added by Stripe</small></article>
         <article><span>Payment method</span><strong>{cardLabel(billing.payment_method)}</strong><small>{billing.payment_method?.exp_month&&billing.payment_method?.exp_year?`Expires ${String(billing.payment_method.exp_month).padStart(2,"0")}/${String(billing.payment_method.exp_year).slice(-2)}`:"Only safe payment metadata is shown"}</small></article>
         <article><span>Subscription status</span><strong>{String(billing.status||"active").replace(/_/g," ")}</strong><small>{cancelling?"Cancels at period end":"Automatic renewal enabled"}</small></article>
       </section>:null}
       {error?<div className="billing-error" role="alert">{error}</div>:null}
-      <section className="billing-card billing-actions-card"><div><h2>Subscription</h2><p>{isPro?(cancelling?"Changed your mind? Resume renewal before your paid period ends.":"Canceling stops future renewals. Your paid access stays active through the end of this billing period."):"You can move to Pro from the upgrade page."}</p></div>{isPro&&!cancelling?<button className="billing-button billing-button-danger" type="button" disabled={Boolean(action)} onClick={()=>runAction("cancel")}>{action==="cancel"?<RefreshCcw className="billing-spin" size={17}/>:null}{action==="cancel"?"Canceling…":"Cancel subscription"}</button>:null}{isPro&&cancelling?<button className="billing-button billing-button-primary" type="button" disabled={Boolean(action)} onClick={()=>runAction("resume")}>{action==="resume"?<RefreshCcw className="billing-spin" size={17}/>:null}{action==="resume"?"Resuming…":"Resume subscription"}</button>:null}{!isPro?<a className="billing-button billing-button-primary" href="/upgrade">Upgrade to Pro</a>:null}</section>
-      <p className="billing-security-note">BragStack never receives or stores your full card number or CVC. Payment processing stays with Stripe.</p>
+      <section className="billing-card billing-actions-card"><div><h2>{isGift?"Complimentary access":"Subscription"}</h2><p>{isGift?"Use every Pro feature while the early-access gift is active. There is nothing to purchase, cancel, or renew for the gift.":isPaidPro?(cancelling?"Changed your mind? Resume renewal before your paid period ends.":"Canceling stops future renewals. Your paid access stays active through the end of this billing period."):"Paid Pro checkout is not currently required for complimentary access."}</p></div>{isPaidPro&&!cancelling?<button className="billing-button billing-button-danger" type="button" disabled={Boolean(action)} onClick={()=>runAction("cancel")}>{action==="cancel"?<RefreshCcw className="billing-spin" size={17}/>:null}{action==="cancel"?"Canceling…":"Cancel subscription"}</button>:null}{isPaidPro&&cancelling?<button className="billing-button billing-button-primary" type="button" disabled={Boolean(action)} onClick={()=>runAction("resume")}>{action==="resume"?<RefreshCcw className="billing-spin" size={17}/>:null}{action==="resume"?"Resuming…":"Resume subscription"}</button>:null}{!isPro&&!isGift?<a className="billing-button billing-button-primary" href="/upgrade">View Pro</a>:null}</section>
+      <p className="billing-security-note">{isGift?"No card or payment method is required for complimentary Pro access.":"BragStack never receives or stores your full card number or CVC. Payment processing stays with Stripe."}</p>
     </>:error?<div className="billing-error" role="alert">{error}</div>:null}
   </main>;
 }

--- a/frontend/src/LandingPageMonetization.css
+++ b/frontend/src/LandingPageMonetization.css
@@ -59,6 +59,35 @@
 .pricing-grid-four .pricing-card-header { min-height:84px; align-items:flex-end; }
 .pricing-grid-four .pricing-card-header h3 { font-size:2.25rem; }
 .pricing-grid-four .pricing-card-header h3 span { display:block; margin-top:.2rem; }
+
+/* The early-access Pro gift keeps the regular $9/month reference visible while
+   making the current complimentary price unmistakable. No card is required. */
+.pricing-card-pro .pricing-card-header h3 {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: .2rem;
+  font-size: 0;
+  line-height: 1.05;
+}
+.pricing-card-pro .pricing-card-header h3 span { display: none; }
+.pricing-card-pro .pricing-card-header h3::before {
+  content: "$9 / month";
+  color: var(--landing-muted);
+  font-size: .95rem;
+  font-weight: 750;
+  text-decoration: line-through;
+  text-decoration-thickness: 2px;
+  opacity: .8;
+}
+.pricing-card-pro .pricing-card-header h3::after {
+  content: "FREE GIFT";
+  color: var(--landing-text);
+  font-size: 2.25rem;
+  font-weight: 950;
+  letter-spacing: -.04em;
+}
+
 .pricing-tagline { min-height:48px; margin:.9rem 0 0; color:var(--landing-muted); line-height:1.45; }
 .pricing-grid-four .pricing-card ul { flex:1; margin-top:1.4rem; }
 .pricing-card-pro { transform:translateY(-10px); box-shadow:0 28px 70px rgba(116,101,255,.18); }

--- a/frontend/src/SettingsPage.jsx
+++ b/frontend/src/SettingsPage.jsx
@@ -9,7 +9,7 @@ const SETTINGS=[
   {href:"/app/settings?section=integrations",icon:CalendarDays,title:"Integrations",description:"Embed your interactive Calendly calendar on your public Proof Portfolio and manage private calendar connections."},
   {href:"/app/settings/appearance",icon:Palette,title:"Profile appearance",description:"Public-page themes, career-inspired styles, and your custom profile colors."},
   {href:"/app/settings/privacy",icon:ShieldCheck,title:"Privacy & sharing",description:"Control what stays private and what can appear on your public proof profile.",comingSoon:true},
-  {href:"/app/settings/billing",icon:CreditCard,title:"Plan & billing",description:"See renewal date, payment method, price, subscription status, and billing controls."},
+  {href:"/app/settings/billing",icon:CreditCard,title:"Plan & billing",description:"See your current plan, complimentary Pro gift status, and billing controls for any existing paid subscription."},
 ];
 
 export default function SettingsPage(){

--- a/frontend/src/UpgradePage.jsx
+++ b/frontend/src/UpgradePage.jsx
@@ -10,18 +10,23 @@ function UpgradePage() {
           <Sparkles size={22} />
           <strong>BragStack Pro · complimentary for now</strong>
         </div>
+        <div style={{ display: "flex", alignItems: "baseline", gap: 12, flexWrap: "wrap", margin: "6px 0 12px" }} aria-label="BragStack Pro regular price $9 per month, currently a free gift">
+          <del style={{ opacity: .65, fontSize: 18 }}>$9/month</del>
+          <strong style={{ fontSize: 30, letterSpacing: "-.03em" }}>FREE GIFT</strong>
+          <span style={{ opacity: .8 }}>No card required</span>
+        </div>
         <h1>Pro is our gift while BragStack is in early access.</h1>
         <p>Every eligible account currently receives BragStack Pro access, including unlimited proof and Impact Receipts, the Practice Interviewer, advanced career analytics, performance-review and promotion packets, PDF exports, integrations, and advanced public profile features.</p>
 
         <div style={{ display: "grid", gap: 10, margin: "24px 0" }}>
           <span><Video size={17} style={{ verticalAlign: "middle", marginRight: 8 }} />Practice role-aware interviews with adaptive answer coaching</span>
           <span><Gift size={17} style={{ verticalAlign: "middle", marginRight: 8 }} />Temporary complimentary Pro access for early users</span>
-          <span><ShieldCheck size={17} style={{ verticalAlign: "middle", marginRight: 8 }} />No payment method or paid checkout required for the gift</span>
+          <span><ShieldCheck size={17} style={{ verticalAlign: "middle", marginRight: 8 }} />No card, payment method, or paid checkout required for the gift</span>
         </div>
 
         <div style={{ margin: "24px 0", padding: 18, borderRadius: 18, border: "1px solid rgba(166,220,255,.24)", background: "rgba(2,6,23,.48)" }}>
           <strong style={{ display: "block", marginBottom: 8 }}>Temporary promotional access</strong>
-          <p style={{ margin: "0 0 10px", lineHeight: 1.6 }}>BragStack Pro is temporarily complimentary as an early-access gift. Receiving this access does <strong>not</strong> create a paid subscription, does not authorize recurring charges, and does not require a payment method.</p>
+          <p style={{ margin: "0 0 10px", lineHeight: 1.6 }}>BragStack Pro is temporarily complimentary as an early-access gift. Receiving this access does <strong>not</strong> create a paid subscription, does not authorize recurring charges, and does not require a card or payment method.</p>
           <p style={{ margin: "0 0 10px", lineHeight: 1.6 }}>This promotional access may change or end later. If BragStack offers paid Pro access again, you will be shown the price and recurring-billing terms and must separately complete checkout and consent before BragStack charges you.</p>
           <p style={{ margin: 0, lineHeight: 1.6 }}>Existing paid subscriptions remain governed by their current billing and cancellation terms. Review the <a href="/terms" target="_blank" rel="noreferrer">Terms</a> and <a href="/privacy" target="_blank" rel="noreferrer">Privacy Policy</a>.</p>
         </div>

--- a/frontend/src/temporaryProGiftSource.test.js
+++ b/frontend/src/temporaryProGiftSource.test.js
@@ -9,21 +9,40 @@ function read(relativePath) {
 
 test("landing page clearly describes temporary complimentary Pro access", () => {
   const source = read("./LandingPage.jsx");
+  const styles = read("./LandingPageMonetization.css");
   assert.match(source, /Everyone gets Pro for now/);
   assert.match(source, /Complimentary Pro gift/);
   assert.match(source, /does not create a paid subscription/i);
   assert.match(source, /does not.*authorize future recurring charges/i);
   assert.match(source, /separate checkout and billing consent/i);
+  assert.match(styles, /content: "\$9 \/ month"/);
+  assert.match(styles, /content: "FREE GIFT"/);
+  assert.match(styles, /text-decoration: line-through/);
 });
 
-test("upgrade page does not solicit a new paid checkout during the gift", () => {
+test("upgrade page does not solicit a new paid checkout or card during the gift", () => {
   const source = read("./UpgradePage.jsx");
   assert.match(source, /complimentary for now/i);
+  assert.match(source, /\$9\/month/);
+  assert.match(source, /FREE GIFT/);
+  assert.match(source, /No card required/i);
   assert.match(source, /does not create a paid subscription/i);
   assert.match(source, /does not authorize recurring charges/i);
+  assert.match(source, /does not require a card or payment method/i);
   assert.match(source, /must separately complete checkout and consent/i);
   assert.doesNotMatch(source, /checkout-session/);
   assert.doesNotMatch(source, /automatically renewing subscription/);
+});
+
+test("billing settings treats complimentary Pro as card-free access", () => {
+  const source = read("./BillingSettingsPage.jsx");
+  assert.match(source, /temporary_pro_gift/);
+  assert.match(source, /FREE GIFT/);
+  assert.match(source, /Payment method/);
+  assert.match(source, /Not required/);
+  assert.match(source, /does not ask for a card/i);
+  assert.match(source, /No paid renewal/);
+  assert.match(source, /separate checkout and consent/i);
 });
 
 test("interim terms distinguish the gift from future paid subscriptions", () => {


### PR DESCRIPTION
## What changed
- Visually shows the regular Pro price as **$9/month crossed out** with **FREE GIFT** on the Pro pricing card.
- Makes the Upgrade page show the same $9/month → FREE GIFT treatment and explicitly says no card is required.
- Makes billing settings gift-aware so complimentary users do not see paid-renewal or payment-method prompts.
- Keeps existing paid Stripe subscribers on their normal billing-management flow.
- Updates billing details API metadata so complimentary Pro is separated from a paid subscription.

## No-card behavior
- Complimentary Pro requires no card, payment method, or paid checkout.
- Gift users see `Payment method: Not required` and `No paid renewal`.
- The gift does not create a subscription or authorize future recurring charges.
- If paid Pro returns later, it still requires a separate checkout and consent.

## Tests
- Added backend coverage for gift-aware `/billing/details` fallback behavior.
- Expanded frontend source checks for the crossed-out $9/month price, FREE GIFT label, no-card language, and gift-aware billing settings.