### PR TITLE
Add consistent back navigation from Settings subpages

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,7 @@
     "test:resume": "node --test src/resumeStructured.test.js src/dashboardTags.test.js",
     "test:safety": "node --test src/ndaSafety.test.js src/ndaInformationGateSource.test.js src/ndaGuidanceSource.test.js src/ndaApiSource.test.js",
     "test:seo": "node --test src/proofPortfolioSource.test.js && node scripts/verify-search-appearance.mjs",
-    "test:settings": "node --test src/settingsAccountClosureSource.test.js",
+    "test:settings": "node --test src/settingsAccountClosureSource.test.js src/settingsBackNavigationSource.test.js",
     "test:clicks": "node scripts/run-click-audit.mjs",
     "test:layout": "node scripts/audit-responsive-layout.mjs",
     "test:bundle": "node scripts/verify-bundle-budget.mjs",

--- a/frontend/src/CalendarIntegrationsPage.jsx
+++ b/frontend/src/CalendarIntegrationsPage.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import {
+  ArrowLeft,
   CalendarDays,
   ChevronLeft,
   ChevronRight,
@@ -76,6 +77,7 @@ export default function CalendarIntegrationsPage() {
 
   return (
     <main className="calendar-integrations-page">
+      <div style={{marginBottom:18}}><a className="provider-connect" href="/app/settings"><ArrowLeft size={17}/> Back to settings</a></div>
       <header className="calendar-integrations-header"><div><p className="calendar-kicker">INTEGRATIONS · CALENDARS</p><h1>Your schedule, beside your proof.</h1><span>Add your Calendly schedule once, then show the actual interactive calendar inside your public Proof Portfolio.</span></div><div className="calendar-privacy-pill"><ShieldCheck size={16}/> You control public booking</div></header>
 
       <section className="calendly-integration-card" aria-labelledby="calendly-heading">

--- a/frontend/src/ProfilePage.jsx
+++ b/frontend/src/ProfilePage.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { ExternalLink, ImagePlus, MessageSquare, Save, Trash2, UserRound } from "lucide-react";
+import { ArrowLeft, ExternalLink, ImagePlus, MessageSquare, Save, Trash2, UserRound } from "lucide-react";
 import BragStackLoader from "./BragStackLoader.jsx";
 import { getCurrentUser, updateCurrentUserProfile } from "./api";
 import { getProfileConnection, updateProfileConnection } from "./profileConnectionApi";
@@ -101,7 +101,7 @@ function ProfilePage() {
   const avatarLetter=form.name?.charAt(0).toUpperCase()||"B";
 
   return <main className="profile-settings">
-    <header className="profile-settings-header"><div><p className="profile-settings-eyebrow">Account</p><h1>Edit profile</h1><p>Everything you save here persists on your BragStack account. Public colors and themes are managed separately under Profile appearance.</p></div><div className="profile-header-actions"><a className="profile-public-link" href="/app/settings/appearance">Profile appearance</a>{user?.public_slug&&<a className="profile-public-link" href={`/brag/${user.public_slug}`} target="_blank" rel="noreferrer">Preview Proof Profile <ExternalLink size={16}/></a>}</div></header>
+    <header className="profile-settings-header"><div><a className="profile-public-link" href="/app/settings"><ArrowLeft size={16}/> Back to settings</a><p className="profile-settings-eyebrow">Account</p><h1>Edit profile</h1><p>Everything you save here persists on your BragStack account. Public colors and themes are managed separately under Profile appearance.</p></div><div className="profile-header-actions"><a className="profile-public-link" href="/app/settings/appearance">Profile appearance</a>{user?.public_slug&&<a className="profile-public-link" href={`/brag/${user.public_slug}`} target="_blank" rel="noreferrer">Preview Proof Profile <ExternalLink size={16}/></a>}</div></header>
     <form className="profile-settings-card" onSubmit={handleSubmit}>
       <div className="profile-avatar-row">
         <div className="profile-settings-avatar">{form.avatar_url?<img src={form.avatar_url} alt="Profile preview"/>:(avatarLetter||<UserRound size={26}/>)}</div>

--- a/frontend/src/settingsBackNavigationSource.test.js
+++ b/frontend/src/settingsBackNavigationSource.test.js
@@ -1,0 +1,20 @@
+import fs from "node:fs";
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const read = (path) => fs.readFileSync(new URL(path, import.meta.url), "utf8");
+
+const SETTINGS_DESTINATIONS = [
+  ["Profile", "./ProfilePage.jsx"],
+  ["Integrations", "./CalendarIntegrationsPage.jsx"],
+  ["Profile appearance", "./AppearanceSettingsPage.jsx"],
+  ["Plan & billing", "./BillingSettingsPage.jsx"],
+];
+
+test("every active Settings destination offers a direct way back to Settings", () => {
+  for (const [label, path] of SETTINGS_DESTINATIONS) {
+    const source = read(path);
+    assert.match(source, /href="\/app\/settings"/, `${label} must link directly back to Settings`);
+    assert.match(source, /ArrowLeft/, `${label} must show a visible back affordance`);
+  }
+});


### PR DESCRIPTION
## What this changes
- adds a visible **Back to settings** button to Integrations
- adds the same direct back affordance to Edit Profile
- keeps the existing back buttons on Profile appearance and Plan & billing
- adds a regression test so every active Settings destination must link back to `/app/settings`

## UX goal
Users should never feel trapped in a Settings detail page. From Integrations, Profile, Appearance, or Billing, one tap returns directly to the Settings hub.