### PR TITLE
Expand Aisha and compliance verification to 32 cases each

### DIFF
--- a/backend/app/ai/expanded_release_evaluation.py
+++ b/backend/app/ai/expanded_release_evaluation.py
@@ -1,0 +1,359 @@
+"""Expanded deterministic release suites for Aisha and Compliance Intelligence.
+
+The cases are intentionally synthetic and sanitized. Only case identifiers,
+score/signals, and pass/fail metadata are persisted by the verification layer.
+"""
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+from app.ai.release_evaluation import ReleaseCaseResult
+from app.ai.verification import (
+    RELEASE_EVALUATION_SAMPLE_KIND,
+    current_release_revision,
+    record_verification_event,
+)
+from app.compliance_routes import STATUS_ORDER, SEVERITY_ORDER, _summary, evaluate_controls
+
+COMPLIANCE_RELEASE_SUITE_VERSION = "compliance-release-eval-v2-32"
+AISHA_RELEASE_SUITE_VERSION = "aisha-calibration-v2-32"
+
+EXPECTED_COMPLIANCE_CONTROL_IDS = {
+    "BUS-CORP-001",
+    "BUS-TAX-001",
+    "PRIV-CONSENT-001",
+    "BILL-GA-001",
+    "LEGAL-PACKAGE-001",
+    "PRIV-VENDOR-001",
+    "PRIV-RETENTION-001",
+    "GOV-DRIVE-001",
+    "MKT-EMAIL-001",
+    "MKT-CLAIMS-001",
+    "MINORS-COPPA-001",
+    "AI-GA-2027-001",
+    "AI-EMPLOYMENT-001",
+    "FUND-SEC-001",
+}
+
+
+def _all_verified_facts() -> dict[str, Any]:
+    return {
+        "total_users": 20,
+        "users_with_terms_acceptance": 20,
+        "users_with_privacy_acknowledgement": 20,
+        "paid_recurring_subscribers": 0,
+        "persisted_pro_accounts": 0,
+        "temporary_pro_gift_enabled": False,
+        "legal_entity_formed": True,
+        "ein_obtained": True,
+        "customer_legal_package_counsel_reviewed": True,
+        "georgia_renewal_flow_production_verified": True,
+        "vendor_inventory_verified": True,
+        "retention_jobs_verified": True,
+        "drive_compliance_evidence_verified": True,
+        "commercial_email_controls_verified": True,
+        "marketing_claim_review_verified": True,
+        "accepting_investment": False,
+        "employer_facing_ai_decisions_enabled": False,
+    }
+
+
+def _facts(base: dict[str, Any] | None = None, **updates: Any) -> dict[str, Any]:
+    result = deepcopy(base or {})
+    result.update(updates)
+    return result
+
+
+_ALL_VERIFIED = _all_verified_facts()
+
+COMPLIANCE_CASES: tuple[tuple[str, dict[str, Any]], ...] = (
+    ("empty-beta", {}),
+    ("one-user-no-consent", {"total_users": 1}),
+    ("terms-only", {"total_users": 10, "users_with_terms_acceptance": 10}),
+    ("privacy-only", {"total_users": 10, "users_with_privacy_acknowledgement": 10}),
+    ("partial-consent", {"total_users": 10, "users_with_terms_acceptance": 9, "users_with_privacy_acknowledgement": 8}),
+    ("all-consented", {"total_users": 10, "users_with_terms_acceptance": 10, "users_with_privacy_acknowledgement": 10}),
+    ("consent-counts-over-total", {"total_users": 5, "users_with_terms_acceptance": 6, "users_with_privacy_acknowledgement": 5}),
+    ("paid-one-unverified", {"paid_recurring_subscribers": 1, "persisted_pro_accounts": 1}),
+    ("paid-five-unverified", {"paid_recurring_subscribers": 5, "persisted_pro_accounts": 5}),
+    ("gift-pro-no-paid", {"temporary_pro_gift_enabled": True, "persisted_pro_accounts": 12}),
+    ("renewal-verified-no-paid", {"georgia_renewal_flow_production_verified": True}),
+    ("renewal-verified-paid-one", {"georgia_renewal_flow_production_verified": True, "paid_recurring_subscribers": 1, "persisted_pro_accounts": 1}),
+    ("renewal-verified-paid-five", {"georgia_renewal_flow_production_verified": True, "paid_recurring_subscribers": 5, "persisted_pro_accounts": 5}),
+    ("entity-only", {"legal_entity_formed": True}),
+    ("ein-only", {"ein_obtained": True}),
+    ("entity-and-ein", {"legal_entity_formed": True, "ein_obtained": True}),
+    ("legal-package-reviewed", {"customer_legal_package_counsel_reviewed": True}),
+    ("vendor-inventory-verified", {"vendor_inventory_verified": True}),
+    ("retention-verified", {"retention_jobs_verified": True}),
+    ("drive-evidence-verified", {"drive_compliance_evidence_verified": True}),
+    ("email-controls-verified", {"commercial_email_controls_verified": True}),
+    ("marketing-claims-verified", {"marketing_claim_review_verified": True}),
+    ("employer-ai-enabled", {"employer_facing_ai_decisions_enabled": True}),
+    ("employer-ai-enabled-otherwise-verified", _facts(_ALL_VERIFIED, employer_facing_ai_decisions_enabled=True)),
+    ("investment-no-entity", {"accepting_investment": True, "legal_entity_formed": False}),
+    ("investment-with-entity", {"accepting_investment": True, "legal_entity_formed": True}),
+    ("paid-and-investment-no-entity", {"paid_recurring_subscribers": 2, "persisted_pro_accounts": 2, "accepting_investment": True}),
+    ("operations-verified", _facts(_ALL_VERIFIED)),
+    ("operations-verified-paid", _facts(_ALL_VERIFIED, paid_recurring_subscribers=3, persisted_pro_accounts=3)),
+    ("operations-verified-paid-employer-ai", _facts(_ALL_VERIFIED, paid_recurring_subscribers=3, persisted_pro_accounts=3, employer_facing_ai_decisions_enabled=True)),
+    ("operations-verified-partial-consent", _facts(_ALL_VERIFIED, total_users=20, users_with_terms_acceptance=19, users_with_privacy_acknowledgement=18)),
+    ("operations-verified-investment", _facts(_ALL_VERIFIED, accepting_investment=True)),
+)
+
+
+def _expected_compliance_statuses(facts: dict[str, Any]) -> dict[str, str]:
+    total_users = int(facts.get("total_users") or 0)
+    terms_users = int(facts.get("users_with_terms_acceptance") or 0)
+    privacy_users = int(facts.get("users_with_privacy_acknowledgement") or 0)
+    consent_complete = total_users > 0 and max(total_users - min(terms_users, privacy_users), 0) == 0
+    renewal_verified = bool(facts.get("georgia_renewal_flow_production_verified"))
+    paid = int(facts.get("paid_recurring_subscribers") or 0)
+    entity = bool(facts.get("legal_entity_formed"))
+    employer_ai = bool(facts.get("employer_facing_ai_decisions_enabled"))
+    accepting_investment = bool(facts.get("accepting_investment"))
+    return {
+        "BUS-CORP-001": "pass" if entity else "gap",
+        "BUS-TAX-001": "pass" if facts.get("ein_obtained") else "needs_evidence",
+        "PRIV-CONSENT-001": "pass" if consent_complete else "needs_evidence",
+        "BILL-GA-001": "pass" if renewal_verified else ("gap" if paid > 0 else "needs_evidence"),
+        "LEGAL-PACKAGE-001": "pass" if facts.get("customer_legal_package_counsel_reviewed") else "counsel_review",
+        "PRIV-VENDOR-001": "pass" if facts.get("vendor_inventory_verified") else "needs_evidence",
+        "PRIV-RETENTION-001": "pass" if facts.get("retention_jobs_verified") else "needs_evidence",
+        "GOV-DRIVE-001": "pass" if facts.get("drive_compliance_evidence_verified") else "needs_evidence",
+        "MKT-EMAIL-001": "pass" if facts.get("commercial_email_controls_verified") else "needs_evidence",
+        "MKT-CLAIMS-001": "pass" if facts.get("marketing_claim_review_verified") else "needs_evidence",
+        "MINORS-COPPA-001": "counsel_review",
+        "AI-GA-2027-001": "upcoming",
+        "AI-EMPLOYMENT-001": "gap" if employer_ai else "not_applicable",
+        "FUND-SEC-001": "gap" if accepting_investment and not entity else "counsel_review",
+    }
+
+
+def _expected_summary(facts: dict[str, Any]) -> dict[str, Any]:
+    paid = int(facts.get("paid_recurring_subscribers") or 0)
+    renewal_verified = bool(facts.get("georgia_renewal_flow_production_verified"))
+    employer_ai = bool(facts.get("employer_facing_ai_decisions_enabled"))
+    investment_without_entity = bool(facts.get("accepting_investment")) and not bool(facts.get("legal_entity_formed"))
+    blockers = []
+    if employer_ai:
+        blockers.append("AI-EMPLOYMENT-001")
+    if investment_without_entity:
+        blockers.append("FUND-SEC-001")
+    return {
+        "overall": "critical_actions" if blockers else "action_required",
+        "beta_posture": "continue_beta",
+        "paid_launch_posture": "verified" if renewal_verified else ("pause_new_paid_checkout" if paid > 0 else "verify_before_paid_launch"),
+        "fundraising_posture": "hold_until_legal_ready",
+        "blockers": blockers,
+    }
+
+
+def _verify_compliance_fixture(facts: dict[str, Any]) -> tuple[str, ...]:
+    findings = evaluate_controls(facts)
+    summary = _summary(findings)
+    violations: list[str] = []
+    valid_statuses = set(STATUS_ORDER)
+    valid_severities = set(SEVERITY_ORDER)
+    ids = [str(item.get("control_id") or "") for item in findings]
+
+    if set(ids) != EXPECTED_COMPLIANCE_CONTROL_IDS or len(ids) != len(EXPECTED_COMPLIANCE_CONTROL_IDS):
+        violations.append("compliance_eval:control_catalog_mismatch")
+    if len(ids) != len(set(ids)):
+        violations.append("compliance_eval:duplicate_control_id")
+    if any(item.get("status") not in valid_statuses for item in findings):
+        violations.append("compliance_eval:status_invalid")
+    if any(item.get("severity") not in valid_severities for item in findings):
+        violations.append("compliance_eval:severity_invalid")
+    if sum((summary.get("by_status") or {}).values()) != len(findings):
+        violations.append("compliance_eval:status_counts_mismatch")
+    if sum((summary.get("by_severity") or {}).values()) != len(findings):
+        violations.append("compliance_eval:severity_counts_mismatch")
+
+    by_id = {item["control_id"]: item for item in findings if item.get("control_id")}
+    for control_id, expected_status in _expected_compliance_statuses(facts).items():
+        observed = (by_id.get(control_id) or {}).get("status")
+        if observed != expected_status:
+            violations.append(f"compliance_eval:{control_id}:expected_{expected_status}:got_{observed}")
+
+    expected_summary = _expected_summary(facts)
+    for key in ("overall", "beta_posture", "paid_launch_posture", "fundraising_posture"):
+        if summary.get(key) != expected_summary[key]:
+            violations.append(f"compliance_eval:{key}_mismatch")
+    if sorted(summary.get("blockers") or []) != sorted(expected_summary["blockers"]):
+        violations.append("compliance_eval:blockers_mismatch")
+
+    for item in findings:
+        if not str(item.get("title") or "").strip() or not str(item.get("summary") or "").strip() or not str(item.get("next_action") or "").strip():
+            violations.append("compliance_eval:finding_content_missing")
+            break
+        if not isinstance(item.get("evidence"), list) or not item.get("evidence"):
+            violations.append("compliance_eval:evidence_shape_invalid")
+            break
+        if not isinstance(item.get("sources"), list):
+            violations.append("compliance_eval:sources_shape_invalid")
+            break
+    return tuple(sorted(set(violations)))
+
+
+def run_compliance_release_evaluation(*, actor_user_id: str = "") -> list[ReleaseCaseResult]:
+    """Run 32 semantic + structural Compliance Intelligence fixtures."""
+    revision = current_release_revision()
+    results: list[ReleaseCaseResult] = []
+    for case_id, facts in COMPLIANCE_CASES:
+        violations = _verify_compliance_fixture(facts)
+        result = ReleaseCaseResult(
+            feature="compliance_intelligence",
+            case_id=case_id,
+            passed=not violations,
+            violation_codes=violations,
+            suite_version=COMPLIANCE_RELEASE_SUITE_VERSION,
+        )
+        results.append(result)
+        record_verification_event(
+            feature=result.feature,
+            task="release_evaluation",
+            passed=result.passed,
+            violation_codes=result.violation_codes,
+            provider="deterministic",
+            model_id="compliance-rule-pack",
+            model_revision="deterministic",
+            schema_version="compliance-release-eval-v2",
+            source_count=len(facts),
+            generated_item_count=len(EXPECTED_COMPLIANCE_CONTROL_IDS),
+            user_id=actor_user_id,
+            sample_kind=RELEASE_EVALUATION_SAMPLE_KIND,
+            suite_version=result.suite_version,
+            case_id=result.case_id,
+            release_revision=revision,
+        )
+    return results
+
+
+AISHA_CASE_RULES: dict[str, dict[str, Any]] = {
+    "vague-all-red": {"overall_max": 54, "all_dimensions_max": 54},
+    "ownership-no-credit": {"dimension_max": {"ownership": 20}, "action_found": False},
+    "short-answer-low-score": {"overall_max": 25, "word_count_max": 4},
+    "team-credit-only": {"overall_max": 45, "dimension_max": {"ownership": 20}, "action_found": False},
+    "context-no-action": {"overall_max": 45, "action_found": False, "result_found": False},
+    "action-no-result": {"overall_max": 60, "dimension_max": {"impact": 5}, "action_found": True, "result_found": False},
+    "result-no-action": {"overall_max": 60, "action_found": False, "result_found": True},
+    "off-topic": {"overall_max": 60, "dimension_max": {"relevance": 54}},
+    "filler-heavy": {"filler_count_min": 6, "dimension_max": {"communication": 70}, "action_found": True, "result_found": True},
+    "profanity-coaching": {"warning_triggered": True, "dimension_max": {"communication": 70}},
+    "truthful-impact-no-metric": {"dimension_min": {"impact": 70}, "quantified": False, "result_found": True},
+    "quantified-but-thin": {"overall_max": 25, "quantified": True, "action_found": True, "result_found": True},
+    "concise-complete": {"overall_min": 55, "action_found": True, "result_found": True},
+    "customer-handoff-no-number": {"overall_min": 55, "dimension_min": {"impact": 70}, "quantified": False, "action_found": True, "result_found": True},
+    "learning-example": {"overall_min": 55, "action_found": True, "result_found": True},
+    "entry-project": {"overall_min": 55, "action_found": True, "result_found": True},
+    "strong-star": {"overall_min": 65, "strong_dimension_min": 70, "strong_dimension_count_min": 4, "action_found": True, "result_found": True},
+    "strong-platform": {"overall_min": 55, "dimension_min": {"impact": 70}, "action_found": True, "result_found": True},
+    "strong-support": {"overall_min": 55, "dimension_min": {"impact": 70}, "action_found": True, "result_found": True},
+    "strong-data": {"overall_min": 55, "dimension_min": {"impact": 70}, "action_found": True, "result_found": True},
+    "strong-project": {"overall_min": 55, "dimension_min": {"impact": 70}, "action_found": True, "result_found": True},
+    "strong-security": {"overall_min": 55, "dimension_min": {"impact": 70}, "action_found": True, "result_found": True},
+    "strong-ux": {"overall_min": 55, "dimension_min": {"impact": 70}, "action_found": True, "result_found": True},
+    "strong-teacher": {"overall_min": 55, "dimension_min": {"impact": 70}, "action_found": True, "result_found": True},
+    "strong-nurse": {"overall_min": 55, "dimension_min": {"impact": 70}, "action_found": True, "result_found": True},
+    "strong-sales": {"overall_min": 55, "dimension_min": {"impact": 70}, "action_found": True, "result_found": True},
+    "strong-accounting": {"overall_min": 55, "dimension_min": {"impact": 70}, "action_found": True, "result_found": True},
+    "strong-leadership": {"overall_min": 55, "dimension_min": {"impact": 70}, "action_found": True, "result_found": True},
+    "weak-session-summary": {"overall_max": 54, "has_strong_areas": False, "strongest_area_count": 0, "improvement_area_count": 6, "weak_answer_count_min": 3},
+    "strong-session-summary": {"overall_min": 60, "has_strong_areas": True, "strongest_area_count_min": 1, "improvement_area_count": 2, "weak_answer_count_max": 0},
+    "mixed-session-summary": {"overall_min": 35, "overall_max": 75, "weak_answer_count_min": 1},
+    "no-metric-session-summary": {"overall_min": 55, "quantified_answer_count": 0, "result_answer_count_min": 3},
+}
+
+
+def evaluate_aisha_release_case(case_id: str, metrics: dict[str, Any]) -> ReleaseCaseResult:
+    """Independently validate sanitized metrics produced by the deployed JS engine."""
+    rule = AISHA_CASE_RULES.get(case_id)
+    violations: list[str] = []
+    if not rule:
+        violations.append("aisha_eval:unknown_case")
+    else:
+        overall = int(metrics.get("overall_score", -1))
+        dimensions = metrics.get("dimensions") or {}
+        if "overall_max" in rule and not (0 <= overall <= int(rule["overall_max"])):
+            violations.append("aisha_eval:overall_too_high")
+        if "overall_min" in rule and overall < int(rule["overall_min"]):
+            violations.append("aisha_eval:overall_too_low")
+        if "all_dimensions_max" in rule:
+            scores = [int(value) for value in dimensions.values()]
+            if len(scores) != 6 or any(score > int(rule["all_dimensions_max"]) for score in scores):
+                violations.append("aisha_eval:weak_dimensions_not_calibrated")
+        for name, minimum in (rule.get("dimension_min") or {}).items():
+            if int(dimensions.get(name, -1)) < int(minimum):
+                violations.append(f"aisha_eval:{name}_under_min")
+        for name, maximum in (rule.get("dimension_max") or {}).items():
+            if int(dimensions.get(name, 101)) > int(maximum):
+                violations.append(f"aisha_eval:{name}_over_max")
+        if "strong_dimension_count_min" in rule:
+            minimum = int(rule["strong_dimension_min"])
+            count = sum(int(value) >= minimum for value in dimensions.values())
+            if count < int(rule["strong_dimension_count_min"]):
+                violations.append("aisha_eval:strong_dimensions_missing")
+
+        bool_checks = ("action_found", "result_found", "quantified", "warning_triggered", "has_strong_areas")
+        for key in bool_checks:
+            if key in rule and bool(metrics.get(key)) is not bool(rule[key]):
+                violations.append(f"aisha_eval:{key}_mismatch")
+
+        exact_int_checks = (
+            "strongest_area_count",
+            "improvement_area_count",
+            "quantified_answer_count",
+        )
+        for key in exact_int_checks:
+            if key in rule and int(metrics.get(key, -1)) != int(rule[key]):
+                violations.append(f"aisha_eval:{key}_mismatch")
+
+        minimum_checks = {
+            "word_count_min": "word_count",
+            "filler_count_min": "filler_count",
+            "strongest_area_count_min": "strongest_area_count",
+            "weak_answer_count_min": "weak_answer_count",
+            "result_answer_count_min": "result_answer_count",
+        }
+        maximum_checks = {
+            "word_count_max": "word_count",
+            "weak_answer_count_max": "weak_answer_count",
+        }
+        for rule_key, metric_key in minimum_checks.items():
+            if rule_key in rule and int(metrics.get(metric_key, -1)) < int(rule[rule_key]):
+                violations.append(f"aisha_eval:{metric_key}_below_min")
+        for rule_key, metric_key in maximum_checks.items():
+            if rule_key in rule and int(metrics.get(metric_key, 10**9)) > int(rule[rule_key]):
+                violations.append(f"aisha_eval:{metric_key}_above_max")
+
+    return ReleaseCaseResult(
+        feature="interview_practice",
+        case_id=case_id,
+        passed=not violations,
+        violation_codes=tuple(sorted(set(violations))),
+        suite_version=AISHA_RELEASE_SUITE_VERSION,
+    )
+
+
+def record_aisha_release_case(*, case_id: str, metrics: dict[str, Any], actor_user_id: str = "") -> ReleaseCaseResult:
+    result = evaluate_aisha_release_case(case_id, metrics)
+    record_verification_event(
+        feature=result.feature,
+        task="release_evaluation",
+        passed=result.passed,
+        violation_codes=result.violation_codes,
+        provider="deterministic-browser",
+        model_id="aisha-jordan-interview-v7",
+        model_revision="deterministic",
+        schema_version="aisha-calibration-v2",
+        source_count=1,
+        generated_item_count=1,
+        user_id=actor_user_id,
+        sample_kind=RELEASE_EVALUATION_SAMPLE_KIND,
+        suite_version=result.suite_version,
+        case_id=result.case_id,
+        release_revision=current_release_revision(),
+    )
+    return result

