### PR TITLE
Use a generic sign-up name placeholder

### DIFF
--- a/frontend/src/AuthPage.jsx
+++ b/frontend/src/AuthPage.jsx
@@ -306,7 +306,7 @@ function AuthPage({ mode = "login", onLogin }) {
             </div>
           )}
 
-          {isRegister && <label className="auth-field">Name<div><UserPlus size={17} /><input name="name" value={formData.name} onChange={handleChange} placeholder="Tee" required /></div></label>}
+          {isRegister && <label className="auth-field">Name<div><UserPlus size={17} /><input name="name" value={formData.name} onChange={handleChange} placeholder="Jordan Lee" required /></div></label>}
           <label className="auth-field">Email<div><Mail size={17} /><input type="email" name="email" value={formData.email} onChange={handleChange} placeholder="you@example.com" required /></div></label>
           <label className="auth-field">Password<div><Lock size={17} /><input type="password" name="password" value={formData.password} onChange={handleChange} placeholder="••••••••" minLength={8} required /></div></label>
 


### PR DESCRIPTION
## What changed
- Replaced the personalized `Tee` placeholder on the registration form with the generic example name `Jordan Lee`.
- No account behavior or validation changed; this is UI copy only.

This addresses the sign-up screen shown on iPad where the name field exposed a personal placeholder.