### PR TITLE
Unify BragStack intelligence and send failures to Ops

### DIFF
--- a/backend/app/ai/runtime.py
+++ b/backend/app/ai/runtime.py
@@ -1,0 +1,43 @@
+"""Shared verification runtime for every BragStack intelligence surface."""
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+from fastapi import HTTPException
+
+from app.ai.verification import record_verification_event
+
+INTELLIGENCE_RUNTIME_VERSION = "bragstack-intelligence-v6"
+
+
+def record_intelligence_outcome(
+    *, feature: str, task: str, violations: Iterable[str] = (), provider: str = "deterministic",
+    model_id: str = "", model_revision: str = "deterministic", schema_version: str = "",
+    source_count: int = 0, generated_item_count: int = 0, user_id: str = "",
+) -> list[str]:
+    """Normalize and persist a privacy-safe outcome for the shared engine."""
+    normalized = sorted({str(code).strip()[:120] for code in violations if str(code).strip()})
+    record_verification_event(
+        feature=feature, task=task, passed=not normalized, violation_codes=normalized,
+        provider=provider, model_id=model_id or INTELLIGENCE_RUNTIME_VERSION,
+        model_revision=model_revision, prompt_version=INTELLIGENCE_RUNTIME_VERSION,
+        schema_version=schema_version or INTELLIGENCE_RUNTIME_VERSION,
+        source_count=source_count, generated_item_count=generated_item_count, user_id=user_id,
+    )
+    return normalized
+
+
+def enforce_intelligence_result(
+    result: dict[str, Any], *, feature: str, task: str, violations: Iterable[str],
+    failure_code: str, failure_message: str, status_code: int = 500, **telemetry: Any,
+) -> dict[str, Any]:
+    """Record one engine run and fail closed when its invariants do not hold."""
+    normalized = record_intelligence_outcome(feature=feature, task=task, violations=violations, **telemetry)
+    if normalized:
+        raise HTTPException(status_code=status_code, detail={
+            "code": failure_code, "message": failure_message, "violation_codes": normalized,
+            "engine_version": INTELLIGENCE_RUNTIME_VERSION,
+        })
+    result.setdefault("intelligence_runtime", {"version": INTELLIGENCE_RUNTIME_VERSION, "verified": True})
+    return result

--- a/backend/app/ai/verification.py
+++ b/backend/app/ai/verification.py
@@ -18,7 +18,9 @@ VERIFICATION_SCHEMA_VERSION = "ai-verification-v1"
 SMART_FEATURES = (
     "resume_builder",
     "career_intelligence",
+    "education_intelligence",
     "interview_practice",
+    "compliance_intelligence",
     "evidence_assistant",
 )
 

--- a/backend/app/career_intelligence_routes.py
+++ b/backend/app/career_intelligence_routes.py
@@ -1,7 +1,8 @@
 """Career Intelligence routes with deterministic quality verification."""
 from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
 
-from app.ai.verification import record_verification_event
+from app.ai.runtime import enforce_intelligence_result, record_intelligence_outcome
 from app.auth import get_current_user
 from app.career_intelligence_graph import build_career_intelligence_v5
 from app.career_intelligence_trajectory import TRAJECTORY_LABELS
@@ -15,6 +16,14 @@ from app.major_explorer import (
 )
 
 router = APIRouter(prefix="/career-intelligence", tags=["career-intelligence"])
+
+
+class InterviewVerificationPayload(BaseModel):
+    """Privacy-safe client verification summary for Aisha Jordan sessions."""
+    response_count: int = Field(ge=0, le=50)
+    overall_score: int = Field(ge=0, le=100)
+    failed: bool = False
+    violation_codes: list[str] = Field(default_factory=list, max_length=20)
 
 
 def _bounded_percent(value) -> bool:
@@ -288,11 +297,11 @@ def _load_intelligence(current_user: dict) -> dict:
     version = str(methodology.get("version") or "career-intelligence-unknown")
     schema_version = str(methodology.get("schema_version") or version)
     graph = result.get("career_graph") or {}
-    record_verification_event(
+    return enforce_intelligence_result(result, violations=violations,
         feature="career_intelligence",
         task="analysis",
-        passed=not violations,
-        violation_codes=violations,
+        failure_code="career_intelligence_verification_failed",
+        failure_message="BragStack withheld Career Intelligence because its calculated metrics did not reconcile to your saved proof.",
         provider="deterministic",
         model_id=version,
         model_revision="deterministic",
@@ -307,16 +316,6 @@ def _load_intelligence(current_user: dict) -> dict:
         ),
         user_id=user_id,
     )
-    if violations:
-        raise HTTPException(
-            status_code=500,
-            detail={
-                "code": "career_intelligence_verification_failed",
-                "message": "BragStack withheld Career Intelligence because its calculated metrics did not reconcile to your saved proof.",
-                "violation_codes": violations,
-            },
-        )
-    return result
 
 
 def _load_application_intelligence(current_user: dict, application_type: str) -> dict:
