### PR TITLE
Restore Google and GitHub sign-up with legal consent

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -111,30 +111,38 @@ jobs:
         run: npm run build
 
   dependency-audit:
-    # Preserve the protected-branch context. This expensive job runs only when
-    # dependency manifests or CI workflow definitions changed.
+    # This context is required by the protected branch, so keep the job itself
+    # merge-safe on every PR. Expensive dependency audits only run when dependency
+    # manifests or CI workflow definitions changed.
     name: Dependency vulnerability audit
     needs: changes
-    if: needs.changes.outputs.dependencies == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      - name: No dependency changes
+        if: needs.changes.outputs.dependencies != 'true'
+        run: echo "No dependency manifests changed; required audit context satisfied."
       - uses: actions/checkout@v4
+        if: needs.changes.outputs.dependencies == 'true'
       - uses: actions/setup-python@v5
+        if: needs.changes.outputs.dependencies == 'true'
         with:
           python-version: "3.12"
           cache: pip
           cache-dependency-path: backend/requirements.txt
       - name: Audit Python dependencies
+        if: needs.changes.outputs.dependencies == 'true'
         run: |
           python -m pip install pip-audit
           pip-audit -r backend/requirements.txt --ignore-vuln PYSEC-2026-1325
       - uses: actions/setup-node@v4
+        if: needs.changes.outputs.dependencies == 'true'
         with:
           node-version: 22
           cache: npm
           cache-dependency-path: frontend/package-lock.json
       - name: Audit frontend dependencies
+        if: needs.changes.outputs.dependencies == 'true'
         working-directory: frontend
         run: |
           npm ci

--- a/backend/app/oauth_routes.py
+++ b/backend/app/oauth_routes.py
@@ -10,6 +10,7 @@ from fastapi import APIRouter, HTTPException, Request, status
 from fastapi.responses import RedirectResponse
 
 from app.auth import create_access_token
+from app.auth_routes import PRIVACY_VERSION, TERMS_VERSION
 from app.database import users_collection
 
 router = APIRouter(prefix="/auth", tags=["auth"])
@@ -82,12 +83,15 @@ def _find_or_create_oauth_user(
     provider_user_id: str,
     email: str,
     name: str,
+    *,
+    accepted_terms: bool = False,
+    accepted_privacy: bool = False,
 ) -> dict:
-    """Link OAuth identity without replacing user-authored profile fields.
+    """Link an OAuth identity or create a consented OAuth account.
 