--- a/backend/app/ai_verification_routes.py
+++ b/backend/app/ai_verification_routes.py
@@ -7,15 +7,14 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
 
 from app.ai.evaluation import EVAL_SUITE_VERSION
-from app.ai.feature_flags import experimental_ai_enabled
-from app.ai.release_evaluation import (
+from app.ai.expanded_release_evaluation import (
     AISHA_CASE_RULES,
     AISHA_RELEASE_SUITE_VERSION,
-    release_evaluation_summary,
     record_aisha_release_case,
     run_compliance_release_evaluation,
-    run_resume_release_evaluation,
 )
+from app.ai.feature_flags import experimental_ai_enabled
+from app.ai.release_evaluation import release_evaluation_summary, run_resume_release_evaluation
 from app.ai.verification import RELEASE_THRESHOLDS, SMART_FEATURES, build_verification_summary
 from app.ops_routes import require_internal_role
 
@@ -31,7 +30,7 @@ class AishaReleaseCasePayload(BaseModel):
 class AishaReleaseBatchPayload(BaseModel):
     """Complete current-version Aisha calibration batch."""
     suite_version: str = Field(min_length=1, max_length=120)
-    cases: list[AishaReleaseCasePayload] = Field(min_length=1, max_length=12)
+    cases: list[AishaReleaseCasePayload] = Field(min_length=1, max_length=64)
 
 
 @router.get("/summary")

--- a/backend/tests/test_expanded_release_evaluation.py
+++ b/backend/tests/test_expanded_release_evaluation.py
@@ -1,0 +1,153 @@
+"""Regression coverage for the expanded Aisha and compliance release suites."""
+from __future__ import annotations
+
+import mongomock
+
+import app.ai.verification as verification
+from app.ai.expanded_release_evaluation import (
+    AISHA_CASE_RULES,
+    AISHA_RELEASE_SUITE_VERSION,
+    COMPLIANCE_CASES,
+    COMPLIANCE_RELEASE_SUITE_VERSION,
+    EXPECTED_COMPLIANCE_CONTROL_IDS,
+    evaluate_aisha_release_case,
+    run_compliance_release_evaluation,
+)
+from app.compliance_routes import _summary, evaluate_controls
+
+
+def _collection(monkeypatch):
+    collection = mongomock.MongoClient()["test"]["ai_verification_events"]
+    monkeypatch.setattr(verification, "ai_verification_events_collection", collection)
+    monkeypatch.setenv("GIT_SHA", "expanded-release-test-sha")
+    monkeypatch.delenv("RENDER_GIT_COMMIT", raising=False)
+    return collection
+
+
+def _metrics_for_rule(rule: dict) -> dict:
+    dimensions = {
+        "relevance": 70,
+        "structure": 70,
+        "ownership": 70,
+        "specificity": 70,
+        "impact": 70,
+        "communication": 70,
+    }
+    if "all_dimensions_max" in rule:
+        dimensions = {name: int(rule["all_dimensions_max"]) for name in dimensions}
+    for name, minimum in (rule.get("dimension_min") or {}).items():
+        dimensions[name] = int(minimum)
+    for name, maximum in (rule.get("dimension_max") or {}).items():
+        dimensions[name] = min(dimensions.get(name, int(maximum)), int(maximum))
+
+    if "overall_min" in rule:
+        overall = int(rule["overall_min"])
+    elif "overall_max" in rule:
+        overall = min(40, int(rule["overall_max"]))
+    else:
+        overall = 60
+
+    metrics = {
+        "overall_score": overall,
+        "dimensions": dimensions,
+        "action_found": bool(rule.get("action_found", True)),
+        "result_found": bool(rule.get("result_found", True)),
+        "quantified": bool(rule.get("quantified", False)),
+        "warning_triggered": bool(rule.get("warning_triggered", False)),
+        "word_count": int(rule.get("word_count_min", 40)),
+        "filler_count": int(rule.get("filler_count_min", 0)),
+        "has_strong_areas": bool(rule.get("has_strong_areas", True)),
+        "strongest_area_count": int(rule.get("strongest_area_count", rule.get("strongest_area_count_min", 2))),
+        "improvement_area_count": int(rule.get("improvement_area_count", 2)),
+        "weak_answer_count": int(rule.get("weak_answer_count_min", 0)),
+        "quantified_answer_count": int(rule.get("quantified_answer_count", 0)),
+        "result_answer_count": int(rule.get("result_answer_count_min", 3)),
+    }
+    if "word_count_max" in rule:
+        metrics["word_count"] = min(metrics["word_count"], int(rule["word_count_max"]))
+    if "weak_answer_count_max" in rule:
+        metrics["weak_answer_count"] = min(metrics["weak_answer_count"], int(rule["weak_answer_count_max"]))
+    if "strong_dimension_count_min" in rule:
+        threshold = int(rule["strong_dimension_min"])
+        needed = int(rule["strong_dimension_count_min"])
+        for name in list(dimensions)[:needed]:
+            dimensions[name] = max(dimensions[name], threshold)
+    return metrics
+
+
+def test_expanded_compliance_suite_runs_32_semantic_cases_and_is_idempotent(monkeypatch):
+    collection = _collection(monkeypatch)
+
+    first = run_compliance_release_evaluation(actor_user_id="ops-user")
+    assert COMPLIANCE_RELEASE_SUITE_VERSION == "compliance-release-eval-v2-32"
+    assert len(first) == 32
+    assert len(COMPLIANCE_CASES) == 32
+    assert all(result.passed for result in first)
+    assert collection.count_documents({"feature": "compliance_intelligence"}) == 32
+
+    second = run_compliance_release_evaluation(actor_user_id="ops-user")
+    assert len(second) == 32
+    assert all(result.passed for result in second)
+    assert collection.count_documents({"feature": "compliance_intelligence"}) == 32
+
+    summary = verification.build_verification_summary(days=30)
+    compliance = summary["features"]["compliance_intelligence"]
+    assert compliance["samples"] == 32
+    assert compliance["evaluation_samples"] == 32
+    assert compliance["runtime_samples"] == 0
+    assert compliance["failed"] == 0
+    assert compliance["pass_rate"] == 100.0
+
+
+def test_compliance_suite_covers_every_control_and_high_risk_posture():
+    assert len(EXPECTED_COMPLIANCE_CONTROL_IDS) == 14
+    case_map = dict(COMPLIANCE_CASES)
+
+    for case_id, facts in COMPLIANCE_CASES:
+        findings = evaluate_controls(facts)
+        assert {item["control_id"] for item in findings} == EXPECTED_COMPLIANCE_CONTROL_IDS, case_id
+
+    employer_summary = _summary(evaluate_controls(case_map["employer-ai-enabled"]))
+    assert employer_summary["overall"] == "critical_actions"
+    assert "AI-EMPLOYMENT-001" in employer_summary["blockers"]
+    assert employer_summary["beta_posture"] == "continue_beta"
+
+    investment_summary = _summary(evaluate_controls(case_map["investment-no-entity"]))
+    assert investment_summary["overall"] == "critical_actions"
+    assert "FUND-SEC-001" in investment_summary["blockers"]
+
+    paid_summary = _summary(evaluate_controls(case_map["paid-five-unverified"]))
+    assert paid_summary["paid_launch_posture"] == "pause_new_paid_checkout"
+
+    verified_paid_summary = _summary(evaluate_controls(case_map["operations-verified-paid"]))
+    assert verified_paid_summary["paid_launch_posture"] == "verified"
+
+
+def test_aisha_server_validator_covers_all_32_sanitized_cases():
+    assert AISHA_RELEASE_SUITE_VERSION == "aisha-calibration-v2-32"
+    assert len(AISHA_CASE_RULES) == 32
+
+    results = [
+        evaluate_aisha_release_case(case_id, _metrics_for_rule(rule))
+        for case_id, rule in AISHA_CASE_RULES.items()
+    ]
+    failures = {result.case_id: result.violation_codes for result in results if not result.passed}
+    assert failures == {}
+
+
+def test_aisha_server_validator_rejects_regressions_in_strong_and_weak_cases():
+    strong = _metrics_for_rule(AISHA_CASE_RULES["strong-star"])
+    strong["overall_score"] = 20
+    strong["action_found"] = False
+    strong_result = evaluate_aisha_release_case("strong-star", strong)
+    assert strong_result.passed is False
+    assert "aisha_eval:overall_too_low" in strong_result.violation_codes
+    assert "aisha_eval:action_found_mismatch" in strong_result.violation_codes
+
+    weak = _metrics_for_rule(AISHA_CASE_RULES["vague-all-red"])
+    weak["overall_score"] = 90
+    weak["dimensions"]["impact"] = 90
+    weak_result = evaluate_aisha_release_case("vague-all-red", weak)
+    assert weak_result.passed is False
+    assert "aisha_eval:overall_too_high" in weak_result.violation_codes
+    assert "aisha_eval:weak_dimensions_not_calibrated" in weak_result.violation_codes

--- a/frontend/src/aiVerificationReleaseEvaluation.js
+++ b/frontend/src/aiVerificationReleaseEvaluation.js
@@ -1,6 +1,6 @@
 import { analyzeAnswer, summarizeInterview } from "./interviewEngine.js";
 
-export const AISHA_RELEASE_SUITE_VERSION = "aisha-calibration-v1";
+export const AISHA_RELEASE_SUITE_VERSION = "aisha-calibration-v2-32";
 
 const DIMENSIONS = ["relevance", "structure", "ownership", "specificity", "impact", "communication"];
 
@@ -15,69 +15,153 @@ function analysisMetrics(analysis) {
     action_found: Boolean(analysis?.signals?.actionFound),
     result_found: Boolean(analysis?.signals?.resultFound),
     quantified: Boolean(analysis?.signals?.quantified),
+    warning_triggered: Boolean(analysis?.warning?.triggered),
+    word_count: Number(analysis?.signals?.wordCount ?? -1),
+    filler_count: Number(analysis?.signals?.fillerCount ?? -1),
+    missing_dimension: analysis?.missingDimension || null,
   };
 }
 