@@ -328,11 +327,11 @@ def _load_application_intelligence(current_user: dict, application_type: str) ->
     receipts = list(impact_receipts_collection.find({"user_id": user_id}))
     result = build_application_intelligence(entries, receipts, application_type)
     violations = _verify_application_intelligence(result, entries, receipts)
-    record_verification_event(
-        feature="career_intelligence",
+    return enforce_intelligence_result(result, violations=violations,
+        feature="education_intelligence",
         task=f"application_{application_type}",
-        passed=not violations,
-        violation_codes=violations,
+        failure_code="application_intelligence_verification_failed",
+        failure_message="BragStack withheld application guidance because its recommendations did not reconcile to your saved proof.",
         provider="deterministic",
         model_id="education-intelligence-v1",
         model_revision="deterministic",
@@ -341,16 +340,6 @@ def _load_application_intelligence(current_user: dict, application_type: str) ->
         generated_item_count=len(result.get("recommended_evidence") or []) + len(result.get("gaps") or []),
         user_id=user_id,
     )
-    if violations:
-        raise HTTPException(
-            status_code=500,
-            detail={
-                "code": "application_intelligence_verification_failed",
-                "message": "BragStack withheld application guidance because its recommendations did not reconcile to your saved proof.",
-                "violation_codes": violations,
-            },
-        )
-    return result
 
 
 def _load_major_explorer(current_user: dict) -> dict:
@@ -360,11 +349,11 @@ def _load_major_explorer(current_user: dict) -> dict:
     receipts = list(impact_receipts_collection.find({"user_id": user_id}))
     result = build_major_explorer(entries, receipts)
     violations = _verify_major_explorer(result, entries, receipts)
-    record_verification_event(
+    return enforce_intelligence_result(result, violations=violations,
         feature="education_intelligence",
         task="major_explorer",
-        passed=not violations,
-        violation_codes=violations,
+        failure_code="major_explorer_verification_failed",
+        failure_message="BragStack withheld Major Explorer guidance because the result did not satisfy its exploration and safety rules.",
         provider="deterministic",
         model_id=MAJOR_EXPLORER_VERSION,
         model_revision="deterministic",
@@ -373,16 +362,6 @@ def _load_major_explorer(current_user: dict) -> dict:
         generated_item_count=len(result.get("recommendations") or []),
         user_id=user_id,
     )
-    if violations:
-        raise HTTPException(
-            status_code=500,
-            detail={
-                "code": "major_explorer_verification_failed",
-                "message": "BragStack withheld Major Explorer guidance because the result did not satisfy its exploration and safety rules.",
-                "violation_codes": violations,
-            },
-        )
-    return result
 
 
 @router.get("")
@@ -419,3 +398,17 @@ def get_major_explorer(current_user: dict = Depends(get_current_user)):
 def get_application_intelligence(application_type: str, current_user: dict = Depends(get_current_user)):
     """Return verified evidence recommendations for a student application workflow."""
     return _load_application_intelligence(current_user, application_type)
+
+
+@router.post("/interview-verification", status_code=202)
+def record_interview_verification(payload: InterviewVerificationPayload, current_user: dict = Depends(get_current_user)):
+    """Record a sanitized Aisha Jordan engine outcome for the Ops intelligence inbox."""
+    violations = list(payload.violation_codes)
+    if payload.failed and not violations:
+        violations.append("interview_engine_failed")
+    record_intelligence_outcome(
+        feature="interview_practice", task="aisha_jordan_session", violations=violations,
+        model_id="aisha-jordan-interview-v6", schema_version="interview-summary-v1",
+        source_count=payload.response_count, generated_item_count=1, user_id=str(current_user["_id"]),
+    )
+    return {"recorded": True}

--- a/backend/app/compliance_routes.py
+++ b/backend/app/compliance_routes.py
@@ -16,6 +16,7 @@ from typing import Any
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pymongo.errors import PyMongoError
 
+from app.ai.runtime import record_intelligence_outcome
 from app.database import compliance_audit_runs_collection, users_collection
 from app.ops_routes import require_internal_role
 
@@ -536,6 +537,20 @@ def run_compliance_audit(current_user: dict = Depends(require_internal_role("ops
         integrity_payload = {key: value for key, value in receipt.items() if key not in {"integrity_sha256"}}
         receipt["integrity_sha256"] = _canonical_hash(integrity_payload)
         compliance_audit_runs_collection.insert_one(dict(receipt))
+        actionable = [
+            finding for finding in findings
+            if finding.get("status") in {"gap", "counsel_review", "needs_evidence"}
+        ]
+        record_intelligence_outcome(
+            feature="compliance_intelligence",
+            task="whole_business_audit",
+            violations=[f"compliance:{item['control_id']}:{item['status']}" for item in actionable],
+            model_id=RULE_PACK_VERSION,
+            schema_version=RULE_PACK_VERSION,
+            source_count=len(facts),
+            generated_item_count=len(findings),
+            user_id=str(current_user.get("_id", "")),
+        )
         return _serialize_run(receipt)
     except PyMongoError as exc:
         raise HTTPException(status_code=503, detail="Compliance audit storage is unavailable.") from exc

--- a/backend/tests/test_ai_verification_dashboard.py
+++ b/backend/tests/test_ai_verification_dashboard.py
@@ -18,6 +18,8 @@ def test_uninstrumented_features_are_never_reported_as_passing(monkeypatch):
     assert summary["features"]["resume_builder"]["instrumented"] is False
     assert summary["features"]["resume_builder"]["pass_rate"] == 0.0
     assert summary["features"]["interview_practice"]["instrumented"] is False
+    assert summary["features"]["education_intelligence"]["instrumented"] is False
+    assert summary["features"]["compliance_intelligence"]["instrumented"] is False
     assert summary["release_gate"]["resume_builder"]["ready"] is False
 
 

--- a/backend/tests/test_intelligence_runtime.py
+++ b/backend/tests/test_intelligence_runtime.py
@@ -1,0 +1,39 @@
+"""Tests for the shared BragStack intelligence verification runtime."""
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+
+import app.ai.runtime as runtime
+
+
+def test_verified_result_gets_shared_runtime_receipt(monkeypatch):
+    events = []
+    monkeypatch.setattr(runtime, "record_verification_event", lambda **event: events.append(event) or True)
+
+    result = runtime.enforce_intelligence_result(
+        {"summary": {"count": 1}}, feature="education_intelligence", task="scholarship",
+        violations=[], failure_code="failed", failure_message="withheld", source_count=1,
+    )
+
+    assert result["intelligence_runtime"]["verified"] is True
+    assert result["intelligence_runtime"]["version"] == runtime.INTELLIGENCE_RUNTIME_VERSION
+    assert events[0]["feature"] == "education_intelligence"
+    assert events[0]["passed"] is True
+
+
+def test_invalid_result_is_recorded_and_withheld(monkeypatch):
+    events = []
+    monkeypatch.setattr(runtime, "record_verification_event", lambda **event: events.append(event) or True)
+
+    with pytest.raises(HTTPException) as raised:
+        runtime.enforce_intelligence_result(
+            {}, feature="career_intelligence", task="analysis",
+            violations=["proof_count_mismatch", "proof_count_mismatch"],
+            failure_code="career_intelligence_verification_failed", failure_message="withheld",
+        )
+
+    assert raised.value.status_code == 500
+    assert raised.value.detail["violation_codes"] == ["proof_count_mismatch"]
+    assert events[0]["passed"] is False
+

--- a/frontend/scripts/verify-aisha-source.mjs
+++ b/frontend/scripts/verify-aisha-source.mjs
@@ -14,8 +14,8 @@ assert.match(interviewSource, /recognition\.interimResults = true/, "Speech reco
 assert.match(interviewSource, /recognition\.continuous = !appleMobile/, "Apple mobile speech recognition must use restartable short sessions");
 assert.match(interviewSource, /primeMicrophonePermission/, "Interviewer must prime microphone permission on mobile");
 assert.match(interviewSource, /role="dialog"/, "Per-question feedback must render as a modal dialog");
-assert.match(interviewSource, /Practice Interview with AJ/, "The interview room must identify the interviewer as AJ");
-assert.doesNotMatch(interviewSource, /Aisha Jordan|Aisha’s|Aisha is|with Aisha/, "Retired Aisha naming must not leak into the AJ experience");
+assert.match(interviewSource, /Practice Interview with Aisha Jordan/, "The interview room must identify the interviewer as Aisha Jordan");
+assert.match(interviewSource, /Aisha Jordan/, "The restored Aisha Jordan identity must be present");
 
 assert.match(avatarSource, /data-avatar-engine="bragstack-static-aj-v1"/, "AJ must identify the static interviewer engine");
 assert.match(avatarSource, /className="aj-avatar-monogram"/, "AJ must expose the static monogram avatar");

--- a/frontend/src/InterviewPracticePage.jsx
+++ b/frontend/src/InterviewPracticePage.jsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useReducer, useRef, useState } from "react";
 import { flushSync } from "react-dom";
 import { AlertTriangle, Camera, CameraOff, CheckCircle2, ChevronRight, Clock3, Mic, RefreshCw, Sparkles, Star, Volume2 } from "lucide-react";
 import AnimatedInterviewerAvatar from "./AnimatedInterviewerAvatar.jsx";
-import { getImpactReceipts } from "./api.js";
+import { getImpactReceipts, reportInterviewIntelligenceVerification } from "./api.js";
 import { EXPERIENCE_LEVELS, INTERVIEW_TYPES } from "./interviewKnowledgeBase.js";
 import { analyzeAnswer, buildInterviewPlan, getBrowserInterviewCapabilities, summarizeInterview } from "./interviewEngine.js";
 import {
@@ -16,7 +16,7 @@ import "./InterviewPracticePage.css";
 
 const HISTORY_KEY = "bragstack_interview_history_v1";
 const INTRO_SEGMENTS = [
-  "Hi, I’m AJ. Welcome to your BragStack practice interview.",
+  "Hi, I’m Aisha Jordan. Welcome to your BragStack practice interview.",
   "Here’s how this works. I’ll ask one question at a time. After I finish speaking, your response timer will begin and I’ll start listening.",
   "Answer naturally, just like you would in a real interview. I’ll evaluate what you said, and if an important detail is missing, I may ask one short follow-up.",
   "When your time ends, you’ll hear a soft chime and I’ll let you know. At the end, you’ll get your score, strengths, and specific ways to improve.",
@@ -498,7 +498,7 @@ export default function InterviewPracticePage() {
       spoken = await speakSoftText(prompt, { cancelFirst: true });
     }
     if (!spoken) {
-      setAudioError("AJ’s audio was blocked or interrupted. The interview is continuing in text mode; Replay question can retry the audio.");
+      setAudioError("Aisha Jordan’s audio was blocked or interrupted. The interview is continuing in text mode; Replay question can retry the audio.");
       beginResponseClock();
       return true;
     }
@@ -521,12 +521,12 @@ export default function InterviewPracticePage() {
         await wait(INTRO_PAUSE_MS);
         const ok = await speakSoftText(INTRO_SEGMENTS[index]);
         if (!ok) {
-          setAudioError("AJ’s intro was interrupted. The interview will continue with the first question.");
+          setAudioError("Aisha Jordan’s intro was interrupted. The interview will continue with the first question.");
           break;
         }
       }
     } else {
-      setAudioError("Spoken audio is unavailable or blocked here. AJ is still available and the interview will continue in text mode.");
+      setAudioError("Spoken audio is unavailable or blocked here. Aisha Jordan is still available and the interview will continue in text mode.");
     }
 
     const enrichedPlan = await catalogPromise;
@@ -676,6 +676,15 @@ export default function InterviewPracticePage() {
 
     if (questionIndex + 1 >= plan.questions.length) {
       const summary = summarizeInterview(nextResponses);
+      const intelligenceViolations = [];
+      if (!Number.isInteger(summary.overallScore) || summary.overallScore < 0 || summary.overallScore > 100) intelligenceViolations.push("interview_score_invalid");
+      if (!Array.isArray(summary.recommendations) || summary.recommendations.length === 0) intelligenceViolations.push("interview_recommendations_missing");
+      if (nextResponses.some((response) => !response?.question || !response?.analysis)) intelligenceViolations.push("interview_response_provenance_missing");
+      void reportInterviewIntelligenceVerification({
+        responseCount: nextResponses.length,
+        overallScore: Number.isInteger(summary.overallScore) ? summary.overallScore : 0,
+        violationCodes: intelligenceViolations,
+      }).catch(() => {});
       saveHistory({
         id: Date.now(),
         completedAt: new Date().toISOString(),
@@ -745,7 +754,7 @@ export default function InterviewPracticePage() {
 
   if (stage === "setup") return (
     <main className="interview-practice-page">
-      <header className="interview-page-header"><div><span className="interview-pro-badge"><Sparkles size={14} /> BRAGSTACK CAREER INTELLIGENCE™</span><h1>Practice Interview</h1><p>AJ greets you, asks each question out loud, starts your timer only after the question finishes, listens to your response, and gives specific coaching.</p></div><div className="zero-cost-card"><strong>BragStack Intelligence</strong><span>Evidence-aware coaching personalized to your target role</span></div></header>
+      <header className="interview-page-header"><div><span className="interview-pro-badge"><Sparkles size={14} /> BRAGSTACK CAREER INTELLIGENCE™</span><h1>Practice Interview with Aisha Jordan</h1><p>Aisha Jordan greets you, asks each question out loud, starts your timer only after the question finishes, listens to your response, and gives specific coaching.</p></div><div className="zero-cost-card"><strong>BragStack Intelligence</strong><span>Evidence-aware coaching personalized to your target role</span></div></header>
       <section className="interview-setup-grid">
         <form className="interview-setup-card" onSubmit={startInterview}>
           <div className="section-kicker">BUILD YOUR INTERVIEW</div>
@@ -763,7 +772,7 @@ export default function InterviewPracticePage() {
           <label className="receipt-personalization"><input type="checkbox" name="useReceipts" checked={setup.useReceipts} onChange={updateSetup} /><span><strong>Personalize with my career proof</strong><small>{receipts.length ? `${receipts.length} Impact Receipt${receipts.length === 1 ? "" : "s"} available` : "No Impact Receipts loaded yet — the interview still works normally."}</small></span></label>
           <button className="start-interview-button" type="submit">Start practice interview <ChevronRight size={18} /></button>
         </form>
-        <aside className="interview-preview-card"><div className="preview-interviewer-window"><div className="interviewer-avatar">AJ</div><div><span>AJ</span><strong>Senior Technical Recruiter</strong></div></div><div className="preview-question-card"><span>REAL INTERVIEW COACHING</span><p>Follow-ups target the missing part of your answer instead of simply repeating the original question.</p></div><div className="preview-capabilities"><div><CheckCircle2 size={17} /><span>Automatic greeting + spoken questions</span></div><div><CheckCircle2 size={17} /><span>1, 3, or 5 minute response timer</span></div><div><CheckCircle2 size={17} /><span>Specific strengths + improvements</span></div><div><CheckCircle2 size={17} /><span>Professional-language red flag warnings</span></div><div><CheckCircle2 size={17} /><span>1–5 star final interview rating</span></div></div></aside>
+        <aside className="interview-preview-card"><div className="preview-interviewer-window"><div className="interviewer-avatar">AJ</div><div><span>Aisha Jordan</span><strong>BragStack Virtual Interviewer</strong></div></div><div className="preview-question-card"><span>REAL INTERVIEW COACHING</span><p>Follow-ups target the missing part of your answer instead of simply repeating the original question.</p></div><div className="preview-capabilities"><div><CheckCircle2 size={17} /><span>Automatic greeting + spoken questions</span></div><div><CheckCircle2 size={17} /><span>1, 3, or 5 minute response timer</span></div><div><CheckCircle2 size={17} /><span>Specific strengths + improvements</span></div><div><CheckCircle2 size={17} /><span>Professional-language red flag warnings</span></div><div><CheckCircle2 size={17} /><span>1–5 star final interview rating</span></div></div></aside>
       </section>
     </main>
   );
@@ -779,17 +788,17 @@ export default function InterviewPracticePage() {
   }
 
   return <main className="interview-practice-page interview-room-page">
-    <header className="interview-room-header"><div><span>{plan.roleTitle}</span><strong>Practice Interview with AJ</strong></div><div className="question-progress"><span>Question {questionIndex + 1} of {plan.questions.length}</span><div><i style={{ width: `${((questionIndex + 1) / plan.questions.length) * 100}%` }} /></div></div></header>
+    <header className="interview-room-header"><div><span>{plan.roleTitle}</span><strong>Practice Interview with Aisha Jordan</strong></div><div className="question-progress"><span>Question {questionIndex + 1} of {plan.questions.length}</span><div><i style={{ width: `${((questionIndex + 1) / plan.questions.length) * 100}%` }} /></div></div></header>
     <section className="interview-room-grid">
       <div className="interview-video-stage">
-        <div className="virtual-interviewer animated-interviewer-host"><AnimatedInterviewerAvatar state={avatarState} name="AJ" /><div className="animated-avatar-caption" aria-hidden="true"><strong>AJ</strong><span>Senior Technical Recruiter</span></div></div>
+        <div className="virtual-interviewer animated-interviewer-host"><AnimatedInterviewerAvatar state={avatarState} name="Aisha Jordan" /><div className="animated-avatar-caption" aria-hidden="true"><strong>Aisha Jordan</strong><span>BragStack Virtual Interviewer</span></div></div>
         <div className="candidate-video-tile">{cameraStream ? <video ref={videoRef} autoPlay muted playsInline /> : <div className="camera-placeholder"><CameraOff size={28} /><span>Your camera is off</span></div>}<div className="candidate-video-label">You</div></div>
         <div className="video-controls">{cameraStream ? <button type="button" onClick={disableCamera}><CameraOff size={17} /> Camera off</button> : <button type="button" onClick={enableCamera} disabled={!capabilities.camera}><Camera size={17} /> Enable camera</button>}<button type="button" onClick={() => { void replayQuestion(); }} disabled={!capabilities.speechSynthesis || sequenceBusyRef.current}><Volume2 size={17} /> Replay question</button></div>
         {cameraError && <p className="camera-error">{cameraError}</p>}
       </div>
       <div className="interview-answer-panel">
         <div className="question-box"><div className="question-meta-row"><span>{followUpActive ? "TARGETED FOLLOW-UP" : `QUESTION ${questionIndex + 1}`}</span><strong className={`response-timer ${secondsLeft <= 20 && timerRunning ? "urgent" : ""}`}><Clock3 size={16} /> {formatTime(secondsLeft)}</strong></div><h1>{currentPrompt}</h1>{followUpActive && <small>This follow-up targets the missing part of your previous answer. You do not need to repeat the whole story.</small>}{audioError && <small>{audioError}</small>}</div>
-        {!feedback ? <form onSubmit={submitAnswer} className="answer-form"><label htmlFor="practice-answer">Your answer</label><textarea id="practice-answer" value={answer} onChange={(event) => { answerRef.current = event.target.value; setAnswer(event.target.value); }} rows="9" data-listening={listening ? "true" : "false"} placeholder="Answer naturally. Focus on the exact question, what YOU did, and what changed as a result." /><div className="answer-tools">{capabilities.speechRecognition ? (listening ? <button className="dictation-button active" type="button" onClick={() => stopDictation()}><Mic size={17} /> Stop dictation</button> : <button className="dictation-button" type="button" onClick={() => { autoListenRef.current = true; void startDictation({ userInitiated: true }); }} disabled={interviewPhase !== INTERVIEW_PHASES.LISTENING}><Mic size={17} /> Speak answer</button>) : <span>Voice dictation is unavailable here — typing still works.</span>}<span>{answer.trim() ? answer.trim().split(/\s+/).length : 0} words</span></div>{capabilities.speechRecognition && <div className={`microphone-status ${microphoneError ? "error" : listening ? "live" : ""}`} aria-live="polite"><Mic size={15} /><span>{microphoneError || microphoneStatus || "AJ will start listening after the question finishes. If your phone blocks auto-listen, tap Speak answer."}</span></div>}<button className="start-interview-button" type="submit" disabled={!answer.trim()}>Review my answer</button></form> : <section ref={feedbackDialogRef} tabIndex="-1" className="answer-feedback-panel" role="dialog" aria-modal="true" aria-label={`Feedback for question ${questionIndex + 1}`}>{feedback.timedOut && <div className="timeout-warning"><Clock3 size={18} /><span>Time expired. This answer was scored as submitted.</span></div>}<div className="feedback-heading"><div><span>ANSWER FEEDBACK</span><h2>{feedback.overallLabel}</h2></div><strong>{feedback.overallScore}/100</strong></div><div className="answer-coaching-grid"><article className="answer-strengths"><span>WHAT WORKED</span>{feedback.strengths.map((item) => <p key={item}>✓ {item}</p>)}</article><article className="answer-improvements"><span>HOW TO IMPROVE</span>{feedback.improvements.map((item) => <p key={item}>→ {item}</p>)}</article></div><div className="feedback-dimensions">{Object.entries(feedback.dimensions).map(([name, value]) => <article key={name}><div><strong>{prettyDimension(name)}</strong><span className={value.label === "Excellent" || value.label === "Strong" ? "strong" : value.label === "Developing" ? "developing" : "needs-detail"}>{value.score}/100 · {value.label}</span></div><p>{value.note}</p><small><b>Improve:</b> {value.improve}</small></article>)}</div>{feedback.followUp && !followUpUsed && <div className="follow-up-card"><span>TARGETED INTERVIEWER FOLLOW-UP</span><p>{feedback.followUp}</p><button type="button" onClick={beginFollowUp}>Answer targeted follow-up</button></div>}<div className="feedback-actions"><button className="secondary-interview-button" type="button" onClick={retryAnswer}>Try this answer again</button><button className="start-interview-button" type="button" onClick={nextQuestion}>{questionIndex + 1 >= plan.questions.length ? "Finish interview" : "Continue"} <ChevronRight size={17} /></button></div></section>}
+        {!feedback ? <form onSubmit={submitAnswer} className="answer-form"><label htmlFor="practice-answer">Your answer</label><textarea id="practice-answer" value={answer} onChange={(event) => { answerRef.current = event.target.value; setAnswer(event.target.value); }} rows="9" data-listening={listening ? "true" : "false"} placeholder="Answer naturally. Focus on the exact question, what YOU did, and what changed as a result." /><div className="answer-tools">{capabilities.speechRecognition ? (listening ? <button className="dictation-button active" type="button" onClick={() => stopDictation()}><Mic size={17} /> Stop dictation</button> : <button className="dictation-button" type="button" onClick={() => { autoListenRef.current = true; void startDictation({ userInitiated: true }); }} disabled={interviewPhase !== INTERVIEW_PHASES.LISTENING}><Mic size={17} /> Speak answer</button>) : <span>Voice dictation is unavailable here — typing still works.</span>}<span>{answer.trim() ? answer.trim().split(/\s+/).length : 0} words</span></div>{capabilities.speechRecognition && <div className={`microphone-status ${microphoneError ? "error" : listening ? "live" : ""}`} aria-live="polite"><Mic size={15} /><span>{microphoneError || microphoneStatus || "Aisha Jordan will start listening after the question finishes. If your phone blocks auto-listen, tap Speak answer."}</span></div>}<button className="start-interview-button" type="submit" disabled={!answer.trim()}>Review my answer</button></form> : <section ref={feedbackDialogRef} tabIndex="-1" className="answer-feedback-panel" role="dialog" aria-modal="true" aria-label={`Feedback for question ${questionIndex + 1}`}>{feedback.timedOut && <div className="timeout-warning"><Clock3 size={18} /><span>Time expired. This answer was scored as submitted.</span></div>}<div className="feedback-heading"><div><span>ANSWER FEEDBACK</span><h2>{feedback.overallLabel}</h2></div><strong>{feedback.overallScore}/100</strong></div><div className="answer-coaching-grid"><article className="answer-strengths"><span>WHAT WORKED</span>{feedback.strengths.map((item) => <p key={item}>✓ {item}</p>)}</article><article className="answer-improvements"><span>HOW TO IMPROVE</span>{feedback.improvements.map((item) => <p key={item}>→ {item}</p>)}</article></div><div className="feedback-dimensions">{Object.entries(feedback.dimensions).map(([name, value]) => <article key={name}><div><strong>{prettyDimension(name)}</strong><span className={value.label === "Excellent" || value.label === "Strong" ? "strong" : value.label === "Developing" ? "developing" : "needs-detail"}>{value.score}/100 · {value.label}</span></div><p>{value.note}</p><small><b>Improve:</b> {value.improve}</small></article>)}</div>{feedback.followUp && !followUpUsed && <div className="follow-up-card"><span>TARGETED INTERVIEWER FOLLOW-UP</span><p>{feedback.followUp}</p><button type="button" onClick={beginFollowUp}>Answer targeted follow-up</button></div>}<div className="feedback-actions"><button className="secondary-interview-button" type="button" onClick={retryAnswer}>Try this answer again</button><button className="start-interview-button" type="button" onClick={nextQuestion}>{questionIndex + 1 >= plan.questions.length ? "Finish interview" : "Continue"} <ChevronRight size={17} /></button></div></section>}
       </div>
     </section>
   </main>;

--- a/frontend/src/OpsConsolePage.jsx
+++ b/frontend/src/OpsConsolePage.jsx
@@ -13,6 +13,7 @@ import {
 import {
   assignOpsRolesByEmail,
   getLatestComplianceAudit,
+  getIntelligenceVerificationSummary,
   getOpsAccess,
   getOpsAudit,
   getOpsObservability,
@@ -78,8 +79,26 @@ function governancePriority(finding = {}) {
   return "info";
 }
 
-function buildOpsMessages({ service = {}, persisted = {}, audit = null, compliance = null }) {
+function buildOpsMessages({ service = {}, persisted = {}, audit = null, compliance = null, intelligence = null }) {
   const messages = [];
+
+  (intelligence?.recent_failures || []).slice(0, 12).forEach((failure, index) => {
+    const feature = String(failure.feature || "intelligence").replaceAll("_", " ");
+    const codes = failure.violation_codes || [];
+    messages.push({
+      id: `intelligence:${failure.feature}:${failure.task}:${failure.created_at || index}`,
+      source: "BragStack Intelligence",
+      category: feature,
+      priority: "urgent",
+      title: `${feature} result was withheld`,
+      summary: codes.length ? `Safety verification found: ${codes.join(", ")}.` : "The shared intelligence engine reported a verification failure.",
+      meaning: "BragStack failed closed instead of showing a result that did not pass its evidence, provenance, or safety rules.",
+      nextStep: "Open the Intelligence Verification report, review the violation code and affected feature, then reproduce and correct the invariant before release.",
+      detail: `${failure.task || "unknown task"} · ${failure.model_id || "shared engine"}`,
+      createdAt: failure.created_at,
+      externalUrl: "/ops/ai-verification",
+    });
+  });
 
   if (compliance) {
     const overall = String(compliance.summary?.overall || "action_required");
@@ -247,8 +266,8 @@ function PriorityIcon({ priority }) {
   return <Info size={18} aria-hidden="true" />;
 }
 
-function OpsInbox({ service, persisted, audit, compliance }) {
-  const messages = useMemo(() => buildOpsMessages({ service, persisted, audit, compliance }), [service, persisted, audit, compliance]);
+function OpsInbox({ service, persisted, audit, compliance, intelligence }) {
+  const messages = useMemo(() => buildOpsMessages({ service, persisted, audit, compliance, intelligence }), [service, persisted, audit, compliance, intelligence]);
   const [state, setState] = useState(readInboxState);
   const [expanded, setExpanded] = useState({});
   const [filter, setFilter] = useState("all");
@@ -446,6 +465,7 @@ export default function OpsConsolePage() {
   const [team, setTeam] = useState(null);
   const [audit, setAudit] = useState(null);
   const [compliance, setCompliance] = useState(null);
+  const [intelligence, setIntelligence] = useState(null);
   const [error, setError] = useState("");
   const [email, setEmail] = useState("");
   const [userResult, setUserResult] = useState(null);
@@ -454,11 +474,11 @@ export default function OpsConsolePage() {
 
   async function loadDiagnostics() {
     const nextAccess = await getOpsAccess();
-    const [nextOverview, nextObservability, nextCompliance] = await Promise.all([getOpsOverview(), getOpsObservability(), getLatestComplianceAudit()]);
+    const [nextOverview, nextObservability, nextCompliance, nextIntelligence] = await Promise.all([getOpsOverview(), getOpsObservability(), getLatestComplianceAudit(), getIntelligenceVerificationSummary()]);
     let nextTeam = null;
     let nextAudit = null;
     if ((nextAccess.roles || []).includes("admin")) [nextTeam, nextAudit] = await Promise.all([getOpsTeam(), getOpsAudit()]);
-    return { nextAccess, nextOverview, nextObservability, nextTeam, nextAudit, nextCompliance };
+    return { nextAccess, nextOverview, nextObservability, nextTeam, nextAudit, nextCompliance, nextIntelligence };
   }
 
   async function refreshDiagnostics() {
@@ -466,7 +486,7 @@ export default function OpsConsolePage() {
     setError("");
     try {
       const data = await loadDiagnostics();
-      setAccess(data.nextAccess); setOverview(data.nextOverview); setObservability(data.nextObservability); setTeam(data.nextTeam); setAudit(data.nextAudit); setCompliance(data.nextCompliance);
+      setAccess(data.nextAccess); setOverview(data.nextOverview); setObservability(data.nextObservability); setTeam(data.nextTeam); setAudit(data.nextAudit); setCompliance(data.nextCompliance); setIntelligence(data.nextIntelligence);
     } catch (err) {
       setError(err.response?.status === 404 ? "This account is not authorized for the BragStack Ops Console." : "Ops diagnostics could not be loaded.");
     } finally {
@@ -480,7 +500,7 @@ export default function OpsConsolePage() {
       try {
         const data = await loadDiagnostics();
         if (!active) return;
-        setAccess(data.nextAccess); setOverview(data.nextOverview); setObservability(data.nextObservability); setTeam(data.nextTeam); setAudit(data.nextAudit); setCompliance(data.nextCompliance);
+        setAccess(data.nextAccess); setOverview(data.nextOverview); setObservability(data.nextObservability); setTeam(data.nextTeam); setAudit(data.nextAudit); setCompliance(data.nextCompliance); setIntelligence(data.nextIntelligence);
       } catch (err) {
         if (!active) return;
         setError(err.response?.status === 404 ? "This account is not authorized for the BragStack Ops Console." : "Ops diagnostics could not be loaded.");
@@ -519,7 +539,7 @@ export default function OpsConsolePage() {
     </section>
 
     <ComplianceAuditPanel onReceiptChange={setCompliance} />
-    <OpsInbox service={service} persisted={persisted} audit={isAdmin ? audit : null} compliance={compliance} />
+    <OpsInbox service={service} persisted={persisted} audit={isAdmin ? audit : null} compliance={compliance} intelligence={intelligence} />
     <FounderAnalyticsPanel analytics={analytics} />
 
     {isAdmin && <section className="ops-panel"><div className="ops-panel-heading"><div><p className="ops-kicker">ADMIN · TEAM & ROLES</p><h2>Invite, assign, and audit internal access</h2><p>Only verified accounts you explicitly assign receive internal access. Grant the minimum role needed; every change is persisted and audit logged.</p></div></div><RoleManager team={team} setTeam={setTeam} audit={audit} setAudit={setAudit} /></section>}

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -226,3 +226,13 @@ export function buildPacketShareUrl(path) {
 }
 
 export async function getPublicImpactReceipts(slug) { const response = await api.get(getPublicBragPath(slug, "/impact-receipts")); return response.data; }
+
+export async function reportInterviewIntelligenceVerification({ responseCount, overallScore, violationCodes = [] }) {
+  const response = await api.post("/career-intelligence/interview-verification", {
+    response_count: responseCount,
+    overall_score: overallScore,
+    failed: violationCodes.length > 0,
+    violation_codes: violationCodes,
+  });
+  return response.data;
+}

--- a/frontend/src/opsApi.js
+++ b/frontend/src/opsApi.js
@@ -29,3 +29,4 @@ export async function getComplianceCatalog() { const response = await opsApi.get
 export async function runComplianceAudit() { const response = await opsApi.post("/ops/compliance/audits"); return response.data; }
 export async function getLatestComplianceAudit() { const response = await opsApi.get("/ops/compliance/audits/latest"); return response.data; }
 export async function getComplianceAuditHistory(limit = 20) { const response = await opsApi.get("/ops/compliance/audits", { params: { limit } }); return response.data; }
+export async function getIntelligenceVerificationSummary(days = 30) { const response = await opsApi.get("/ops/ai-verification/summary", { params: { days } }); return response.data; }

--- a/frontend/src/opsIntelligenceInboxSource.test.js
+++ b/frontend/src/opsIntelligenceInboxSource.test.js
@@ -1,0 +1,13 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import test from "node:test";
+
+const source = fs.readFileSync(new URL("./OpsConsolePage.jsx", import.meta.url), "utf8");
+const apiSource = fs.readFileSync(new URL("./opsApi.js", import.meta.url), "utf8");
+
+test("Ops Inbox receives shared intelligence verification failures", () => {
+  assert.match(apiSource, /getIntelligenceVerificationSummary/);
+  assert.match(source, /intelligence\?\.recent_failures/);
+  assert.match(source, /BragStack Intelligence/);
+  assert.match(source, /result was withheld/);
+});


### PR DESCRIPTION
## What changed
- adds a shared fail-closed Intelligence Runtime used by Career Intelligence, Education Intelligence, Major Explorer, and Compliance
- restores the full Aisha Jordan identity throughout the practice interview experience
- records privacy-safe Aisha Jordan session verification outcomes without storing answers
- separates Education Intelligence telemetry from Career Intelligence
- sends recent intelligence verification failures into the `/ops` inbox as urgent messages with actionable details
- tracks compliance readiness findings in the same verification dashboard

## Safety
- retains the existing fail-closed behavior for unsupported intelligence output
- stores metadata and violation codes only; no resume, interview-answer, evidence, or generated-output bodies
- telemetry write failures remain non-blocking for customer workflows

## Verification
- Python compile checks passed
- shared runtime and verification dashboard tests: 5 passed
- Ops inbox source regression test: passed