### PR TITLE
Add five selectable ATS-friendly resume templates

### DIFF
--- a/frontend/src/ResumeBuilderGuidedPage.jsx
+++ b/frontend/src/ResumeBuilderGuidedPage.jsx
@@ -1,8 +1,49 @@
 import { useEffect, useRef, useState } from "react";
+import { CheckCircle2, ShieldCheck } from "lucide-react";
 import ResumeBuilderStructuredPage from "./ResumeBuilderStructuredPage.jsx";
 import "./ResumeBuilderGuidedPage.css";
+import "./ResumeTemplateGallery.css";
 
 const STEP_LABELS = ["Add resume", "Review & confirm", "Target job", "ATS results"];
+const TEMPLATE_STORAGE_KEY = "bragstack_resume_template_v1";
+const RESUME_TEMPLATES = [
+  {
+    id: "classic",
+    name: "Classic",
+    tag: "Traditional",
+    description: "Centered header, serif name, strong section rules.",
+  },
+  {
+    id: "modern",
+    name: "Modern",
+    tag: "Recommended",
+    description: "Clean left-aligned layout with a restrained navy accent.",
+  },
+  {
+    id: "executive",
+    name: "Executive",
+    tag: "Leadership",
+    description: "Polished typography and understated senior-level styling.",
+  },
+  {
+    id: "technical",
+    name: "Technical",
+    tag: "Engineering",
+    description: "Compact, scannable spacing for skills-heavy careers.",
+  },
+  {
+    id: "minimal",
+    name: "Minimal",
+    tag: "Clean",
+    description: "Lightweight styling with generous whitespace and simple rules.",
+  },
+];
+
+function getInitialTemplate() {
+  if (typeof window === "undefined") return "modern";
+  const stored = window.localStorage.getItem(TEMPLATE_STORAGE_KEY);
+  return RESUME_TEMPLATES.some((template) => template.id === stored) ? stored : "modern";
+}
 
 function focusElement(element) {
   if (!element) return;
@@ -38,6 +79,7 @@ function destinationForStep(host, step) {
 export default function ResumeBuilderGuidedPage() {
   const hostRef = useRef(null);
   const [activeStep, setActiveStep] = useState(1);
+  const [templateId, setTemplateId] = useState(getInitialTemplate);
   const pendingStepRef = useRef(null);
 
   useEffect(() => {
@@ -89,6 +131,17 @@ export default function ResumeBuilderGuidedPage() {
     };
   }, []);
 
+  useEffect(() => {
+    const host = hostRef.current;
+    if (!host) return;
+    host.dataset.resumeTemplate = templateId;
+    try {
+      window.localStorage.setItem(TEMPLATE_STORAGE_KEY, templateId);
+    } catch {
+      // Keep template selection usable even when storage is unavailable.
+    }
+  }, [templateId]);
+
   function goToStep(step) {
     const destination = destinationForStep(hostRef.current, step);
     if (destination) focusElement(destination);
@@ -118,6 +171,49 @@ export default function ResumeBuilderGuidedPage() {
           })}
         </div>
       </nav>
+
+      <section className="resume-template-gallery" aria-labelledby="resume-template-gallery-title">
+        <div className="resume-template-gallery-head">
+          <div>
+            <span className="resume-template-eyebrow">ATS-FRIENDLY TEMPLATES</span>
+            <h2 id="resume-template-gallery-title">Choose your resume style</h2>
+            <p>Five visual treatments, one safe reading order. The resume content stays single-column with standard headings, no tables, no text boxes, and the ATS text view stays unchanged.</p>
+          </div>
+          <div className="resume-template-ats-pill"><ShieldCheck size={16} /><span><strong>ATS-safe structure</strong><small>Style changes only</small></span></div>
+        </div>
+
+        <div className="resume-template-options">
+          {RESUME_TEMPLATES.map((template) => {
+            const selected = template.id === templateId;
+            return (
+              <button
+                type="button"
+                className={`resume-template-option ${selected ? "active" : ""}`}
+                key={template.id}
+                aria-pressed={selected}
+                onClick={() => setTemplateId(template.id)}
+              >
+                <span className={`resume-template-thumb thumb-${template.id}`} aria-hidden="true">
+                  <i className="resume-template-thumb-name" />
+                  <i className="resume-template-thumb-contact" />
+                  <i className="resume-template-thumb-heading" />
+                  <i className="resume-template-thumb-line wide" />
+                  <i className="resume-template-thumb-line" />
+                  <i className="resume-template-thumb-heading second" />
+                  <i className="resume-template-thumb-line wide" />
+                  <i className="resume-template-thumb-line short" />
+                </span>
+                <span className="resume-template-option-copy">
+                  <span className="resume-template-option-title"><strong>{template.name}</strong><em>{template.tag}</em></span>
+                  <span>{template.description}</span>
+                  <small className={selected ? "selected" : ""}>{selected ? <><CheckCircle2 size={13} /> Selected</> : "Select template"}</small>
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      </section>
+
       <ResumeBuilderStructuredPage />
     </div>
   );

--- a/frontend/src/ResumeTemplateGallery.css
+++ b/frontend/src/ResumeTemplateGallery.css
@@ -1,0 +1,138 @@
+.resume-template-gallery{
+  max-width:1680px;
+  margin:0 auto 18px;
+  padding:0 28px;
+  box-sizing:border-box;
+}
+
+.resume-template-gallery-head{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:20px;
+  margin-bottom:14px;
+}
+
+.resume-template-gallery-head>div:first-child{max-width:860px}
+.resume-template-eyebrow{display:block;margin-bottom:5px;color:#c4b5fd;font-size:.68rem;font-weight:950;letter-spacing:.13em}
+.resume-template-gallery h2{margin:0;color:#f8fafc;font-size:1.2rem;letter-spacing:-.02em}
+.resume-template-gallery p{margin:6px 0 0;color:#94a3b8;font-size:.82rem;line-height:1.5}
+.resume-template-ats-pill{display:flex;align-items:center;gap:9px;flex:0 0 auto;padding:10px 12px;border:1px solid rgba(52,211,153,.25);border-radius:13px;background:rgba(6,78,59,.22);color:#d1fae5}
+.resume-template-ats-pill svg{color:#6ee7b7}
+.resume-template-ats-pill span{display:flex;flex-direction:column;gap:2px}
+.resume-template-ats-pill strong{font-size:.76rem}
+.resume-template-ats-pill small{color:#a7f3d0;font-size:.66rem}
+
+.resume-template-options{display:grid;grid-template-columns:repeat(5,minmax(0,1fr));gap:10px}
+.resume-template-option{min-width:0;display:grid;grid-template-columns:74px minmax(0,1fr);gap:11px;align-items:center;padding:10px;border:1px solid rgba(148,163,184,.18);border-radius:16px;background:linear-gradient(180deg,rgba(30,41,59,.82),rgba(15,23,42,.78));color:#e5e7eb;text-align:left;cursor:pointer;transition:transform 160ms ease,border-color 160ms ease,box-shadow 160ms ease,background 160ms ease}
+.resume-template-option:hover{transform:translateY(-2px);border-color:rgba(167,139,250,.46);box-shadow:0 10px 26px rgba(2,6,23,.2)}
+.resume-template-option.active{border-color:#8b5cf6;background:linear-gradient(180deg,rgba(76,29,149,.34),rgba(30,41,59,.92));box-shadow:0 0 0 2px rgba(139,92,246,.13),0 14px 34px rgba(2,6,23,.24)}
+.resume-template-option:focus-visible{outline:3px solid rgba(196,181,253,.65);outline-offset:2px}
+.resume-template-option-copy{min-width:0;display:flex;flex-direction:column;gap:4px}
+.resume-template-option-title{display:flex;align-items:center;justify-content:space-between;gap:6px}
+.resume-template-option-title strong{color:#fff;font-size:.83rem}
+.resume-template-option-title em{font-style:normal;padding:3px 6px;border-radius:999px;background:rgba(148,163,184,.13);color:#cbd5e1;font-size:.58rem;font-weight:850;letter-spacing:.04em;text-transform:uppercase}
+.resume-template-option-copy>span:nth-child(2){color:#94a3b8;font-size:.68rem;line-height:1.35}
+.resume-template-option-copy small{display:flex;align-items:center;gap:4px;margin-top:2px;color:#a5b4fc;font-size:.65rem;font-weight:850}
+.resume-template-option-copy small.selected{color:#86efac}
+
+.resume-template-thumb{position:relative;width:68px;height:88px;padding:8px 7px;box-sizing:border-box;border-radius:5px;background:#fff;box-shadow:0 5px 16px rgba(2,6,23,.28);overflow:hidden;display:block}
+.resume-template-thumb i{display:block;border-radius:999px;background:#cbd5e1}
+.resume-template-thumb-name{width:68%;height:5px;margin-bottom:4px}
+.resume-template-thumb-contact{width:90%;height:2px;margin-bottom:8px;background:#e2e8f0!important}
+.resume-template-thumb-heading{width:46%;height:3px;margin:0 0 4px;border-radius:0!important}
+.resume-template-thumb-heading.second{margin-top:7px}
+.resume-template-thumb-line{width:78%;height:2px;margin:3px 0;background:#e5e7eb!important}
+.resume-template-thumb-line.wide{width:100%}
+.resume-template-thumb-line.short{width:58%}
+.thumb-classic .resume-template-thumb-name{margin-left:auto;margin-right:auto;background:#111827}
+.thumb-classic .resume-template-thumb-contact{margin-left:auto;margin-right:auto}
+.thumb-classic .resume-template-thumb-heading{width:100%;height:2px;background:#111827}
+.thumb-modern .resume-template-thumb-name{background:#1d4ed8}
+.thumb-modern .resume-template-thumb-heading{background:#2563eb}
+.thumb-executive .resume-template-thumb-name{background:#292524}
+.thumb-executive .resume-template-thumb-heading{background:#57534e}
+.thumb-technical .resume-template-thumb-name{background:#0f172a}
+.thumb-technical .resume-template-thumb-heading{width:58%;background:#334155}
+.thumb-technical .resume-template-thumb-line{margin:2px 0}
+.thumb-minimal .resume-template-thumb-name{background:#374151}
+.thumb-minimal .resume-template-thumb-heading{height:1px;background:#9ca3af}
+
+/* All five templates keep the same single-column DOM. Only typography,
+   spacing, alignment, and decorative rules change. */
+.resume-guided-host[data-resume-template="classic"] .resume-v2-paper{
+  font-family:Arial,Helvetica,sans-serif!important;
+  padding:.55in .62in .62in!important;
+}
+.resume-guided-host[data-resume-template="classic"] .resume-v2-paper>header{text-align:center!important;border-bottom:1px solid #cbd5e1!important;padding-bottom:13px!important}
+.resume-guided-host[data-resume-template="classic"] .resume-v2-paper>header h1{font-family:Georgia,"Times New Roman",serif!important;font-size:28px!important;color:#111827!important;letter-spacing:.01em!important}
+.resume-guided-host[data-resume-template="classic"] .resume-v2-contact{justify-content:center!important}
+.resume-guided-host[data-resume-template="classic"] .resume-v2-paper section h2{font-family:Arial,Helvetica,sans-serif!important;color:#111827!important;border-bottom:1.5px solid #1f2937!important;letter-spacing:.08em!important}
+
+.resume-guided-host[data-resume-template="modern"] .resume-v2-paper{
+  font-family:Arial,Helvetica,sans-serif!important;
+  padding:.52in .62in .62in!important;
+}
+.resume-guided-host[data-resume-template="modern"] .resume-v2-paper>header{text-align:left!important;border-bottom:3px solid #1d4ed8!important;padding-bottom:13px!important}
+.resume-guided-host[data-resume-template="modern"] .resume-v2-paper>header h1{font-family:Arial,Helvetica,sans-serif!important;font-size:30px!important;font-weight:800!important;color:#0f172a!important;letter-spacing:-.025em!important}
+.resume-guided-host[data-resume-template="modern"] .resume-v2-contact{justify-content:flex-start!important;color:#334155!important}
+.resume-guided-host[data-resume-template="modern"] .resume-v2-paper section h2{font-family:Arial,Helvetica,sans-serif!important;color:#1e3a8a!important;border-bottom:1px solid #bfdbfe!important;letter-spacing:.075em!important}
+.resume-guided-host[data-resume-template="modern"] .resume-v2-job-head strong{color:#0f172a!important}
+
+.resume-guided-host[data-resume-template="executive"] .resume-v2-paper{
+  font-family:Arial,Helvetica,sans-serif!important;
+  padding:.58in .68in .65in!important;
+}
+.resume-guided-host[data-resume-template="executive"] .resume-v2-paper>header{text-align:left!important;border-top:4px solid #292524!important;border-bottom:1px solid #d6d3d1!important;padding:14px 0 13px!important}
+.resume-guided-host[data-resume-template="executive"] .resume-v2-paper>header h1{font-family:Georgia,"Times New Roman",serif!important;font-size:31px!important;color:#292524!important;letter-spacing:.005em!important}
+.resume-guided-host[data-resume-template="executive"] .resume-v2-contact{justify-content:flex-start!important;color:#57534e!important}
+.resume-guided-host[data-resume-template="executive"] .resume-v2-paper section{margin-bottom:17px!important}
+.resume-guided-host[data-resume-template="executive"] .resume-v2-paper section h2{font-family:Georgia,"Times New Roman",serif!important;font-size:12.5px!important;color:#44403c!important;border-bottom:1px solid #a8a29e!important;letter-spacing:.055em!important}
+.resume-guided-host[data-resume-template="executive"] .resume-v2-job-head strong{font-family:Georgia,"Times New Roman",serif!important;color:#292524!important;font-size:12.5px!important}
+
+.resume-guided-host[data-resume-template="technical"] .resume-v2-paper{
+  font-family:Arial,Helvetica,sans-serif!important;
+  padding:.48in .56in .56in!important;
+}
+.resume-guided-host[data-resume-template="technical"] .resume-v2-paper>header{text-align:left!important;border-bottom:2px solid #334155!important;padding-bottom:10px!important}
+.resume-guided-host[data-resume-template="technical"] .resume-v2-paper>header h1{font-family:Arial,Helvetica,sans-serif!important;font-size:27px!important;font-weight:800!important;color:#0f172a!important;letter-spacing:-.02em!important}
+.resume-guided-host[data-resume-template="technical"] .resume-v2-contact{justify-content:flex-start!important;font-size:10.5px!important}
+.resume-guided-host[data-resume-template="technical"] .resume-v2-paper section{margin-bottom:12px!important}
+.resume-guided-host[data-resume-template="technical"] .resume-v2-paper section h2{font-family:Arial,Helvetica,sans-serif!important;font-size:11.5px!important;color:#0f172a!important;border-bottom:1px solid #94a3b8!important;letter-spacing:.105em!important}
+.resume-guided-host[data-resume-template="technical"] .resume-v2-summary,.resume-guided-host[data-resume-template="technical"] .resume-v2-skills{font-size:11px!important;line-height:1.42!important}
+.resume-guided-host[data-resume-template="technical"] .resume-v2-job{margin-bottom:10px!important}
+.resume-guided-host[data-resume-template="technical"] .resume-v2-job li{font-size:10.75px!important;line-height:1.38!important;margin-bottom:3px!important}
+
+.resume-guided-host[data-resume-template="minimal"] .resume-v2-paper{
+  font-family:Arial,Helvetica,sans-serif!important;
+  padding:.62in .72in .68in!important;
+}
+.resume-guided-host[data-resume-template="minimal"] .resume-v2-paper>header{text-align:left!important;border-bottom:0!important;padding-bottom:18px!important}
+.resume-guided-host[data-resume-template="minimal"] .resume-v2-paper>header h1{font-family:Arial,Helvetica,sans-serif!important;font-size:29px!important;font-weight:700!important;color:#1f2937!important;letter-spacing:-.025em!important}
+.resume-guided-host[data-resume-template="minimal"] .resume-v2-contact{justify-content:flex-start!important;color:#6b7280!important}
+.resume-guided-host[data-resume-template="minimal"] .resume-v2-paper section{margin-bottom:19px!important}
+.resume-guided-host[data-resume-template="minimal"] .resume-v2-paper section h2{font-family:Arial,Helvetica,sans-serif!important;font-size:11.5px!important;color:#4b5563!important;border-bottom:1px solid #e5e7eb!important;letter-spacing:.11em!important}
+.resume-guided-host[data-resume-template="minimal"] .resume-v2-summary{line-height:1.55!important}
+.resume-guided-host[data-resume-template="minimal"] .resume-v2-job{margin-bottom:15px!important}
+
+@media(max-width:1180px){
+  .resume-template-gallery{padding:0 18px}
+  .resume-template-options{grid-template-columns:repeat(3,minmax(0,1fr))}
+}
+
+@media(max-width:760px){
+  .resume-template-gallery{padding:0 12px;margin-bottom:14px}
+  .resume-template-gallery-head{align-items:flex-start;flex-direction:column;gap:10px}
+  .resume-template-ats-pill{width:100%;box-sizing:border-box}
+  .resume-template-options{display:flex;overflow-x:auto;gap:9px;padding:2px 2px 8px;scroll-snap-type:x proximity}
+  .resume-template-option{min-width:235px;scroll-snap-align:start}
+  .resume-guided-host[data-resume-template="classic"] .resume-v2-paper,
+  .resume-guided-host[data-resume-template="modern"] .resume-v2-paper,
+  .resume-guided-host[data-resume-template="executive"] .resume-v2-paper,
+  .resume-guided-host[data-resume-template="technical"] .resume-v2-paper,
+  .resume-guided-host[data-resume-template="minimal"] .resume-v2-paper{padding:30px 26px 34px!important}
+}
+
+@media print{
+  .resume-template-gallery{display:none!important}
+}


### PR DESCRIPTION
Adds a visual template gallery to Resume Builder with five selectable styles while preserving the same ATS-friendly single-column structure.

Templates:
- Classic
- Modern (default)
- Executive
- Technical
- Minimal

Implementation details:
- Template choice is UI-only styling; resume content/order and ATS text serialization do not change.
- All five keep standard section headings, single-column DOM flow, and no tables/text boxes inside the resume.
- Selection persists in localStorage for convenience.
- Gallery includes thumbnail previews, selected state, ATS-safety note, responsive horizontal scrolling on mobile, and is hidden in print.
- Modern is the default template.