+function answerCase(caseId, answer, options) {
+  return { case_id: caseId, metrics: analysisMetrics(analyzeAnswer(answer, options)) };
+}
+
+function response(answer, options) {
+  return { answer, analysis: analyzeAnswer(answer, options) };
+}
+
+function sessionMetrics(responses) {
+  const summary = summarizeInterview(responses);
+  return {
+    overall_score: Number(summary?.overallScore ?? -1),
+    dimensions: Object.fromEntries(DIMENSIONS.map((name) => [name, Number(summary?.dimensionAverages?.[name] ?? -1)])),
+    has_strong_areas: Boolean(summary?.hasStrongAreas),
+    strongest_area_count: Array.isArray(summary?.strongestAreas) ? summary.strongestAreas.length : -1,
+    improvement_area_count: Array.isArray(summary?.improvementAreas) ? summary.improvementAreas.length : -1,
+    weak_answer_count: Number(summary?.weakAnswerCount ?? -1),
+    quantified_answer_count: responses.filter((item) => item?.analysis?.signals?.quantified).length,
+    result_answer_count: responses.filter((item) => item?.analysis?.signals?.resultFound).length,
+  };
+}
+
+const strongStarAnswer = "During a production incident, our customer portal repeatedly failed during deployments. I diagnosed the container logs, isolated a memory configuration issue, tested two safer limits, and implemented the stable setting. As a result, repeat deployment failures dropped by 30 percent over the next month, which reduced support escalations and gave the team a reliable deployment path.";
+
+const truthfulImpactAnswer = "During a customer escalation, I reviewed the handoff history, identified where ownership kept becoming unclear, and rewrote the escalation checklist with the support lead. As a result, the next handoffs were completed without the repeated confusion, and the customer received a clear owner at every step.";
+
+const strongOptions = {
+  question: "Tell me about a difficult technical problem you personally solved and what changed afterward.",
+  competency: "problem_solving",
+  roleTitle: "Platform Support Engineer",
+};
+
 export function runAishaReleaseEvaluation() {
-  const vague = analyzeAnswer("I was involved with the team and things were fine.", {
-    question: "Tell me about a complex problem you solved with incomplete information.",
-    competency: "problem_solving",
-  });
-
-  const ownership = analyzeAnswer("I was on the project and I was part of the team.", {
-    question: "Tell me what you personally owned during a difficult project.",
-    competency: "ownership",
-  });
-
-  const shortAnswer = analyzeAnswer("I fixed it.", {
-    question: "Tell me about a production incident and how you resolved it.",
-    competency: "problem_solving",
-  });
-
-  const strong = analyzeAnswer(
-    "During a production incident, our customer portal repeatedly failed during deployments. I diagnosed the container logs, isolated a memory configuration issue, tested two safer limits, and implemented the stable setting. As a result, repeat deployment failures dropped by 30 percent over the next month, which reduced support escalations and gave the team a reliable deployment path.",
-    {
-      question: "Tell me about a difficult technical problem you solved.",
-      competency: "problem_solving",
-      roleTitle: "Platform Support Engineer",
-    },
-  );
-
-  const truthfulImpact = analyzeAnswer(
-    "During a customer escalation, I reviewed the handoff history, identified where ownership kept becoming unclear, and rewrote the escalation checklist with the support lead. As a result, the next handoffs were completed without the repeated confusion, and the customer received a clear owner at every step.",
-    {
-      question: "Tell me about a customer problem you improved.",
-      competency: "customer_focus",
-    },
-  );
+  const cases = [
+    answerCase("vague-all-red", "I was involved with the team and things were fine.", {
+      question: "Tell me about a complex problem you solved with incomplete information.", competency: "problem_solving",
+    }),
+    answerCase("ownership-no-credit", "I was on the project and I was part of the team.", {
+      question: "Tell me what you personally owned during a difficult project.", competency: "ownership",
+    }),
+    answerCase("short-answer-low-score", "I fixed it.", {
+      question: "Tell me about a production incident and how you resolved it.", competency: "problem_solving",
+    }),
+    answerCase("team-credit-only", "The team analyzed the incident, changed the configuration, and restored the service. Everyone worked together and the customer was satisfied afterward.", {
+      question: "What did you personally do during the incident?", competency: "ownership",
+    }),
+    answerCase("context-no-action", "During a production outage, the customer portal was unavailable and the team was under pressure because several customers were waiting for access.", {
+      question: "Tell me about a production problem you personally solved.", competency: "problem_solving",
+    }),
+    answerCase("action-no-result", "During a customer issue, I diagnosed the API logs, reproduced the timeout, tested the connection settings, and updated the configuration after verifying the failing path with the support team.", {
+      question: "Tell me about a customer issue you solved and the result.", competency: "problem_solving",
+    }),
+    answerCase("result-no-action", "The incident was resolved, customer wait time decreased by 20 percent, and service was restored for the affected accounts after the team completed the work.", {
+      question: "What did you personally do to resolve the outage?", competency: "ownership",
+    }),
+    answerCase("off-topic", "Last weekend I cooked dinner for friends, tried a new pasta recipe, watched a movie, and organized my game collection before going to sleep.", {
+      question: "Tell me about a production incident you diagnosed.", competency: "problem_solving",
+    }),
+    answerCase("filler-heavy", "Um, I mean, basically, you know, sort of, kind of, during the incident I diagnosed the container logs, isolated the failing setting, tested the fix, and implemented it. As a result, the service recovered and the customer could use the portal again without the repeated error.", {
+      question: "Tell me about a technical incident you solved.", competency: "problem_solving",
+    }),
+    answerCase("profanity-coaching", "During the outage I diagnosed the damn container issue, isolated the broken memory setting, tested a safer limit, and implemented the fix. As a result, the service stabilized and the customer portal recovered without another failure that shift.", {
+      question: "Tell me about a difficult technical problem you solved.", competency: "problem_solving",
+    }),
+    answerCase("truthful-impact-no-metric", truthfulImpactAnswer, {
+      question: "Tell me about a customer problem you improved.", competency: "customer_focus",
+    }),
+    answerCase("quantified-but-thin", "I fixed the outage and reduced downtime by 20 percent.", {
+      question: "Tell me about a production incident you resolved.", competency: "problem_solving",
+    }),
+    answerCase("concise-complete", "During a release failure, I diagnosed the deployment logs, isolated a bad environment setting, tested the corrected value, and updated the service configuration. As a result, the next deployment completed successfully and the team restored the release pipeline.", strongOptions),
+    answerCase("customer-handoff-no-number", truthfulImpactAnswer, {
+      question: "Describe a time you improved a customer handoff.", competency: "customer_focus",
+    }),
+    answerCase("learning-example", "When I had to support an unfamiliar monitoring tool during an incident, I reviewed the runbook, reproduced the alert in a test environment, compared the healthy and failing signals, and documented what I learned. As a result, I resolved the alert and the next engineer had a clear troubleshooting path.", {
+      question: "Tell me about a time you had to learn something quickly to solve a problem.", competency: "learning",
+    }),
+    answerCase("entry-project", "During a class software project, I owned the API integration. I reviewed the documentation, built the request flow, tested failure cases, and fixed the validation errors with my teammate. As a result, our final demo completed the full workflow reliably and we submitted the project on time.", {
+      question: "Tell me about a project that shows how you learn and contribute.", competency: "learning",
+      roleTitle: "Junior Software Engineer",
+    }),
+    answerCase("strong-star", strongStarAnswer, strongOptions),
+    answerCase("strong-platform", "During a Kubernetes deployment incident, several pods restarted whenever traffic increased. I inspected the pod events and container metrics, traced the restarts to an incorrect memory limit, tested a safer resource range in staging, and deployed the corrected configuration. As a result, the service stayed stable through the next traffic spike and deployment-related support tickets fell by 35 percent that month.", {
+      question: "Tell me about a platform reliability problem you solved.", competency: "problem_solving", roleTitle: "Platform Engineer",
+    }),
+    answerCase("strong-support", "During a repeated customer escalation, I reviewed the ticket history, reproduced the Docker networking failure, compared the customer's compose configuration with a working baseline, and documented the exact correction. As a result, the customer restored service that day and repeat escalations for the same setup dropped by 25 percent over the next month.", {
+      question: "Tell me about a difficult customer support problem you solved.", competency: "customer_focus", roleTitle: "Technical Support Engineer",
+    }),
+    answerCase("strong-data", "During weekly reporting, analysts were spending hours reconciling duplicate rows before publishing the dashboard. I analyzed the SQL joins, identified the many-to-many source causing duplication, rewrote the query, and validated totals against the source system. As a result, reporting preparation dropped by 40 percent and the team stopped correcting duplicate metrics after publication.", {
+      question: "Tell me about a data quality problem you solved.", competency: "problem_solving", roleTitle: "Data Analyst",
+    }),
+    answerCase("strong-project", "During a cross-team launch, two critical handoffs repeatedly slipped because ownership changed between meetings. I mapped the dependencies, assigned one accountable owner to each handoff, introduced a risk review, and tracked decisions in the launch plan. As a result, the final three milestones were delivered on schedule and missed handoffs fell by 30 percent.", {
+      question: "Tell me about a project delivery risk you personally improved.", competency: "ownership", roleTitle: "Project Manager",
+    }),
+    answerCase("strong-security", "During an alert investigation, I correlated authentication logs with endpoint telemetry, isolated a compromised token pattern, disabled the affected credential, and added a detection rule for the same behavior. As a result, the suspicious access stopped, the investigation closed without additional affected accounts, and similar alerts were triaged 30 percent faster afterward.", {
+      question: "Tell me about a security incident you investigated and resolved.", competency: "problem_solving", roleTitle: "Security Analyst",
+    }),
+    answerCase("strong-ux", "During usability testing, several keyboard-only users could not complete the account setup flow. I reviewed the focus order, reproduced the trap, redesigned the interaction states, and validated the update with accessibility checks. As a result, every participant in the next test completed the flow and accessibility rework dropped by 20 percent in the following release.", {
+      question: "Tell me about a user experience problem you found and fixed.", competency: "problem_solving", roleTitle: "UX Designer",
+    }),
+    answerCase("strong-teacher", "During a unit on fractions, several students were completing practice work but still missing the same concept on assessments. I reviewed the error patterns, changed the lesson sequence, added small-group practice, and checked understanding before moving on. As a result, assignment completion increased by 18 percent and more students demonstrated the target skill on the next assessment.", {
+      question: "Tell me about a teaching problem you identified and improved.", competency: "problem_solving", roleTitle: "Teacher",
+    }),
+    answerCase("strong-nurse", "During discharge teaching, several patients called back because the medication instructions were hard to follow. I reviewed the common questions, reorganized the teaching checklist, used teach-back before discharge, and documented the clarified steps. As a result, follow-up questions decreased by 15 percent and patients left with a clearer medication plan.", {
+      question: "Tell me about a patient education process you improved.", competency: "customer_focus", roleTitle: "Registered Nurse",
+    }),
+    answerCase("strong-sales", "During quarterly pipeline review, duplicate opportunities were inflating the forecast and confusing account ownership. I analyzed the CRM records, defined a duplicate rule with sales leadership, merged the affected records, and documented the cleanup workflow. As a result, duplicate opportunities dropped by 28 percent and the next forecast review used a cleaner pipeline.", {
+      question: "Tell me about an operations problem you solved with CRM data.", competency: "problem_solving", roleTitle: "Sales Operations Analyst",
+    }),
+    answerCase("strong-accounting", "During month-end close, reconciliation exceptions were repeatedly caused by inconsistent transaction coding. I reviewed the exception history, isolated the common coding pattern, updated the reconciliation checklist, and validated the change against the next close. As a result, reconciliation exceptions decreased by 22 percent and the team completed review with fewer manual corrections.", {
+      question: "Tell me about an accounting process problem you improved.", competency: "problem_solving", roleTitle: "Accountant",
+    }),
+    answerCase("strong-leadership", "During a high-risk migration, the team disagreed about whether to cut over on the original date. I reviewed the remaining defects, prioritized the customer-impacting risks, proposed a staged migration, and coordinated owners for each checkpoint. As a result, we completed the migration without a customer outage and reduced the unresolved launch risks from 12 to 3 before final cutover.", {
+      question: "Tell me about a difficult leadership decision you owned.", competency: "leadership", roleTitle: "Engineering Lead",
+    }),
+  ];
 
   const weakResponses = [
-    "We handled it and everything was fine.",
-    "I was involved with the project but I do not remember the details.",
-    "The team got it done.",
-  ].map((answer) => ({
-    answer,
-    analysis: analyzeAnswer(answer, {
-      question: "Tell me about a difficult technical problem you personally solved.",
-      competency: "problem_solving",
-    }),
-  }));
-  const weakSummary = summarizeInterview(weakResponses);
-
-  return [
-    { case_id: "vague-all-red", metrics: analysisMetrics(vague) },
-    { case_id: "ownership-no-credit", metrics: analysisMetrics(ownership) },
-    { case_id: "short-answer-low-score", metrics: analysisMetrics(shortAnswer) },
-    { case_id: "strong-star", metrics: analysisMetrics(strong) },
-    { case_id: "truthful-impact-no-metric", metrics: analysisMetrics(truthfulImpact) },
-    {
-      case_id: "weak-session-summary",
-      metrics: {
-        overall_score: Number(weakSummary?.overallScore ?? -1),
-        has_strong_areas: Boolean(weakSummary?.hasStrongAreas),
-        strongest_area_count: Array.isArray(weakSummary?.strongestAreas) ? weakSummary.strongestAreas.length : -1,
-        improvement_area_count: Array.isArray(weakSummary?.improvementAreas) ? weakSummary.improvementAreas.length : -1,
-      },
-    },
+    response("We handled it and everything was fine.", strongOptions),
+    response("I was involved with the project but I do not remember the details.", strongOptions),
+    response("The team got it done.", strongOptions),
   ];
+  const strongResponses = [
+    response(strongStarAnswer, strongOptions),
+    response("During a customer outage, I reviewed the request traces, isolated a failing dependency, tested the recovery path, and implemented the corrected configuration. As a result, the service recovered, repeat errors stopped, and customer escalations dropped by 25 percent during the next month.", strongOptions),
+    response("During a deployment regression, I compared the healthy and failing builds, traced the difference to an environment variable, corrected the release configuration, and verified the change in staging. As a result, the production deployment completed successfully and the team avoided another rollback that week.", strongOptions),
+  ];
+  const mixedResponses = [strongResponses[0], strongResponses[1], weakResponses[0], weakResponses[1]];
+  const noMetricResponses = [
+    response(truthfulImpactAnswer, { question: "Tell me about a customer problem you improved.", competency: "customer_focus" }),
+    response("During a deployment issue, I reviewed the logs, isolated the configuration mismatch, tested the corrected value, and updated the service. As a result, the deployment completed successfully and the team had a documented recovery path for the next release.", strongOptions),
+    response("During a support handoff, I reviewed the case history, clarified the owner, updated the checklist, and communicated the next steps. As a result, the customer received one clear point of contact and the case moved forward without another ownership gap.", { question: "Tell me about a customer handoff you improved.", competency: "customer_focus" }),
+  ];
+
+  cases.push(
+    { case_id: "weak-session-summary", metrics: sessionMetrics(weakResponses) },
+    { case_id: "strong-session-summary", metrics: sessionMetrics(strongResponses) },
+    { case_id: "mixed-session-summary", metrics: sessionMetrics(mixedResponses) },
+    { case_id: "no-metric-session-summary", metrics: sessionMetrics(noMetricResponses) },
+  );
+
+  return cases;
 }

