### PR TITLE
Fix support hub mobile navbar

### DIFF
--- a/frontend/src/SupportHubNavbarFix.css
+++ b/frontend/src/SupportHubNavbarFix.css
@@ -1,0 +1,110 @@
+.support-hub-topbar {
+  width: 100%;
+  margin: 0;
+  padding: 0;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.12);
+  background: rgba(7, 11, 20, 0.9);
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.18);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+}
+
+.support-hub-topbar-inner {
+  width: min(1160px, 100%);
+  min-height: 72px;
+  margin: 0 auto;
+  padding: 0 24px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+}
+
+.support-hub-topbar .support-hub-brand {
+  flex: 0 0 auto;
+  white-space: nowrap;
+}
+
+.support-hub-topbar nav {
+  min-width: 0;
+  margin-left: auto;
+}
+
+.support-hub-topbar nav a {
+  white-space: nowrap;
+}
+
+.support-hub-topbar .support-account-link {
+  display: inline-flex;
+  min-height: 38px;
+  align-items: center;
+  justify-content: center;
+  padding: 0 14px;
+  border: 1px solid rgba(166, 220, 255, 0.22);
+  border-radius: 999px;
+  color: #eaf4ff;
+  background: linear-gradient(135deg, rgba(68, 120, 184, 0.2), rgba(118, 88, 194, 0.16));
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  transition: border-color 160ms ease, background 160ms ease, transform 160ms ease;
+}
+
+.support-hub-topbar .support-account-link:hover {
+  color: #fff;
+  border-color: rgba(166, 220, 255, 0.42);
+  background: linear-gradient(135deg, rgba(68, 120, 184, 0.3), rgba(118, 88, 194, 0.24));
+  transform: translateY(-1px);
+}
+
+@media (max-width: 680px) {
+  .support-hub-topbar-inner {
+    min-height: 64px;
+    padding: 0 16px;
+    gap: 12px;
+  }
+
+  .support-hub-topbar .support-hub-brand {
+    gap: 7px;
+    letter-spacing: 0.08em;
+  }
+
+  .support-hub-topbar .support-hub-brand span {
+    font-size: 0.84rem;
+  }
+
+  .support-hub-topbar .support-hub-brand em {
+    padding: 3px 6px;
+    font-size: 0.52rem;
+  }
+
+  .support-hub-topbar nav {
+    gap: 0;
+    font-size: 0.76rem;
+  }
+
+  .support-hub-topbar nav a:not(.support-account-link) {
+    display: none;
+  }
+
+  .support-hub-topbar .support-account-link {
+    min-height: 36px;
+    padding: 0 12px;
+    font-size: 0.74rem;
+    font-weight: 850;
+  }
+}
+
+@media (max-width: 390px) {
+  .support-hub-topbar-inner {
+    padding: 0 12px;
+    gap: 8px;
+  }
+
+  .support-hub-topbar .support-hub-brand span {
+    font-size: 0.78rem;
+  }
+
+  .support-hub-topbar .support-account-link {
+    padding: 0 10px;
+    font-size: 0.7rem;
+  }
+}

--- a/frontend/src/SupportHubPage.jsx
+++ b/frontend/src/SupportHubPage.jsx
@@ -13,6 +13,7 @@ import {
   Wrench,
 } from "lucide-react";
 import "./SupportHubPage.css";
+import "./SupportHubNavbarFix.css";
 
 const supportCards = [
   {
@@ -61,8 +62,10 @@ export default function SupportHubPage() {
 
   return <main className="support-hub-page">
     <header className="support-hub-topbar">
-      <a className="support-hub-brand" href="/"><span>BragStack</span><em>Beta</em></a>
-      <nav aria-label="Support navigation"><a href="/docs">Docs</a><a href="/security">Security</a><a href="/nda-safety">NDA guidance</a>{token ? <a href="/app">My workspace</a> : <a href="/login">Sign in</a>}</nav>
+      <div className="support-hub-topbar-inner">
+        <a className="support-hub-brand" href="/"><span>BragStack</span><em>Beta</em></a>
+        <nav aria-label="Support navigation"><a href="/docs">Docs</a><a href="/security">Security</a><a href="/nda-safety">NDA guidance</a>{token ? <a className="support-account-link" href="/app">My workspace</a> : <a className="support-account-link" href="/login">Sign in</a>}</nav>
+      </div>
     </header>
 
     <section className="support-hub-hero">


### PR DESCRIPTION
## What changed
- Reworked the Support Hub top bar into a full-width sticky glass header with a centered inner container.
- Prevented the mobile `My workspace` action from clipping off-screen.
- Added a compact pill treatment for the account action.
- Tightened mobile brand sizing, spacing, and padding at 680px and 390px breakpoints.
- Preserved the full Docs / Security / NDA navigation on desktop while keeping mobile intentionally minimal.

This specifically addresses the cramped/clipped navbar shown on iPhone Safari.