-    New OAuth account creation is temporarily disabled so every new BragStack
-    account passes through the explicit legal-acceptance registration flow.
-    Existing OAuth users continue to sign in normally.
+    Existing users can always sign in or link their provider. A brand-new OAuth
+    account is created only when the exact OAuth attempt started after the user
+    accepted the current Terms and Privacy Policy on the registration page.
     """
     normalized_email = email.lower().strip()
     provider_field = f"oauth.{provider}_id"
@@ -128,13 +132,45 @@ def _find_or_create_oauth_user(
         )
         return users_collection.find_one({"_id": user["_id"]})
 
-    raise HTTPException(
-        status_code=status.HTTP_403_FORBIDDEN,
-        detail=(
-            "New Google/GitHub account creation is temporarily unavailable. "
-            "Create your BragStack account with email/password first so the current Terms and Privacy Policy acceptance can be recorded."
-        ),
-    )
+    if not accepted_terms or not accepted_privacy:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=(
+                "To create a new BragStack account with Google or GitHub, start from Create Account "
+                "and accept the current Terms and Privacy Policy first."
+            ),
+        )
+
+    accepted_at = datetime.now(timezone.utc).isoformat()
+    display_name = name.strip() or normalized_email.split("@", 1)[0] or "User"
+    doc = {
+        "name": display_name,
+        "email": normalized_email,
+        "public_slug": _generate_unique_public_slug(display_name),
+        "oauth": {f"{provider}_id": provider_user_id},
+        "email_verified_at": verified_at,
+        "email_verification_required": False,
+        "created_at": accepted_at,
+        "terms_accepted_at": accepted_at,
+        "terms_version": TERMS_VERSION,
+        "privacy_accepted_at": accepted_at,
+        "privacy_version": PRIVACY_VERSION,
+        "legal_acceptance_source": f"{provider}-oauth-registration",
+        "consents": {
+            "terms": {
+                "accepted": True,
+                "version": TERMS_VERSION,
+                "accepted_at": accepted_at,
+            },
+            "privacy_policy": {
+                "accepted": True,
+                "version": PRIVACY_VERSION,
+                "accepted_at": accepted_at,
+            },
+        },
+    }
+    result = users_collection.insert_one(doc)
+    return users_collection.find_one({"_id": result.inserted_id})
 
 
 def _frontend_success_redirect(user: dict) -> RedirectResponse:
@@ -156,6 +192,35 @@ def _set_state_cookie(response: RedirectResponse, provider: str, state_value: st
     )
 
 
+def _set_registration_consent_cookie(
+    response: RedirectResponse,
+    provider: str,
+    state_value: str,
+    accepted_terms: bool,
+    accepted_privacy: bool,
+) -> None:
+    """Bind registration consent to this exact OAuth state value."""
+    if not accepted_terms or not accepted_privacy:
+        return
+    response.set_cookie(
+        key=f"oauth_registration_consent_{provider}",
+        value=state_value,
+        max_age=600,
+        httponly=True,
+        secure=True,
+        samesite="lax",
+    )
+
+
+def _registration_consent_matches(request: Request, provider: str, state_value: str | None) -> bool:
+    consent_state = request.cookies.get(f"oauth_registration_consent_{provider}")
+    return bool(
+        consent_state
+        and state_value
+        and secrets.compare_digest(consent_state, state_value)
+    )
+
+
 def _validate_state(request: Request, provider: str, state_value: str | None) -> None:
     expected = request.cookies.get(f"oauth_state_{provider}")
     if not expected or not state_value or not secrets.compare_digest(expected, state_value):
@@ -166,7 +231,11 @@ def _validate_state(request: Request, provider: str, state_value: str | None) ->
 
 
 @router.get("/google/login", name="google_login")
-def google_login(request: Request):
+def google_login(
+    request: Request,
+    accepted_terms: bool = False,
+    accepted_privacy: bool = False,
+):
     _require_credentials("google")
     state_value = secrets.token_urlsafe(32)
     params = {
@@ -179,6 +248,13 @@ def google_login(request: Request):
     }
     response = RedirectResponse(f"{GOOGLE_AUTHORIZE_URL}?{_authorization_query(params)}")
     _set_state_cookie(response, "google", state_value)
+    _set_registration_consent_cookie(
+        response,
+        "google",
+        state_value,
+        accepted_terms,
+        accepted_privacy,
+    )
     return response
 
 
@@ -186,6 +262,7 @@ def google_login(request: Request):
 async def google_callback(request: Request, code: str, state: str | None = None):
     _require_credentials("google")
     _validate_state(request, "google", state)
+    registration_consented = _registration_consent_matches(request, "google", state)
 
     async with httpx.AsyncClient(timeout=15.0) as client:
         token_response = await client.post(
@@ -218,14 +295,21 @@ async def google_callback(request: Request, code: str, state: str | None = None)
         str(profile.get("sub")),
         profile["email"],
         profile.get("name") or "",
+        accepted_terms=registration_consented,
+        accepted_privacy=registration_consented,
     )
     response = _frontend_success_redirect(user)
     response.delete_cookie("oauth_state_google")
+    response.delete_cookie("oauth_registration_consent_google")
     return response
 
 
 @router.get("/github/login", name="github_login")
-def github_login(request: Request):
+def github_login(
+    request: Request,
+    accepted_terms: bool = False,
+    accepted_privacy: bool = False,
+):
     _require_credentials("github")
     state_value = secrets.token_urlsafe(32)
     params = {
@@ -236,6 +320,13 @@ def github_login(request: Request):
     }
     response = RedirectResponse(f"{GITHUB_AUTHORIZE_URL}?{_authorization_query(params)}")
     _set_state_cookie(response, "github", state_value)
+    _set_registration_consent_cookie(
+        response,
+        "github",
+        state_value,
+        accepted_terms,
+        accepted_privacy,
+    )
     return response
 
 
@@ -243,6 +334,7 @@ def github_login(request: Request):
 async def github_callback(request: Request, code: str, state: str | None = None):
     _require_credentials("github")
     _validate_state(request, "github", state)
+    registration_consented = _registration_consent_matches(request, "github", state)
 
     headers = {"Accept": "application/json", "User-Agent": "BragStack"}
     async with httpx.AsyncClient(timeout=15.0, headers=headers) as client:
@@ -280,7 +372,10 @@ async def github_callback(request: Request, code: str, state: str | None = None)
         str(profile.get("id")),
         selected_email["email"],
         profile.get("name") or profile.get("login") or "",
+        accepted_terms=registration_consented,
+        accepted_privacy=registration_consented,
     )
     response = _frontend_success_redirect(user)
     response.delete_cookie("oauth_state_github")
+    response.delete_cookie("oauth_registration_consent_github")
     return response

--- a/backend/tests/test_oauth_routes.py
+++ b/backend/tests/test_oauth_routes.py
@@ -10,6 +10,7 @@ def _request(
     scheme: str = "http",
     forwarded_proto: str = "",
     forwarded_host: str = "",
+    cookie: str = "",
 ) -> Request:
     """Build a minimal Starlette request for OAuth redirect tests."""
     headers = [(b"host", host.encode())]
@@ -17,6 +18,8 @@ def _request(
         headers.append((b"x-forwarded-proto", forwarded_proto.encode()))
     if forwarded_host:
         headers.append((b"x-forwarded-host", forwarded_host.encode()))
+    if cookie:
+        headers.append((b"cookie", cookie.encode()))
     scope = {
         "type": "http",
         "method": "GET",
@@ -65,3 +68,10 @@ def test_redirect_uri_honors_reverse_proxy_public_origin(monkeypatch):
 
     assert oauth_routes._redirect_uri(request, "google") == "https://api.usebragstack.com/auth/google/callback"
     assert oauth_routes._redirect_uri(request, "github") == "https://api.usebragstack.com/auth/github/callback"
+
+
+def test_registration_consent_is_bound_to_oauth_state():
+    request = _request(cookie="oauth_registration_consent_google=expected-state")
+
+    assert oauth_routes._registration_consent_matches(request, "google", "expected-state") is True
+    assert oauth_routes._registration_consent_matches(request, "google", "different-state") is False

--- a/backend/tests/test_uat_profile_oauth_persistence.py
+++ b/backend/tests/test_uat_profile_oauth_persistence.py
@@ -1,7 +1,9 @@
 """UAT regressions for OAuth, profile persistence, photos, and Open to Talk."""
 
 import mongomock
+import pytest
 from bson import ObjectId
+from fastapi import HTTPException
 
 import app.auth_routes as auth_routes
 import app.oauth_routes as oauth_routes
@@ -57,6 +59,41 @@ def test_oauth_link_preserves_user_authored_profile(monkeypatch):
     assert linked["profile_primary_color"] == original["profile_primary_color"]
     assert linked["name"] == "Tee"
     assert linked["oauth"]["google_id"] == "google-user-123"
+
+
+def test_new_oauth_account_requires_registration_legal_consent(monkeypatch):
+    _mock_users(monkeypatch)
+
+    with pytest.raises(HTTPException) as exc_info:
+        oauth_routes._find_or_create_oauth_user(
+            "google", "google-new-user", "new@example.com", "New User"
+        )
+
+    assert exc_info.value.status_code == 403
+    assert "accept the current Terms and Privacy Policy" in exc_info.value.detail
+
+
+def test_new_oauth_account_records_legal_consent(monkeypatch):
+    users = _mock_users(monkeypatch)
+
+    created = oauth_routes._find_or_create_oauth_user(
+        "github",
+        "github-new-user",
+        "new@example.com",
+        "New User",
+        accepted_terms=True,
+        accepted_privacy=True,
+    )
+
+    saved = users.find_one({"_id": created["_id"]})
+    assert saved["oauth"]["github_id"] == "github-new-user"
+    assert saved["email_verified_at"]
+    assert saved["email_verification_required"] is False
+    assert saved["terms_version"] == auth_routes.TERMS_VERSION
+    assert saved["privacy_version"] == auth_routes.PRIVACY_VERSION
+    assert saved["legal_acceptance_source"] == "github-oauth-registration"
+    assert saved["consents"]["terms"]["accepted"] is True
+    assert saved["consents"]["privacy_policy"]["accepted"] is True
 
 
 def test_partial_profile_patch_does_not_clear_omitted_fields(monkeypatch):

--- a/frontend/src/AuthPage.jsx
+++ b/frontend/src/AuthPage.jsx
@@ -205,8 +205,8 @@ function AuthPage({ mode = "login", onLogin }) {
   }
 
   async function startOAuth(provider) {
-    if (isRegister) {
-      setErrorMessage("For now, create new accounts with email/password so BragStack can record the required legal confirmations. Existing users can still use OAuth from Log in.");
+    if (isRegister && (!acceptedTerms || !acceptedPrivacy)) {
+      setErrorMessage("Please accept the Terms and Privacy Policy before continuing with Google or GitHub.");
       return;
     }
     setConnectingProvider(provider);
@@ -216,7 +216,8 @@ function AuthPage({ mode = "login", onLogin }) {
     try {
       const ready = await ensureApiReady();
       if (!ready) throw new Error("BragStack is taking longer than expected to start. Please try again.");
-      window.location.assign(`${apiBaseUrl}/auth/${provider}/login`);
+      const consentQuery = isRegister ? "?accepted_terms=true&accepted_privacy=true" : "";
+      window.location.assign(`${apiBaseUrl}/auth/${provider}/login${consentQuery}`);
     } catch (error) {
       setErrorMessage(error.message || `Could not connect to ${provider}. Please try again.`);
       setConnectingProvider("");
@@ -334,11 +335,29 @@ function AuthPage({ mode = "login", onLogin }) {
             </div>
           )}
 
-          {isRegister ? (
-            <div className="auth-oauth-temporary"><strong>Google & GitHub sign-up</strong><p>Temporarily paused for new accounts so every new user completes the required legal-consent step. Existing OAuth users can still sign in from the Log in page.</p></div>
-          ) : (
-            <><div className="auth-divider"><span>or continue with</span></div><div className="auth-oauth-grid"><button type="button" className="auth-oauth-button auth-oauth-google" onClick={() => startOAuth("google")} disabled={Boolean(connectingProvider)}><span className="auth-google-mark" aria-hidden="true">G</span><span>{connectingProvider === "google" ? "Connecting to Google..." : "Continue with Google"}</span></button><button type="button" className="auth-oauth-button auth-oauth-github" onClick={() => startOAuth("github")} disabled={Boolean(connectingProvider)}><GitHubMark /><span>{connectingProvider === "github" ? "Connecting to GitHub..." : "Continue with GitHub"}</span></button>{connectingProvider && oauthIsTakingLonger && <p className="auth-oauth-status" role="status">BragStack is waking up. We’ll continue automatically as soon as it’s ready.</p>}</div></>
-          )}
+          <div className="auth-divider"><span>{isRegister ? "or sign up with" : "or continue with"}</span></div>
+          <div className="auth-oauth-grid">
+            <button
+              type="button"
+              className="auth-oauth-button auth-oauth-google"
+              onClick={() => startOAuth("google")}
+              disabled={Boolean(connectingProvider) || (isRegister && (!acceptedTerms || !acceptedPrivacy))}
+            >
+              <span className="auth-google-mark" aria-hidden="true">G</span>
+              <span>{connectingProvider === "google" ? "Connecting to Google..." : "Continue with Google"}</span>
+            </button>
+            <button
+              type="button"
+              className="auth-oauth-button auth-oauth-github"
+              onClick={() => startOAuth("github")}
+              disabled={Boolean(connectingProvider) || (isRegister && (!acceptedTerms || !acceptedPrivacy))}
+            >
+              <GitHubMark />
+              <span>{connectingProvider === "github" ? "Connecting to GitHub..." : "Continue with GitHub"}</span>
+            </button>
+            {connectingProvider && oauthIsTakingLonger && <p className="auth-oauth-status" role="status">BragStack is waking up. We’ll continue automatically as soon as it’s ready.</p>}
+          </div>
+          {isRegister && !acceptedTerms && !acceptedPrivacy && <p className="auth-submit-status">Accept the Terms and Privacy Policy above to enable Google or GitHub sign-up.</p>}
 
           <p className="auth-switch">{isRegister ? "Already have an account?" : "New to BragStack?"} <a href={isRegister ? "/login" : "/register"}>{isRegister ? "Log in" : "Create one"}</a></p>
         </form>

--- a/frontend/src/legalRegistrationSource.test.js
+++ b/frontend/src/legalRegistrationSource.test.js
@@ -16,10 +16,13 @@ test("registration visibly requires legal acceptance without an age gate", () =>
   assert.match(source, /records the current policy versions/i);
 });
 
-test("new OAuth sign-up is paused while existing OAuth login remains", () => {
+test("new OAuth sign-up is available only after legal acceptance", () => {
   const source = read("./AuthPage.jsx");
-  assert.match(source, /Temporarily paused for new accounts/);
-  assert.match(source, /required legal-consent step/);
+  assert.doesNotMatch(source, /Temporarily paused for new accounts/);
+  assert.match(source, /accepted_terms=true/);
+  assert.match(source, /accepted_privacy=true/);
+  assert.match(source, /Please accept the Terms and Privacy Policy before continuing with Google or GitHub/);
+  assert.match(source, /or sign up with/);
   assert.match(source, /Continue with Google/);
   assert.match(source, /Continue with GitHub/);
 });


### PR DESCRIPTION
Restores Google and GitHub OAuth buttons on the registration page immediately while keeping the legal-consent protections in place.

Changes:
- Shows Google and GitHub OAuth buttons on Create Account again.
- Requires Terms + Privacy checkboxes before OAuth sign-up can start.
- Binds OAuth registration consent to the exact OAuth state via a short-lived HttpOnly cookie.
- Allows new OAuth accounts only when that consent is present; existing OAuth sign-in/linking continues normally.
- Records Terms/Privacy versions, timestamps, and legal acceptance source for new OAuth accounts.
- Updates frontend regression coverage and adds backend consent-account-creation tests.