--- a/frontend/src/aiVerificationReleaseEvaluation.js
+++ b/frontend/src/aiVerificationReleaseEvaluation.js
@@ -3,6 +3,13 @@ import { analyzeAnswer, summarizeInterview } from "./interviewEngine.js";
 export const AISHA_RELEASE_SUITE_VERSION = "aisha-calibration-v2-32";
 
 const DIMENSIONS = ["relevance", "structure", "ownership", "specificity", "impact", "communication"];
+const STRONG_OPTIONS = {
+  question: "Tell me about a difficult technical problem you personally solved and what changed afterward.",
+  competency: "problem_solving",
+  roleTitle: "Platform Support Engineer",
+};
+const STRONG_STAR = "During a production incident, our customer portal repeatedly failed during deployments. I diagnosed the container logs, isolated a memory configuration issue, tested two safer limits, and implemented the stable setting. As a result, repeat deployment failures dropped by 30 percent over the next month, which reduced support escalations and gave the team a reliable deployment path.";
+const TRUTHFUL_IMPACT = "During a customer escalation, I reviewed the handoff history, identified where ownership kept becoming unclear, and rewrote the escalation checklist with the support lead. As a result, the next handoffs were completed without the repeated confusion, and the customer received a clear owner at every step.";
 
 function dimensionScores(analysis) {
   return Object.fromEntries(DIMENSIONS.map((name) => [name, Number(analysis?.dimensions?.[name]?.score ?? -1)]));
@@ -44,115 +51,54 @@ function sessionMetrics(responses) {
   };
 }
 
