### PR TITLE
Harden login during Render cold starts

### DIFF
--- a/frontend/src/AuthPage.jsx
+++ b/frontend/src/AuthPage.jsx
@@ -8,8 +8,9 @@ function getApiBaseUrl() {
 }
 
 const sleep = (milliseconds) => new Promise((resolve) => window.setTimeout(resolve, milliseconds));
+const API_WAKE_TIMEOUT_MS = 120000;
 
-async function waitForApiReady(apiBaseUrl, timeoutMs = 45000) {
+async function waitForApiReady(apiBaseUrl, timeoutMs = API_WAKE_TIMEOUT_MS) {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     const controller = new AbortController();
@@ -336,7 +337,7 @@ function AuthPage({ mode = "login", onLogin }) {
           {isRegister ? (
             <div className="auth-oauth-temporary"><strong>Google & GitHub sign-up</strong><p>Temporarily paused for new accounts so every new user completes the required legal-consent step. Existing OAuth users can still sign in from the Log in page.</p></div>
           ) : (
-            <><div className="auth-divider"><span>or continue with</span></div><div className="auth-oauth-grid"><button type="button" className="auth-oauth-button auth-oauth-google" onClick={() => startOAuth("google")} disabled={Boolean(connectingProvider)}><span className="auth-google-mark" aria-hidden="true">G</span><span>{connectingProvider === "google" ? "Connecting to Google..." : "Continue with Google"}</span></button><button type="button" className="auth-oauth-button auth-oauth-github" onClick={() => startOAuth("github")} disabled={Boolean(connectingProvider)}><GitHubMark /><span>{connectingProvider === "github" ? "Connecting to GitHub..." : "Continue with GitHub"}</span></button>{connectingProvider && oauthIsTakingLonger && <p className="auth-oauth-status" role="status">BragStack is waking up. This can take about a minute on the current low-cost server.</p>}</div></>
+            <><div className="auth-divider"><span>or continue with</span></div><div className="auth-oauth-grid"><button type="button" className="auth-oauth-button auth-oauth-google" onClick={() => startOAuth("google")} disabled={Boolean(connectingProvider)}><span className="auth-google-mark" aria-hidden="true">G</span><span>{connectingProvider === "google" ? "Connecting to Google..." : "Continue with Google"}</span></button><button type="button" className="auth-oauth-button auth-oauth-github" onClick={() => startOAuth("github")} disabled={Boolean(connectingProvider)}><GitHubMark /><span>{connectingProvider === "github" ? "Connecting to GitHub..." : "Continue with GitHub"}</span></button>{connectingProvider && oauthIsTakingLonger && <p className="auth-oauth-status" role="status">BragStack is waking up. We’ll continue automatically as soon as it’s ready.</p>}</div></>
           )}
 
           <p className="auth-switch">{isRegister ? "Already have an account?" : "New to BragStack?"} <a href={isRegister ? "/login" : "/register"}>{isRegister ? "Log in" : "Create one"}</a></p>


### PR DESCRIPTION
## What this fixes
A sleeping free Render API can take longer than the current 45-second frontend readiness window to wake. That makes the login page show a scary red startup error even though the API may become healthy seconds later.

## Changes
- extend the API wake-up window from 45 seconds to 120 seconds
- keep the user-facing OAuth state as a neutral “BragStack is waking up” progress message while the API comes online
- preserve the existing fail-closed behavior if the API genuinely remains unavailable

## Why
Production logs showed the BragStack API shutting down while idle and restarting when the login page was opened. The API then returned healthy responses and OAuth/auth requests succeeded, so this is a cold-start timing problem rather than an authentication failure.