### PR TITLE
Polish mobile public auth navigation

### DIFF
--- a/frontend/src/PublicAuthHeader.css
+++ b/frontend/src/PublicAuthHeader.css
@@ -151,39 +151,70 @@
   .public-auth-header {
     position: relative;
     top: 0;
-    display: grid;
-    grid-template-columns: 1fr auto;
+    width: calc(100% - 1rem);
+    margin-top: 0.5rem;
+    padding: 0.62rem 0.68rem 0.62rem 0.82rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
     gap: 0.6rem;
+    border-radius: 14px;
+    box-shadow: 0 12px 30px rgba(0, 0, 0, 0.2);
+  }
+
+  .public-auth-brand {
+    font-size: 0.82rem;
+    letter-spacing: 0.12em;
   }
 
   .public-auth-links {
-    grid-column: 1 / -1;
-    grid-row: 2;
-    justify-content: flex-start;
-    gap: 0.75rem;
-    overflow-x: auto;
-    padding: 0.1rem 0 0.15rem;
-    scrollbar-width: none;
-  }
-
-  .public-auth-links::-webkit-scrollbar {
     display: none;
-  }
-
-  .public-auth-links a {
-    flex: 0 0 auto;
-    padding: 0.35rem 0.55rem;
-    border-radius: 999px;
-    border: 1px solid rgba(148, 163, 184, 0.14);
-    background: rgba(15, 23, 42, 0.46);
   }
 
   .public-auth-actions,
   .public-auth-register-actions {
-    gap: 0.45rem;
+    gap: 0.35rem;
   }
 
   .public-auth-button {
-    padding-inline: 0.68rem;
+    min-height: 36px;
+    padding: 0.45rem 0.72rem;
+    border-radius: 10px;
+    font-size: 0.76rem;
+    font-weight: 850;
+  }
+
+  .public-auth-actions .public-auth-button-secondary {
+    min-height: auto;
+    padding: 0.45rem 0.55rem;
+    border-color: transparent;
+    background: transparent;
+    color: #c7d2e4;
+  }
+
+  .public-auth-actions .public-auth-button-secondary:hover,
+  .public-auth-actions .public-auth-button-secondary:focus-visible {
+    border-color: transparent;
+    background: rgba(148, 163, 184, 0.08);
+  }
+
+  .public-auth-button-primary {
+    box-shadow: 0 8px 22px rgba(124, 154, 255, 0.18);
+  }
+}
+
+@media (max-width: 390px) {
+  .public-auth-header {
+    padding-left: 0.7rem;
+    padding-right: 0.55rem;
+  }
+
+  .public-auth-brand {
+    font-size: 0.76rem;
+    letter-spacing: 0.1em;
+  }
+
+  .public-auth-button {
+    padding-inline: 0.62rem;
   }
 }


### PR DESCRIPTION
## What this changes
- removes the oversized second row of marketing pill links on narrow mobile screens
- keeps the mobile header to one clean row: BragStack, Docs, Start free
- turns Docs into a quiet text action instead of another heavy pill
- makes Start free compact with a tighter radius and lighter shadow
- reduces mobile header padding, radius, and visual weight

## Why
The current login-page navbar wraps into a chunky two-row control block on phones. This makes the header dominate the page and the buttons look oversized. The new mobile treatment is much closer to a polished SaaS auth header.