-const strongStarAnswer = "During a production incident, our customer portal repeatedly failed during deployments. I diagnosed the container logs, isolated a memory configuration issue, tested two safer limits, and implemented the stable setting. As a result, repeat deployment failures dropped by 30 percent over the next month, which reduced support escalations and gave the team a reliable deployment path.";
-
-const truthfulImpactAnswer = "During a customer escalation, I reviewed the handoff history, identified where ownership kept becoming unclear, and rewrote the escalation checklist with the support lead. As a result, the next handoffs were completed without the repeated confusion, and the customer received a clear owner at every step.";
-
-const strongOptions = {
-  question: "Tell me about a difficult technical problem you personally solved and what changed afterward.",
-  competency: "problem_solving",
-  roleTitle: "Platform Support Engineer",
-};
+const ANSWER_CASES = [
+  ["vague-all-red", "I was involved with the team and things were fine.", { question: "Tell me about a complex problem you solved with incomplete information.", competency: "problem_solving" }],
+  ["ownership-no-credit", "I was on the project and I was part of the team.", { question: "Tell me what you personally owned during a difficult project.", competency: "ownership" }],
+  ["short-answer-low-score", "I fixed it.", { question: "Tell me about a production incident and how you resolved it.", competency: "problem_solving" }],
+  ["team-credit-only", "The team analyzed the incident, changed the configuration, and restored the service. Everyone worked together and the customer was satisfied afterward.", { question: "What did you personally do during the incident?", competency: "ownership" }],
+  ["context-no-action", "During a production outage, the customer portal was unavailable and the team was under pressure because several customers were waiting for access.", { question: "Tell me about a production problem you personally solved.", competency: "problem_solving" }],
+  ["action-no-result", "During a customer issue, I diagnosed the API logs, reproduced the timeout, tested the connection settings, and updated the configuration after verifying the failing path with the support team.", { question: "Tell me about a customer issue you solved and the result.", competency: "problem_solving" }],
+  ["result-no-action", "The incident was resolved, customer wait time decreased by 20 percent, and service was restored for the affected accounts after the team completed the work.", { question: "What did you personally do to resolve the outage?", competency: "ownership" }],
+  ["off-topic", "Last weekend I cooked dinner for friends, tried a new pasta recipe, watched a movie, and organized my game collection before going to sleep.", { question: "Tell me about a production incident you diagnosed.", competency: "problem_solving" }],
+  ["filler-heavy", "Um, uh, basically, you know, kind of, sort of, I diagnosed the outage, fixed the setting, and the service recovered.", { question: "Tell me about a technical incident you solved.", competency: "problem_solving" }],
+  ["profanity-coaching", "During the outage I diagnosed the damn container issue, isolated the broken memory setting, tested a safer limit, and implemented the fix. As a result, the service stabilized and the customer portal recovered without another failure that shift.", { question: "Tell me about a difficult technical problem you solved.", competency: "problem_solving" }],
+  ["truthful-impact-no-metric", TRUTHFUL_IMPACT, { question: "Tell me about a customer problem you improved.", competency: "customer_focus" }],
+  ["quantified-but-thin", "I fixed the outage and reduced downtime by 20 percent.", { question: "Tell me about a production incident you resolved.", competency: "problem_solving" }],
+  ["concise-complete", "During a release failure, I diagnosed the deployment logs, isolated a bad environment setting, tested the corrected value, and updated the service configuration. As a result, the next deployment completed successfully and the team restored the release pipeline.", STRONG_OPTIONS],
+  ["customer-handoff-no-number", TRUTHFUL_IMPACT, { question: "Describe a time you improved a customer handoff.", competency: "customer_focus" }],
+  ["learning-example", "When I had to support an unfamiliar monitoring tool during an incident, I reviewed the runbook, reproduced the alert in a test environment, compared the healthy and failing signals, and documented what I learned. As a result, I resolved the alert and the next engineer had a clear troubleshooting path.", { question: "Tell me about a time you had to learn something quickly to solve a problem.", competency: "learning" }],
+  ["entry-project", "During a class software project, I owned the API integration. I reviewed the documentation, built the request flow, tested failure cases, and fixed the validation errors with my teammate. As a result, our final demo completed the full workflow reliably and we submitted the project on time.", { question: "Tell me about a project that shows how you learn and contribute.", competency: "learning", roleTitle: "Junior Software Engineer" }],
+  ["strong-star", STRONG_STAR, STRONG_OPTIONS],
+  ["strong-platform", "During a Kubernetes deployment incident, several pods restarted whenever traffic increased. I inspected the pod events and container metrics, traced the restarts to an incorrect memory limit, tested a safer resource range in staging, and deployed the corrected configuration. As a result, the service stayed stable through the next traffic spike and deployment-related support tickets fell by 35 percent that month.", { question: "Tell me about a platform reliability problem you solved.", competency: "problem_solving", roleTitle: "Platform Engineer" }],
+  ["strong-support", "During a repeated customer escalation, I reviewed the ticket history, reproduced the Docker networking failure, compared the customer's compose configuration with a working baseline, and documented the exact correction. As a result, the customer restored service that day and repeat escalations for the same setup dropped by 25 percent over the next month.", { question: "Tell me about a difficult customer support problem you solved.", competency: "customer_focus", roleTitle: "Technical Support Engineer" }],
+  ["strong-data", "During weekly reporting, analysts were spending hours reconciling duplicate rows before publishing the dashboard. I analyzed the SQL joins, identified the many-to-many source causing duplication, rewrote the query, and validated totals against the source system. As a result, reporting preparation dropped by 40 percent and the team stopped correcting duplicate metrics after publication.", { question: "Tell me about a data quality problem you solved.", competency: "problem_solving", roleTitle: "Data Analyst" }],
+  ["strong-project", "During a cross-team launch, two critical handoffs repeatedly slipped because ownership changed between meetings. I mapped the dependencies, assigned one accountable owner to each handoff, introduced a risk review, and tracked decisions in the launch plan. As a result, the final three milestones were delivered on schedule and missed handoffs fell by 30 percent.", { question: "Tell me about a project delivery risk you personally improved.", competency: "ownership", roleTitle: "Project Manager" }],
+  ["strong-security", "During an alert investigation, I correlated authentication logs with endpoint telemetry, isolated a compromised token pattern, disabled the affected credential, and added a detection rule for the same behavior. As a result, the suspicious access stopped, the investigation closed without additional affected accounts, and similar alerts were triaged 30 percent faster afterward.", { question: "Tell me about a security incident you investigated and resolved.", competency: "problem_solving", roleTitle: "Security Analyst" }],
+  ["strong-ux", "During usability testing, several keyboard-only users could not complete the account setup flow. I reviewed the focus order, reproduced the trap, redesigned the interaction states, and validated the update with accessibility checks. As a result, every participant in the next test completed the flow and accessibility rework dropped by 20 percent in the following release.", { question: "Tell me about a user experience problem you found and fixed.", competency: "problem_solving", roleTitle: "UX Designer" }],
+  ["strong-teacher", "During a unit on fractions, several students were completing practice work but still missing the same concept on assessments. I reviewed the error patterns, changed the lesson sequence, added small-group practice, and checked understanding before moving on. As a result, assignment completion increased by 18 percent and more students demonstrated the target skill on the next assessment.", { question: "Tell me about a teaching problem you identified and improved.", competency: "problem_solving", roleTitle: "Teacher" }],
+  ["strong-nurse", "During discharge teaching, several patients called back because the medication instructions were hard to follow. I reviewed the common questions, reorganized the teaching checklist, used teach-back before discharge, and documented the clarified steps. As a result, follow-up questions decreased by 15 percent and patients left with a clearer medication plan.", { question: "Tell me about a patient education process you improved.", competency: "customer_focus", roleTitle: "Registered Nurse" }],
+  ["strong-sales", "During quarterly pipeline review, duplicate opportunities were inflating the forecast and confusing account ownership. I analyzed the CRM records, defined a duplicate rule with sales leadership, merged the affected records, and documented the cleanup workflow. As a result, duplicate opportunities dropped by 28 percent and the next forecast review used a cleaner pipeline.", { question: "Tell me about an operations problem you solved with CRM data.", competency: "problem_solving", roleTitle: "Sales Operations Analyst" }],
+  ["strong-accounting", "During month-end close, reconciliation exceptions were repeatedly caused by inconsistent transaction coding. I reviewed the exception history, isolated the common coding pattern, updated the reconciliation checklist, and validated the change against the next close. As a result, reconciliation exceptions decreased by 22 percent and the team completed review with fewer manual corrections.", { question: "Tell me about an accounting process problem you improved.", competency: "problem_solving", roleTitle: "Accountant" }],
+  ["strong-leadership", "During a high-risk migration, the team disagreed about whether to cut over on the original date. I reviewed the remaining defects, prioritized the customer-impacting risks, proposed a staged migration, and coordinated owners for each checkpoint. As a result, we completed the migration without a customer outage and reduced the unresolved launch risks from 12 to 3 before final cutover.", { question: "Tell me about a difficult leadership decision you owned.", competency: "leadership", roleTitle: "Engineering Lead" }],
+];
 
 export function runAishaReleaseEvaluation() {
-  const cases = [
-    answerCase("vague-all-red", "I was involved with the team and things were fine.", {
-      question: "Tell me about a complex problem you solved with incomplete information.", competency: "problem_solving",
-    }),
-    answerCase("ownership-no-credit", "I was on the project and I was part of the team.", {
-      question: "Tell me what you personally owned during a difficult project.", competency: "ownership",
-    }),
-    answerCase("short-answer-low-score", "I fixed it.", {
-      question: "Tell me about a production incident and how you resolved it.", competency: "problem_solving",
-    }),
-    answerCase("team-credit-only", "The team analyzed the incident, changed the configuration, and restored the service. Everyone worked together and the customer was satisfied afterward.", {
-      question: "What did you personally do during the incident?", competency: "ownership",
-    }),
-    answerCase("context-no-action", "During a production outage, the customer portal was unavailable and the team was under pressure because several customers were waiting for access.", {
-      question: "Tell me about a production problem you personally solved.", competency: "problem_solving",
-    }),
-    answerCase("action-no-result", "During a customer issue, I diagnosed the API logs, reproduced the timeout, tested the connection settings, and updated the configuration after verifying the failing path with the support team.", {
-      question: "Tell me about a customer issue you solved and the result.", competency: "problem_solving",
-    }),
-    answerCase("result-no-action", "The incident was resolved, customer wait time decreased by 20 percent, and service was restored for the affected accounts after the team completed the work.", {
-      question: "What did you personally do to resolve the outage?", competency: "ownership",
-    }),
-    answerCase("off-topic", "Last weekend I cooked dinner for friends, tried a new pasta recipe, watched a movie, and organized my game collection before going to sleep.", {
-      question: "Tell me about a production incident you diagnosed.", competency: "problem_solving",
-    }),
-    answerCase("filler-heavy", "Um, I mean, basically, you know, sort of, kind of, during the incident I diagnosed the container logs, isolated the failing setting, tested the fix, and implemented it. As a result, the service recovered and the customer could use the portal again without the repeated error.", {
-      question: "Tell me about a technical incident you solved.", competency: "problem_solving",
-    }),
-    answerCase("profanity-coaching", "During the outage I diagnosed the damn container issue, isolated the broken memory setting, tested a safer limit, and implemented the fix. As a result, the service stabilized and the customer portal recovered without another failure that shift.", {
-      question: "Tell me about a difficult technical problem you solved.", competency: "problem_solving",
-    }),
-    answerCase("truthful-impact-no-metric", truthfulImpactAnswer, {
-      question: "Tell me about a customer problem you improved.", competency: "customer_focus",
-    }),
-    answerCase("quantified-but-thin", "I fixed the outage and reduced downtime by 20 percent.", {
-      question: "Tell me about a production incident you resolved.", competency: "problem_solving",
-    }),
-    answerCase("concise-complete", "During a release failure, I diagnosed the deployment logs, isolated a bad environment setting, tested the corrected value, and updated the service configuration. As a result, the next deployment completed successfully and the team restored the release pipeline.", strongOptions),
-    answerCase("customer-handoff-no-number", truthfulImpactAnswer, {
-      question: "Describe a time you improved a customer handoff.", competency: "customer_focus",
-    }),
-    answerCase("learning-example", "When I had to support an unfamiliar monitoring tool during an incident, I reviewed the runbook, reproduced the alert in a test environment, compared the healthy and failing signals, and documented what I learned. As a result, I resolved the alert and the next engineer had a clear troubleshooting path.", {
-      question: "Tell me about a time you had to learn something quickly to solve a problem.", competency: "learning",
-    }),
-    answerCase("entry-project", "During a class software project, I owned the API integration. I reviewed the documentation, built the request flow, tested failure cases, and fixed the validation errors with my teammate. As a result, our final demo completed the full workflow reliably and we submitted the project on time.", {
-      question: "Tell me about a project that shows how you learn and contribute.", competency: "learning",
-      roleTitle: "Junior Software Engineer",
-    }),
-    answerCase("strong-star", strongStarAnswer, strongOptions),
-    answerCase("strong-platform", "During a Kubernetes deployment incident, several pods restarted whenever traffic increased. I inspected the pod events and container metrics, traced the restarts to an incorrect memory limit, tested a safer resource range in staging, and deployed the corrected configuration. As a result, the service stayed stable through the next traffic spike and deployment-related support tickets fell by 35 percent that month.", {
-      question: "Tell me about a platform reliability problem you solved.", competency: "problem_solving", roleTitle: "Platform Engineer",
-    }),
-    answerCase("strong-support", "During a repeated customer escalation, I reviewed the ticket history, reproduced the Docker networking failure, compared the customer's compose configuration with a working baseline, and documented the exact correction. As a result, the customer restored service that day and repeat escalations for the same setup dropped by 25 percent over the next month.", {
-      question: "Tell me about a difficult customer support problem you solved.", competency: "customer_focus", roleTitle: "Technical Support Engineer",
-    }),
-    answerCase("strong-data", "During weekly reporting, analysts were spending hours reconciling duplicate rows before publishing the dashboard. I analyzed the SQL joins, identified the many-to-many source causing duplication, rewrote the query, and validated totals against the source system. As a result, reporting preparation dropped by 40 percent and the team stopped correcting duplicate metrics after publication.", {
-      question: "Tell me about a data quality problem you solved.", competency: "problem_solving", roleTitle: "Data Analyst",
-    }),
-    answerCase("strong-project", "During a cross-team launch, two critical handoffs repeatedly slipped because ownership changed between meetings. I mapped the dependencies, assigned one accountable owner to each handoff, introduced a risk review, and tracked decisions in the launch plan. As a result, the final three milestones were delivered on schedule and missed handoffs fell by 30 percent.", {
-      question: "Tell me about a project delivery risk you personally improved.", competency: "ownership", roleTitle: "Project Manager",
-    }),
-    answerCase("strong-security", "During an alert investigation, I correlated authentication logs with endpoint telemetry, isolated a compromised token pattern, disabled the affected credential, and added a detection rule for the same behavior. As a result, the suspicious access stopped, the investigation closed without additional affected accounts, and similar alerts were triaged 30 percent faster afterward.", {
-      question: "Tell me about a security incident you investigated and resolved.", competency: "problem_solving", roleTitle: "Security Analyst",
-    }),
-    answerCase("strong-ux", "During usability testing, several keyboard-only users could not complete the account setup flow. I reviewed the focus order, reproduced the trap, redesigned the interaction states, and validated the update with accessibility checks. As a result, every participant in the next test completed the flow and accessibility rework dropped by 20 percent in the following release.", {
-      question: "Tell me about a user experience problem you found and fixed.", competency: "problem_solving", roleTitle: "UX Designer",
-    }),
-    answerCase("strong-teacher", "During a unit on fractions, several students were completing practice work but still missing the same concept on assessments. I reviewed the error patterns, changed the lesson sequence, added small-group practice, and checked understanding before moving on. As a result, assignment completion increased by 18 percent and more students demonstrated the target skill on the next assessment.", {
-      question: "Tell me about a teaching problem you identified and improved.", competency: "problem_solving", roleTitle: "Teacher",
-    }),
-    answerCase("strong-nurse", "During discharge teaching, several patients called back because the medication instructions were hard to follow. I reviewed the common questions, reorganized the teaching checklist, used teach-back before discharge, and documented the clarified steps. As a result, follow-up questions decreased by 15 percent and patients left with a clearer medication plan.", {
-      question: "Tell me about a patient education process you improved.", competency: "customer_focus", roleTitle: "Registered Nurse",
-    }),
-    answerCase("strong-sales", "During quarterly pipeline review, duplicate opportunities were inflating the forecast and confusing account ownership. I analyzed the CRM records, defined a duplicate rule with sales leadership, merged the affected records, and documented the cleanup workflow. As a result, duplicate opportunities dropped by 28 percent and the next forecast review used a cleaner pipeline.", {
-      question: "Tell me about an operations problem you solved with CRM data.", competency: "problem_solving", roleTitle: "Sales Operations Analyst",
-    }),
-    answerCase("strong-accounting", "During month-end close, reconciliation exceptions were repeatedly caused by inconsistent transaction coding. I reviewed the exception history, isolated the common coding pattern, updated the reconciliation checklist, and validated the change against the next close. As a result, reconciliation exceptions decreased by 22 percent and the team completed review with fewer manual corrections.", {
-      question: "Tell me about an accounting process problem you improved.", competency: "problem_solving", roleTitle: "Accountant",
-    }),
-    answerCase("strong-leadership", "During a high-risk migration, the team disagreed about whether to cut over on the original date. I reviewed the remaining defects, prioritized the customer-impacting risks, proposed a staged migration, and coordinated owners for each checkpoint. As a result, we completed the migration without a customer outage and reduced the unresolved launch risks from 12 to 3 before final cutover.", {
-      question: "Tell me about a difficult leadership decision you owned.", competency: "leadership", roleTitle: "Engineering Lead",
-    }),
-  ];
+  const cases = ANSWER_CASES.map(([caseId, answer, options]) => answerCase(caseId, answer, options));
 
   const weakResponses = [
-    response("We handled it and everything was fine.", strongOptions),
-    response("I was involved with the project but I do not remember the details.", strongOptions),
-    response("The team got it done.", strongOptions),
+    response("We handled it and everything was fine.", STRONG_OPTIONS),
+    response("I was involved with the project but I do not remember the details.", STRONG_OPTIONS),
+    response("The team got it done.", STRONG_OPTIONS),
   ];
   const strongResponses = [
-    response(strongStarAnswer, strongOptions),
-    response("During a customer outage, I reviewed the request traces, isolated a failing dependency, tested the recovery path, and implemented the corrected configuration. As a result, the service recovered, repeat errors stopped, and customer escalations dropped by 25 percent during the next month.", strongOptions),
-    response("During a deployment regression, I compared the healthy and failing builds, traced the difference to an environment variable, corrected the release configuration, and verified the change in staging. As a result, the production deployment completed successfully and the team avoided another rollback that week.", strongOptions),
+    response(STRONG_STAR, STRONG_OPTIONS),
+    response("During a customer outage, I reviewed the request traces, isolated a failing dependency, tested the recovery path, and implemented the corrected configuration. As a result, the service recovered, repeat errors stopped, and customer escalations dropped by 25 percent during the next month.", STRONG_OPTIONS),
+    response("During a deployment regression, I compared the healthy and failing builds, traced the difference to an environment variable, corrected the release configuration, and verified the change in staging. As a result, the production deployment completed successfully and the team avoided another rollback that week.", STRONG_OPTIONS),
   ];
   const mixedResponses = [strongResponses[0], strongResponses[1], weakResponses[0], weakResponses[1]];
   const noMetricResponses = [
-    response(truthfulImpactAnswer, { question: "Tell me about a customer problem you improved.", competency: "customer_focus" }),
-    response("During a deployment issue, I reviewed the logs, isolated the configuration mismatch, tested the corrected value, and updated the service. As a result, the deployment completed successfully and the team had a documented recovery path for the next release.", strongOptions),
+    response(TRUTHFUL_IMPACT, { question: "Tell me about a customer problem you improved.", competency: "customer_focus" }),
+    response("During a deployment issue, I reviewed the logs, isolated the configuration mismatch, tested the corrected value, and updated the service. As a result, the deployment completed successfully and the team had a documented recovery path for the next release.", STRONG_OPTIONS),
     response("During a support handoff, I reviewed the case history, clarified the owner, updated the checklist, and communicated the next steps. As a result, the customer received one clear point of contact and the case moved forward without another ownership gap.", { question: "Tell me about a customer handoff you improved.", competency: "customer_focus" }),
   ];
 
@@ -162,6 +108,5 @@ export function runAishaReleaseEvaluation() {
     { case_id: "mixed-session-summary", metrics: sessionMetrics(mixedResponses) },
     { case_id: "no-metric-session-summary", metrics: sessionMetrics(noMetricResponses) },
   );
-
   return cases;
 }

--- a/frontend/src/interviewEngine.releaseEvaluation.test.js
+++ b/frontend/src/interviewEngine.releaseEvaluation.test.js
@@ -3,53 +3,182 @@ import assert from "node:assert/strict";
 
 import { AISHA_RELEASE_SUITE_VERSION, runAishaReleaseEvaluation } from "./aiVerificationReleaseEvaluation.js";
 
-test("Aisha release calibration emits the complete privacy-safe suite", () => {
+const EXPECTED_CASE_IDS = [
+  "action-no-result",
+  "concise-complete",
+  "context-no-action",
+  "customer-handoff-no-number",
+  "entry-project",
+  "filler-heavy",
+  "learning-example",
+  "mixed-session-summary",
+  "no-metric-session-summary",
+  "off-topic",
+  "ownership-no-credit",
+  "profanity-coaching",
+  "quantified-but-thin",
+  "result-no-action",
+  "short-answer-low-score",
+  "strong-accounting",
+  "strong-data",
+  "strong-leadership",
+  "strong-nurse",
+  "strong-platform",
+  "strong-project",
+  "strong-sales",
+  "strong-security",
+  "strong-session-summary",
+  "strong-star",
+  "strong-support",
+  "strong-teacher",
+  "strong-ux",
+  "team-credit-only",
+  "truthful-impact-no-metric",
+  "vague-all-red",
+  "weak-session-summary",
+].sort();
+
+const STRONG_ROLE_CASES = [
+  "strong-platform",
+  "strong-support",
+  "strong-data",
+  "strong-project",
+  "strong-security",
+  "strong-ux",
+  "strong-teacher",
+  "strong-nurse",
+  "strong-sales",
+  "strong-accounting",
+  "strong-leadership",
+];
+
+test("Aisha release calibration emits 32 unique privacy-safe cases", () => {
   const cases = runAishaReleaseEvaluation();
-  assert.equal(AISHA_RELEASE_SUITE_VERSION, "aisha-calibration-v1");
-  assert.deepEqual(
-    cases.map((item) => item.case_id).sort(),
-    [
-      "ownership-no-credit",
-      "short-answer-low-score",
-      "strong-star",
-      "truthful-impact-no-metric",
-      "vague-all-red",
-      "weak-session-summary",
-    ],
-  );
+  assert.equal(AISHA_RELEASE_SUITE_VERSION, "aisha-calibration-v2-32");
+  assert.equal(cases.length, 32);
+  assert.deepEqual(cases.map((item) => item.case_id).sort(), EXPECTED_CASE_IDS);
+  assert.equal(new Set(cases.map((item) => item.case_id)).size, 32);
 
   for (const item of cases) {
     assert.ok(item.metrics && typeof item.metrics === "object");
     assert.equal("answer" in item.metrics, false);
     assert.equal("question" in item.metrics, false);
+    assert.equal("job_description" in item.metrics, false);
+    assert.equal(JSON.stringify(item.metrics).includes("customer portal repeatedly failed"), false);
   }
 });
 
-test("Aisha release calibration remains inside the expected score envelopes", () => {
+test("Aisha keeps weak and incomplete answers below strong-answer scoring", () => {
   const cases = Object.fromEntries(runAishaReleaseEvaluation().map((item) => [item.case_id, item.metrics]));
 
-  assert.ok(cases["vague-all-red"].overall_score < 55);
-  assert.equal(Object.values(cases["vague-all-red"].dimensions).every((score) => score < 55), true);
+  assert.ok(cases["vague-all-red"].overall_score <= 54);
+  assert.equal(Object.values(cases["vague-all-red"].dimensions).every((score) => score <= 54), true);
 
   assert.ok(cases["ownership-no-credit"].dimensions.ownership <= 20);
   assert.equal(cases["ownership-no-credit"].action_found, false);
 
   assert.ok(cases["short-answer-low-score"].overall_score <= 25);
+  assert.ok(cases["short-answer-low-score"].word_count <= 4);
 
-  const strong = cases["strong-star"];
-  assert.ok(strong.overall_score >= 65);
-  assert.ok(Object.values(strong.dimensions).filter((score) => score >= 70).length >= 4);
-  assert.equal(strong.action_found, true);
-  assert.equal(strong.result_found, true);
+  assert.ok(cases["team-credit-only"].overall_score <= 45);
+  assert.ok(cases["team-credit-only"].dimensions.ownership <= 20);
+  assert.equal(cases["team-credit-only"].action_found, false);
 
-  const truthfulImpact = cases["truthful-impact-no-metric"];
-  assert.ok(truthfulImpact.dimensions.impact >= 70);
-  assert.equal(truthfulImpact.quantified, false);
-  assert.equal(truthfulImpact.result_found, true);
+  assert.equal(cases["context-no-action"].action_found, false);
+  assert.equal(cases["context-no-action"].result_found, false);
+  assert.ok(cases["context-no-action"].overall_score <= 45);
 
-  const weakSummary = cases["weak-session-summary"];
-  assert.ok(weakSummary.overall_score < 55);
-  assert.equal(weakSummary.has_strong_areas, false);
-  assert.equal(weakSummary.strongest_area_count, 0);
-  assert.equal(weakSummary.improvement_area_count, 6);
+  assert.equal(cases["action-no-result"].action_found, true);
+  assert.equal(cases["action-no-result"].result_found, false);
+  assert.ok(cases["action-no-result"].dimensions.impact <= 5);
+
+  assert.equal(cases["result-no-action"].action_found, false);
+  assert.equal(cases["result-no-action"].result_found, true);
+  assert.ok(cases["result-no-action"].overall_score <= 60);
+
+  assert.ok(cases["off-topic"].dimensions.relevance <= 54);
+  assert.ok(cases["off-topic"].overall_score <= 60);
+});
+
+test("Aisha detects filler load and coaches profanity without hard-failing", () => {
+  const cases = Object.fromEntries(runAishaReleaseEvaluation().map((item) => [item.case_id, item.metrics]));
+
+  assert.ok(cases["filler-heavy"].filler_count >= 6);
+  assert.ok(cases["filler-heavy"].dimensions.communication <= 70);
+  assert.equal(cases["filler-heavy"].action_found, true);
+  assert.equal(cases["filler-heavy"].result_found, true);
+
+  assert.equal(cases["profanity-coaching"].warning_triggered, true);
+  assert.ok(cases["profanity-coaching"].dimensions.communication <= 70);
+});
+
+test("Aisha distinguishes truthful non-numeric impact from thin quantified answers", () => {
+  const cases = Object.fromEntries(runAishaReleaseEvaluation().map((item) => [item.case_id, item.metrics]));
+
+  const truthful = cases["truthful-impact-no-metric"];
+  assert.ok(truthful.dimensions.impact >= 70);
+  assert.equal(truthful.quantified, false);
+  assert.equal(truthful.result_found, true);
+
+  const thin = cases["quantified-but-thin"];
+  assert.equal(thin.quantified, true);
+  assert.equal(thin.action_found, true);
+  assert.equal(thin.result_found, true);
+  assert.ok(thin.overall_score <= 25);
+
+  assert.ok(cases["customer-handoff-no-number"].overall_score >= 55);
+  assert.ok(cases["customer-handoff-no-number"].dimensions.impact >= 70);
+  assert.equal(cases["customer-handoff-no-number"].quantified, false);
+});
+
+test("Aisha rewards complete evidence across multiple career families", () => {
+  const cases = Object.fromEntries(runAishaReleaseEvaluation().map((item) => [item.case_id, item.metrics]));
+
+  assert.ok(cases["concise-complete"].overall_score >= 55);
+  assert.equal(cases["concise-complete"].action_found, true);
+  assert.equal(cases["concise-complete"].result_found, true);
+
+  assert.ok(cases["learning-example"].overall_score >= 55);
+  assert.ok(cases["entry-project"].overall_score >= 55);
+
+  const star = cases["strong-star"];
+  assert.ok(star.overall_score >= 65);
+  assert.ok(Object.values(star.dimensions).filter((score) => score >= 70).length >= 4);
+  assert.equal(star.action_found, true);
+  assert.equal(star.result_found, true);
+
+  for (const caseId of STRONG_ROLE_CASES) {
+    const metrics = cases[caseId];
+    assert.ok(metrics.overall_score >= 55, `${caseId} should clear the complete-answer floor`);
+    assert.ok(metrics.dimensions.impact >= 70, `${caseId} should receive impact credit`);
+    assert.equal(metrics.action_found, true, `${caseId} should detect personal action`);
+    assert.equal(metrics.result_found, true, `${caseId} should detect an outcome`);
+  }
+});
+
+test("Aisha session summaries stay calibrated for weak, strong, mixed, and non-numeric sessions", () => {
+  const cases = Object.fromEntries(runAishaReleaseEvaluation().map((item) => [item.case_id, item.metrics]));
+
+  const weak = cases["weak-session-summary"];
+  assert.ok(weak.overall_score <= 54);
+  assert.equal(weak.has_strong_areas, false);
+  assert.equal(weak.strongest_area_count, 0);
+  assert.equal(weak.improvement_area_count, 6);
+  assert.ok(weak.weak_answer_count >= 3);
+
+  const strong = cases["strong-session-summary"];
+  assert.ok(strong.overall_score >= 60);
+  assert.equal(strong.has_strong_areas, true);
+  assert.ok(strong.strongest_area_count >= 1);
+  assert.equal(strong.improvement_area_count, 2);
+  assert.equal(strong.weak_answer_count, 0);
+
+  const mixed = cases["mixed-session-summary"];
+  assert.ok(mixed.overall_score >= 35 && mixed.overall_score <= 75);
+  assert.ok(mixed.weak_answer_count >= 1);
+
+  const noMetric = cases["no-metric-session-summary"];
+  assert.ok(noMetric.overall_score >= 55);
+  assert.equal(noMetric.quantified_answer_count, 0);
+  assert.ok(noMetric.result_answer_count >= 3);
 });


### PR DESCRIPTION
## What this changes
- expands Aisha browser calibration from 6 to 32 privacy-safe cases
- adds weak, incomplete, off-topic, filler-heavy, profanity-coaching, quantified-thin, strong STAR, cross-career, and session-summary scenarios
- expands Compliance Intelligence from 5 to 32 deterministic fixtures
- validates all 14 compliance controls, expected statuses, blockers, paid-launch posture, beta posture, and fundraising posture
- keeps release-evaluation samples revision-scoped and idempotent
- raises the Aisha batch limit so the full suite can be recorded

## Test intent
These are not filler rows. Aisha cases execute the real interview engine in frontend CI. Compliance fixtures execute the real deterministic control engine in backend CI. The server independently validates Aisha's sanitized metrics before recording them.