### PR TITLE
Fix packet page overflow and add reviewer worksheets

### DIFF
--- a/backend/app/packet_catalog_routes.py
+++ b/backend/app/packet_catalog_routes.py
@@ -13,14 +13,14 @@ from app.auth import get_current_user
 from app.certification_packet_routes import _build_certification_packet
 from app.interview_packet_routes import _build_interview_packet
 from app.packet_audit import record_packet_export, record_packet_generation
-from app.packet_document_exports import (
-    DOCX_MIME,
-    build_career_packet_docx,
-    build_career_packet_pdf,
-    make_career_packet_filename,
-)
+from app.packet_document_exports import DOCX_MIME, make_career_packet_filename
 from app.packet_platform import apply_packet_platform
 from app.packet_platform_routes import _signature_candidates, build_platform_packet
+from app.packet_reviewer_exports import (
+    build_reviewable_career_packet_docx,
+    build_reviewable_career_packet_pdf,
+    reviewer_guide_for_packet,
+)
 from app.performance_packet_routes import _build_packet, _clean_string, _parse_period
 from app.plans import require_feature
 from app.promotion_packet_routes import _build_promotion_packet
@@ -419,12 +419,13 @@ def build_catalog_packet(packet_type: str, payload: PacketCatalogRequest, curren
         "scorecard_intro": spec["scorecard_intro"],
         "highlight_label": spec["highlight_label"],
     }
+    packet["reviewer_guide"] = reviewer_guide_for_packet(packet_type)
     return packet
 
 
 def _pdf_response(packet: dict[str, Any], current_user: dict):
     require_feature(current_user, "export_pdf")
-    pdf_bytes = build_career_packet_pdf(packet)
+    pdf_bytes = build_reviewable_career_packet_pdf(packet)
     filename = make_career_packet_filename(packet, "pdf")
     record_packet_export(
         user_id=str(current_user["_id"]),
@@ -445,7 +446,7 @@ def _pdf_response(packet: dict[str, Any], current_user: dict):
 
 def _docx_response(packet: dict[str, Any], current_user: dict):
     require_feature(current_user, "export_pdf")
-    docx_bytes = build_career_packet_docx(packet)
+    docx_bytes = build_reviewable_career_packet_docx(packet)
     filename = make_career_packet_filename(packet, "docx")
     return StreamingResponse(
         io.BytesIO(docx_bytes),

--- a/backend/app/packet_reviewer_exports.py
+++ b/backend/app/packet_reviewer_exports.py
@@ -1,0 +1,331 @@
+"""Reviewer worksheets appended to BragStack career packet PDF and DOCX exports."""
+from __future__ import annotations
+
+from io import BytesIO
+from typing import Any
+
+from docx import Document
+from docx.enum.table import WD_TABLE_ALIGNMENT
+from docx.enum.text import WD_ALIGN_PARAGRAPH
+from docx.oxml import OxmlElement
+from docx.oxml.ns import qn
+from docx.shared import Inches, Pt, RGBColor
+from pypdf import PdfReader, PdfWriter
+from reportlab.lib import colors
+from reportlab.lib.pagesizes import letter
+from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
+from reportlab.lib.units import inch
+from reportlab.platypus import Paragraph, SimpleDocTemplate, Spacer, Table, TableStyle
+
+from app.packet_document_exports import PALETTES, build_career_packet_docx, build_career_packet_pdf
+
+
+REVIEWER_GUIDES: dict[str, list[tuple[str, str]]] = {
+    "performance-review": [
+        ("Results and impact", "Are the outcomes clear, accurate, and meaningful for the review period?"),
+        ("Ownership and contribution", "Is the person's specific role in the work clear?"),
+        ("Collaboration and recognition", "Does the packet show how the work was carried with or recognized by others?"),
+        ("Skills and growth", "Does the evidence show capability growth or repeated application?"),
+        ("Evidence quality", "Are claims supported well enough to discuss confidently?"),
+        ("Review narrative", "Does the packet tell a fair, complete story of the period?"),
+    ],
+    "promotion": [
+        ("Expanded scope", "Does the evidence show broader responsibility, complexity, or ownership?"),
+        ("Sustained results", "Are the strongest outcomes repeated or durable rather than one-off?"),
+        ("Leadership and influence", "Does the record show influence, mentorship, coordination, or initiative where relevant?"),
+        ("Next-level capabilities", "Do the documented skills match the expectations of the target level?"),
+        ("Evidence quality", "Are the progression claims supported by concrete proof?"),
+        ("Case clarity", "Is the progression case easy to follow without overstating readiness?"),
+    ],
+    "interview": [
+        ("Role relevance", "Are the selected stories relevant to the role or organization?"),
+        ("Story clarity", "Can the situation, contribution, result, and learning be understood quickly?"),
+        ("Ownership", "Is the candidate's personal contribution distinct from the team's work?"),
+        ("Outcome strength", "Are results specific and supported where possible?"),
+        ("Evidence credibility", "Could the candidate defend the claims if asked for detail?"),
+        ("Preparation gaps", "What missing context or follow-up questions should be prepared?"),
+    ],
+    "certification": [
+        ("Competency alignment", "Does the evidence map clearly to the credential or licensure expectations?"),
+        ("Experience relevance", "Is the documented experience directly relevant to the review?"),
+        ("Evidence sufficiency", "Is there enough support for the competencies being claimed?"),
+        ("Recency and continuity", "Is the work recent or sustained enough for the stated requirement?"),
+        ("Accuracy and compliance", "Are claims precise and free of unsupported or confidential details?"),
+        ("Requirement gaps", "What requirements still need stronger proof or clarification?"),
+    ],
+    "program-application": [
+        ("Program alignment", "Does the packet connect the applicant's evidence to the program's focus?"),
+        ("Growth and learning", "Does the record show learning, persistence, or development?"),
+        ("Initiative and impact", "Are there concrete examples of ownership or meaningful contribution?"),
+        ("Evidence strength", "Are the strongest statements supported by documented proof?"),
+        ("Narrative clarity", "Does the material tell a coherent application story?"),
+        ("Missing context", "What should the applicant clarify before submitting?"),
+    ],
+    "scholarship": [
+        ("Selection alignment", "Does the evidence connect to the scholarship or award criteria?"),
+        ("Leadership or service", "Where relevant, does the packet show initiative, service, or leadership?"),
+        ("Documented impact", "Are outcomes specific enough to support the application?"),
+        ("Recognition and evidence", "Are meaningful claims backed by evidence or recognition where available?"),
+        ("Story clarity", "Does the material support a compelling but factual narrative?"),
+        ("Missing context", "What needs clarification before an essay, nomination, or interview?"),
+    ],
+    "portfolio": [
+        ("Audience relevance", "Are the selected projects appropriate for the intended audience?"),
+        ("Project impact", "Do the examples explain what changed because of the work?"),
+        ("Craft and quality", "Does the work demonstrate the quality expected for the field?"),
+        ("Skills depth and breadth", "Does the portfolio show the right balance of capability?"),
+        ("Evidence credibility", "Are outcomes and claims supported by available proof?"),
+        ("Presentation clarity", "Can a reviewer quickly understand the strongest work?"),
+    ],
+    "career-transition": [
+        ("Transferable skills", "Are the strongest transferable capabilities obvious?"),
+        ("Target relevance", "Does the packet connect prior work to the target field or role?"),
+        ("Evidence bridge", "Are the transition claims grounded in documented examples?"),
+        ("Learning and growth", "Does the record show preparation for the new direction?"),
+        ("Narrative credibility", "Is the transition story persuasive without claiming undocumented experience?"),
+        ("Gaps to address", "What skills, context, or proof should be strengthened next?"),
+    ],
+}
+
+FEEDBACK_SECTIONS = [
+    "Strengths / what stands out",
+    "Corrections or factual changes",
+    "Questions / clarification needed",
+    "Recommended next steps",
+]
+
+
+def reviewer_guide_for_packet(packet_type: str) -> dict[str, Any]:
+    criteria = REVIEWER_GUIDES.get(packet_type, REVIEWER_GUIDES["performance-review"])
+    return {
+        "rating_scale": "1 = needs clarification; 3 = solid; 5 = especially strong; N/A = not applicable",
+        "criteria": [{"label": label, "prompt": prompt} for label, prompt in criteria],
+        "feedback_sections": list(FEEDBACK_SECTIONS),
+        "source_record_notice": "Reviewer corrections are suggestions and do not automatically change BragStack source records.",
+    }
+
+
+def _palette(packet: dict[str, Any]) -> dict[str, str]:
+    name = packet.get("render_config", {}).get("theme") or "modern-minimal"
+    return PALETTES.get(name, PALETTES["modern-minimal"])
+
+
+def _pdf_reviewer_page(packet: dict[str, Any]) -> bytes:
+    palette = _palette(packet)
+    primary = colors.HexColor(f"#{palette['primary']}")
+    secondary = colors.HexColor(f"#{palette['secondary']}")
+    soft = colors.HexColor(f"#{palette['soft']}")
+    line = colors.HexColor(f"#{palette['accent']}")
+    ink = colors.HexColor(f"#{palette['ink']}")
+    muted = colors.HexColor(f"#{palette['muted']}")
+    guide = packet.get("reviewer_guide") or reviewer_guide_for_packet(str(packet.get("kind") or "performance-review"))
+    criteria = (guide.get("criteria") or [])[:6]
+    reviewer = str((packet.get("branding") or {}).get("reviewer_name") or "").strip()
+
+    buffer = BytesIO()
+    doc = SimpleDocTemplate(
+        buffer,
+        pagesize=letter,
+        leftMargin=0.62 * inch,
+        rightMargin=0.62 * inch,
+        topMargin=0.55 * inch,
+        bottomMargin=0.48 * inch,
+        title="BragStack Reviewer Worksheet",
+        author="BragStack",
+    )
+    base = getSampleStyleSheet()
+    eyebrow = ParagraphStyle("ReviewerEyebrow", parent=base["Normal"], fontName="Helvetica-Bold", fontSize=7.5, leading=9, textColor=secondary, spaceAfter=5)
+    title = ParagraphStyle("ReviewerTitle", parent=base["Heading1"], fontName="Helvetica-Bold", fontSize=22, leading=25, textColor=primary, spaceAfter=7)
+    body = ParagraphStyle("ReviewerBody", parent=base["BodyText"], fontName="Helvetica", fontSize=7.8, leading=10.4, textColor=muted, spaceAfter=5)
+    small = ParagraphStyle("ReviewerSmall", parent=base["BodyText"], fontName="Helvetica", fontSize=6.4, leading=8.2, textColor=ink)
+    small_bold = ParagraphStyle("ReviewerSmallBold", parent=small, fontName="Helvetica-Bold", textColor=primary)
+
+    story = [
+        Paragraph("10 · REVIEWER WORKSHEET", eyebrow),
+        Paragraph("Grade the evidence. Leave the record better.", title),
+        Paragraph("Use this worksheet to assess the packet, flag factual corrections, and leave actionable feedback. Ratings are completed by the reviewer—not generated by BragStack.", body),
+    ]
+
+    meta = Table([
+        [Paragraph("Reviewer", small_bold), Paragraph(reviewer or "________________________", small), Paragraph("Date", small_bold), Paragraph("____________", small)],
+        [Paragraph("Role / relationship", small_bold), Paragraph("________________________", small), Paragraph("Overall assessment", small_bold), Paragraph("____ / 5 or N/A", small)],
+    ], colWidths=[1.15 * inch, 2.35 * inch, 1.25 * inch, 1.55 * inch])
+    meta.setStyle(TableStyle([
+        ("BACKGROUND", (0, 0), (0, -1), soft),
+        ("BACKGROUND", (2, 0), (2, -1), soft),
+        ("GRID", (0, 0), (-1, -1), 0.45, line),
+        ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
+        ("LEFTPADDING", (0, 0), (-1, -1), 6),
+        ("RIGHTPADDING", (0, 0), (-1, -1), 6),
+        ("TOPPADDING", (0, 0), (-1, -1), 5),
+        ("BOTTOMPADDING", (0, 0), (-1, -1), 5),
+    ]))
+    story.extend([meta, Spacer(1, 8)])
+
+    rows = [[Paragraph("Section to review", small_bold), Paragraph("Grade", small_bold), Paragraph("Reviewer note", small_bold)]]
+    for item in criteria:
+        label = str(item.get("label") or "Review area")
+        prompt = str(item.get("prompt") or "")
+        rows.append([
+            Paragraph(f"<b>{label}</b><br/><font color='#{palette['muted']}'>{prompt}</font>", small),
+            Paragraph("____ / 5", small_bold),
+            Paragraph("________________________________", small),
+        ])
+    rubric = Table(rows, colWidths=[3.55 * inch, 0.8 * inch, 2.0 * inch], repeatRows=1)
+    rubric.setStyle(TableStyle([
+        ("BACKGROUND", (0, 0), (-1, 0), primary),
+        ("TEXTCOLOR", (0, 0), (-1, 0), colors.white),
+        ("GRID", (0, 0), (-1, -1), 0.4, line),
+        ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
+        ("LEFTPADDING", (0, 0), (-1, -1), 6),
+        ("RIGHTPADDING", (0, 0), (-1, -1), 6),
+        ("TOPPADDING", (0, 1), (-1, -1), 5),
+        ("BOTTOMPADDING", (0, 1), (-1, -1), 5),
+    ]))
+    story.extend([rubric, Spacer(1, 8)])
+
+    feedback_cells = []
+    for label in FEEDBACK_SECTIONS:
+        feedback_cells.append([
+            Paragraph(label, small_bold),
+            Paragraph("______________________________________________<br/>______________________________________________", small),
+        ])
+    feedback = Table([
+        [feedback_cells[0], feedback_cells[1]],
+        [feedback_cells[2], feedback_cells[3]],
+    ], colWidths=[3.18 * inch, 3.18 * inch])
+    feedback.setStyle(TableStyle([
+        ("BACKGROUND", (0, 0), (-1, -1), colors.white),
+        ("BOX", (0, 0), (-1, -1), 0.45, line),
+        ("INNERGRID", (0, 0), (-1, -1), 0.35, line),
+        ("VALIGN", (0, 0), (-1, -1), "TOP"),
+        ("LEFTPADDING", (0, 0), (-1, -1), 7),
+        ("RIGHTPADDING", (0, 0), (-1, -1), 7),
+        ("TOPPADDING", (0, 0), (-1, -1), 6),
+        ("BOTTOMPADDING", (0, 0), (-1, -1), 6),
+    ]))
+    story.extend([
+        feedback,
+        Spacer(1, 7),
+        Paragraph("<b>Corrections are suggestions, not automatic edits.</b> Reviewer notes do not overwrite accomplishments, Impact Receipts, evidence, or recognition in BragStack. The packet owner decides what source records should be updated.", body),
+    ])
+    doc.build(story)
+    return buffer.getvalue()
+
+
+def build_reviewable_career_packet_pdf(packet: dict[str, Any]) -> bytes:
+    base_bytes = build_career_packet_pdf(packet)
+    reviewer_bytes = _pdf_reviewer_page(packet)
+    writer = PdfWriter()
+    for source in (base_bytes, reviewer_bytes):
+        reader = PdfReader(BytesIO(source))
+        for page in reader.pages:
+            writer.add_page(page)
+    output = BytesIO()
+    writer.write(output)
+    return output.getvalue()
+
+
+def _set_docx_cell_shading(cell, fill: str) -> None:
+    tc_pr = cell._tc.get_or_add_tcPr()
+    shd = tc_pr.find(qn("w:shd"))
+    if shd is None:
+        shd = OxmlElement("w:shd")
+        tc_pr.append(shd)
+    shd.set(qn("w:fill"), fill)
+
+
+def _format_docx_run(run, *, size: float, bold: bool = False, color: str = "17202A") -> None:
+    run.font.name = "Aptos"
+    run.font.size = Pt(size)
+    run.bold = bold
+    run.font.color.rgb = RGBColor.from_string(color)
+
+
+def _add_feedback_box(document: Document, label: str, palette: dict[str, str]) -> None:
+    table = document.add_table(rows=1, cols=1)
+    cell = table.cell(0, 0)
+    _set_docx_cell_shading(cell, palette["soft"])
+    paragraph = cell.paragraphs[0]
+    label_run = paragraph.add_run(label)
+    _format_docx_run(label_run, size=9, bold=True, color=palette["primary"])
+    for _ in range(3):
+        line = cell.add_paragraph("____________________________________________________________")
+        for run in line.runs:
+            _format_docx_run(run, size=8, color=palette["muted"])
+
+
+def build_reviewable_career_packet_docx(packet: dict[str, Any]) -> bytes:
+    base_bytes = build_career_packet_docx(packet)
+    document = Document(BytesIO(base_bytes))
+    palette = _palette(packet)
+    guide = packet.get("reviewer_guide") or reviewer_guide_for_packet(str(packet.get("kind") or "performance-review"))
+    criteria = (guide.get("criteria") or [])[:6]
+    reviewer = str((packet.get("branding") or {}).get("reviewer_name") or "").strip()
+
+    document.add_page_break()
+    eyebrow = document.add_paragraph()
+    eyebrow_run = eyebrow.add_run("REVIEWER WORKSHEET")
+    _format_docx_run(eyebrow_run, size=8, bold=True, color=palette["secondary"])
+    heading = document.add_paragraph()
+    heading_run = heading.add_run("Grade the evidence. Leave the record better.")
+    _format_docx_run(heading_run, size=21, bold=True, color=palette["primary"])
+    intro = document.add_paragraph("Use this worksheet to assess the packet, flag factual corrections, and leave actionable feedback. Ratings are completed by the reviewer—not generated by BragStack.")
+    for run in intro.runs:
+        _format_docx_run(run, size=9, color=palette["muted"])
+
+    meta = document.add_table(rows=2, cols=4)
+    meta.alignment = WD_TABLE_ALIGNMENT.CENTER
+    meta_values = [
+        ("Reviewer", reviewer or "________________________", "Date", "____________"),
+        ("Role / relationship", "________________________", "Overall assessment", "____ / 5 or N/A"),
+    ]
+    for row_index, row_values in enumerate(meta_values):
+        for col_index, value in enumerate(row_values):
+            cell = meta.cell(row_index, col_index)
+            if col_index in (0, 2):
+                _set_docx_cell_shading(cell, palette["soft"])
+            run = cell.paragraphs[0].add_run(value)
+            _format_docx_run(run, size=8.5, bold=col_index in (0, 2), color=palette["primary"] if col_index in (0, 2) else palette["ink"])
+
+    document.add_paragraph()
+    rubric = document.add_table(rows=1, cols=3)
+    rubric.alignment = WD_TABLE_ALIGNMENT.CENTER
+    headers = ["Section to review", "Grade", "Reviewer note"]
+    for index, label in enumerate(headers):
+        _set_docx_cell_shading(rubric.cell(0, index), palette["primary"])
+        run = rubric.cell(0, index).paragraphs[0].add_run(label)
+        _format_docx_run(run, size=8, bold=True, color="FFFFFF")
+    for item in criteria:
+        cells = rubric.add_row().cells
+        label = str(item.get("label") or "Review area")
+        prompt = str(item.get("prompt") or "")
+        label_run = cells[0].paragraphs[0].add_run(label)
+        _format_docx_run(label_run, size=8.5, bold=True, color=palette["primary"])
+        prompt_run = cells[0].add_paragraph(prompt).add_run()
+        _format_docx_run(prompt_run, size=7.5, color=palette["muted"])
+        grade_run = cells[1].paragraphs[0].add_run("____ / 5")
+        _format_docx_run(grade_run, size=8.5, bold=True, color=palette["primary"])
+        note_run = cells[2].paragraphs[0].add_run("____________________________")
+        _format_docx_run(note_run, size=8, color=palette["muted"])
+
+    document.add_paragraph()
+    for label in FEEDBACK_SECTIONS:
+        _add_feedback_box(document, label, palette)
+        document.add_paragraph()
+
+    safety = document.add_paragraph()
+    lead = safety.add_run("Corrections are suggestions, not automatic edits. ")
+    _format_docx_run(lead, size=8.5, bold=True, color=palette["primary"])
+    body = safety.add_run("Reviewer notes do not overwrite accomplishments, Impact Receipts, evidence, or recognition in BragStack. The packet owner decides what source records should be updated.")
+    _format_docx_run(body, size=8.5, color=palette["muted"])
+
+    section = document.sections[-1]
+    section.top_margin = Inches(0.62)
+    section.bottom_margin = Inches(0.62)
+    footer = section.footer.paragraphs[0]
+    footer.alignment = WD_ALIGN_PARAGRAPH.CENTER
+
+    output = BytesIO()
+    document.save(output)
+    return output.getvalue()

--- a/backend/tests/test_packet_catalog_exports.py
+++ b/backend/tests/test_packet_catalog_exports.py
@@ -182,6 +182,14 @@ def test_catalog_packet_generation_contains_saved_proof(packet_catalog_context, 
     assert packet["quality_message"] == catalog_routes.QUALITY_MESSAGE
     assert packet["usage_example"]
     assert packet["signature_accomplishments"]
+    assert len(packet["reviewer_guide"]["criteria"]) == 6
+    assert packet["reviewer_guide"]["feedback_sections"] == [
+        "Strengths / what stands out",
+        "Corrections or factual changes",
+        "Questions / clarification needed",
+        "Recommended next steps",
+    ]
+    assert "do not automatically change" in packet["reviewer_guide"]["source_record_notice"]
 
 
 @pytest.mark.parametrize("packet_type", PACKET_TYPES)
@@ -199,6 +207,9 @@ def test_catalog_pdf_download_is_nonblank_and_contains_packet_content(packet_cat
     assert catalog_routes.PACKET_SPECS[packet_type]["title"] in text
     assert "Impact Receipts" in text
     assert "Automated a recurring support validation workflow" in text
+    assert "REVIEWER WORKSHEET" in text
+    assert "Corrections or factual changes" in text
+    assert "not automatic edits" in text
 
 
 @pytest.mark.parametrize("packet_type", PACKET_TYPES)
@@ -216,3 +227,6 @@ def test_catalog_docx_download_is_nonblank_and_contains_packet_content(packet_ca
     assert catalog_routes.PACKET_SPECS[packet_type]["title"] in text
     assert "Impact Receipts" in text
     assert "Automated a recurring support validation workflow" in text
+    assert "REVIEWER WORKSHEET" in text
+    assert "Corrections or factual changes" in text
+    assert "not automatic edits" in text

--- a/frontend/src/GenericPacketPages.jsx
+++ b/frontend/src/GenericPacketPages.jsx
@@ -1,4 +1,5 @@
 import { Award, BadgeCheck, FileCheck2, Sparkles, Target } from "lucide-react";
+import PacketReviewerPage from "./PacketReviewerPage.jsx";
 import "./GenericPacketPages.css";
 
 function themeClass(packet) {
@@ -53,6 +54,8 @@ function GenericPacketPages({ packet }) {
       <div className="generic-export-note"><FileCheck2 size={18} /><p>This packet is generated from user-saved BragStack data. Review it before submitting it to an employer, school, licensing body, scholarship committee, client, or other third party.</p></div>
       <PacketFooter page={5} />
     </section>
+
+    <PacketReviewerPage packet={packet} page={6} index={5} />
   </>;
 }
 

--- a/frontend/src/PacketPlatformPreview.css
+++ b/frontend/src/PacketPlatformPreview.css
@@ -95,6 +95,21 @@
   border-color: var(--packet-line);
 }
 
+.packet-theme-modern-minimal .packet-growth-callout,
+.packet-theme-executive-report .packet-growth-callout {
+  color: var(--packet-ink);
+}
+
+.packet-theme-modern-minimal .packet-growth-callout p,
+.packet-theme-executive-report .packet-growth-callout p {
+  color: var(--packet-muted);
+}
+
+.packet-theme-modern-minimal .packet-growth-callout svg,
+.packet-theme-executive-report .packet-growth-callout svg {
+  color: var(--packet-highlight);
+}
+
 .packet-user-note {
   margin-top: 9px;
   padding: 10px 12px;

--- a/frontend/src/PacketReviewerPage.css
+++ b/frontend/src/PacketReviewerPage.css
@@ -1,0 +1,211 @@
+.packet-reviewer-page {
+  --reviewer-line: var(--packet-line, #d9e2e8);
+  --reviewer-ink: var(--packet-ink, #172126);
+  --reviewer-muted: var(--packet-muted, #667176);
+  --reviewer-accent: var(--packet-accent, #173f43);
+  --reviewer-soft: var(--packet-soft, #f3f7f9);
+  padding-bottom: clamp(44px, 6vw, 62px);
+}
+
+.packet-reviewer-intro {
+  margin: 14px 0 12px;
+  max-width: 680px;
+  color: var(--reviewer-muted);
+  font-size: clamp(7px, 1vw, 9px);
+  line-height: 1.45;
+}
+
+.packet-reviewer-meta {
+  display: grid;
+  grid-template-columns: 1.2fr 1.2fr .7fr .9fr;
+  border: 1px solid var(--reviewer-line);
+  border-radius: 9px;
+  overflow: hidden;
+  background: var(--reviewer-soft);
+}
+
+.packet-reviewer-meta > div {
+  min-width: 0;
+  padding: 9px 10px;
+  display: grid;
+  gap: 5px;
+}
+
+.packet-reviewer-meta > div + div {
+  border-left: 1px solid var(--reviewer-line);
+}
+
+.packet-reviewer-meta span {
+  color: var(--reviewer-muted);
+  font-size: clamp(5.5px, .8vw, 7px);
+  font-weight: 850;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+}
+
+.packet-reviewer-meta strong {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  color: var(--reviewer-ink);
+  font-size: clamp(7px, 1vw, 9px);
+  line-height: 1.25;
+}
+
+.packet-reviewer-rubric {
+  margin-top: 12px;
+  border: 1px solid var(--reviewer-line);
+  border-radius: 9px;
+  overflow: hidden;
+}
+
+.packet-reviewer-rubric-header,
+.packet-reviewer-rubric-row {
+  display: grid;
+  grid-template-columns: minmax(0, 2.2fr) .55fr minmax(0, 1fr);
+  align-items: stretch;
+}
+
+.packet-reviewer-rubric-header {
+  background: var(--reviewer-accent);
+  color: #fff;
+}
+
+.packet-reviewer-rubric-header > div,
+.packet-reviewer-rubric-header > strong {
+  padding: 7px 9px;
+}
+
+.packet-reviewer-rubric-header > * + * {
+  border-left: 1px solid rgba(255,255,255,.2);
+}
+
+.packet-reviewer-rubric-header strong {
+  font-size: clamp(6px, .85vw, 7.5px);
+  letter-spacing: .05em;
+  text-transform: uppercase;
+}
+
+.packet-reviewer-rubric-header span {
+  display: block;
+  margin-top: 2px;
+  color: rgba(255,255,255,.78);
+  font-size: clamp(5px, .72vw, 6.2px);
+  font-weight: 500;
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.packet-reviewer-rubric-row + .packet-reviewer-rubric-row {
+  border-top: 1px solid var(--reviewer-line);
+}
+
+.packet-reviewer-rubric-row > div {
+  min-width: 0;
+  min-height: 43px;
+  padding: 6px 9px;
+}
+
+.packet-reviewer-rubric-row > div + div {
+  border-left: 1px solid var(--reviewer-line);
+}
+
+.packet-reviewer-rubric-row > div:first-child {
+  display: grid;
+  align-content: center;
+  gap: 2px;
+}
+
+.packet-reviewer-rubric-row strong {
+  color: var(--reviewer-ink);
+  font-size: clamp(6.5px, .9vw, 8px);
+}
+
+.packet-reviewer-rubric-row span {
+  color: var(--reviewer-muted);
+  font-size: clamp(5.2px, .74vw, 6.5px);
+  line-height: 1.28;
+}
+
+.packet-reviewer-grade {
+  display: grid;
+  place-items: center;
+  color: var(--reviewer-accent);
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: clamp(8px, 1.05vw, 10px);
+  font-weight: 700;
+}
+
+.packet-reviewer-note-line {
+  margin: 8px 9px !important;
+  min-height: 0 !important;
+  align-self: end;
+  border-bottom: 1px solid color-mix(in srgb, var(--reviewer-muted) 45%, transparent);
+}
+
+.packet-reviewer-feedback-grid {
+  margin-top: 12px;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.packet-reviewer-feedback-grid section {
+  min-height: 82px;
+  padding: 8px 10px;
+  border: 1px solid var(--reviewer-line);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--reviewer-soft) 62%, white);
+}
+
+.packet-reviewer-feedback-grid section > div {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--reviewer-accent);
+}
+
+.packet-reviewer-feedback-grid section strong {
+  font-size: clamp(6.5px, .9vw, 8px);
+}
+
+.packet-reviewer-feedback-grid section svg {
+  flex: 0 0 auto;
+}
+
+.packet-reviewer-write-line {
+  display: block;
+  height: 15px;
+  border-bottom: 1px solid color-mix(in srgb, var(--reviewer-muted) 34%, transparent);
+}
+
+.packet-reviewer-safety-note {
+  margin-top: 9px;
+  padding: 8px 10px;
+  border-left: 3px solid var(--packet-highlight, #b68b4c);
+  background: var(--reviewer-soft);
+  color: var(--reviewer-ink);
+}
+
+.packet-reviewer-safety-note strong {
+  font-size: clamp(6.5px, .9vw, 8px);
+}
+
+.packet-reviewer-safety-note p {
+  margin: 3px 0 0;
+  color: var(--reviewer-muted);
+  font-size: clamp(5.3px, .75vw, 6.6px);
+  line-height: 1.3;
+}
+
+@media (max-width: 680px) {
+  .packet-reviewer-meta {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .packet-reviewer-meta > div:nth-child(3) {
+    border-left: 0;
+    border-top: 1px solid var(--reviewer-line);
+  }
+  .packet-reviewer-meta > div:nth-child(4) {
+    border-top: 1px solid var(--reviewer-line);
+  }
+}

--- a/frontend/src/PacketReviewerPage.jsx
+++ b/frontend/src/PacketReviewerPage.jsx
@@ -1,0 +1,151 @@
+import {
+  ClipboardCheck,
+  MessageSquareText,
+  PenLine,
+  RotateCcw,
+} from "lucide-react";
+
+import "./PacketReviewerPage.css";
+
+const REVIEWER_GUIDES = {
+  "performance-review": [
+    ["Results and impact", "Are the outcomes clear, accurate, and meaningful for the review period?"],
+    ["Ownership and contribution", "Is the person’s specific role in the work clear?"],
+    ["Collaboration and recognition", "Does the packet show how the work was carried with or recognized by others?"],
+    ["Skills and growth", "Does the evidence show capability growth or repeated application?"],
+    ["Evidence quality", "Are claims supported well enough to discuss confidently?"],
+    ["Review narrative", "Does the packet tell a fair, complete story of the period?"],
+  ],
+  promotion: [
+    ["Expanded scope", "Does the evidence show broader responsibility, complexity, or ownership?"],
+    ["Sustained results", "Are the strongest outcomes repeated or durable rather than one-off?"],
+    ["Leadership and influence", "Does the record show influence, mentorship, coordination, or initiative where relevant?"],
+    ["Next-level capabilities", "Do the documented skills match the expectations of the target level?"],
+    ["Evidence quality", "Are the progression claims supported by concrete proof?"],
+    ["Case clarity", "Is the argument for progression easy to follow without overstating readiness?"],
+  ],
+  interview: [
+    ["Role relevance", "Are the selected stories relevant to the role or organization?"],
+    ["Story clarity", "Can the situation, contribution, result, and learning be understood quickly?"],
+    ["Ownership", "Is the candidate’s personal contribution distinct from the team’s work?"],
+    ["Outcome strength", "Are results specific and supported where possible?"],
+    ["Evidence credibility", "Could the candidate defend the claims if asked for detail?"],
+    ["Preparation gaps", "What missing context or follow-up questions should be prepared?"],
+  ],
+  certification: [
+    ["Competency alignment", "Does the evidence map clearly to the credential or licensure expectations?"],
+    ["Experience relevance", "Is the documented experience directly relevant to the review?"],
+    ["Evidence sufficiency", "Is there enough support for the competencies being claimed?"],
+    ["Recency and continuity", "Is the work recent or sustained enough for the stated requirement?"],
+    ["Accuracy and compliance", "Are claims precise and free of unsupported or confidential details?"],
+    ["Requirement gaps", "What requirements still need stronger proof or clarification?"],
+  ],
+  "program-application": [
+    ["Program alignment", "Does the packet connect the applicant’s evidence to the program’s focus?"],
+    ["Growth and learning", "Does the record show learning, persistence, or development?"],
+    ["Initiative and impact", "Are there concrete examples of ownership or meaningful contribution?"],
+    ["Evidence strength", "Are the strongest statements supported by documented proof?"],
+    ["Narrative clarity", "Does the material tell a coherent application story?"],
+    ["Missing context", "What should the applicant clarify before submitting?"],
+  ],
+  scholarship: [
+    ["Selection alignment", "Does the evidence connect to the scholarship or award criteria?"],
+    ["Leadership or service", "Where relevant, does the packet show initiative, service, or leadership?"],
+    ["Documented impact", "Are outcomes specific enough to support the application?"],
+    ["Recognition and evidence", "Are meaningful claims backed by evidence or recognition where available?"],
+    ["Story clarity", "Does the material support a compelling but factual narrative?"],
+    ["Missing context", "What needs clarification before an essay, nomination, or interview?"],
+  ],
+  portfolio: [
+    ["Audience relevance", "Are the selected projects appropriate for the intended audience?"],
+    ["Project impact", "Do the examples explain what changed because of the work?"],
+    ["Craft and quality", "Does the work demonstrate the quality expected for the field?"],
+    ["Skills depth and breadth", "Does the portfolio show the right balance of capability?"],
+    ["Evidence credibility", "Are outcomes and claims supported by available proof?"],
+    ["Presentation clarity", "Can a reviewer quickly understand the strongest work?"],
+  ],
+  "career-transition": [
+    ["Transferable skills", "Are the strongest transferable capabilities obvious?"],
+    ["Target relevance", "Does the packet connect prior work to the target field or role?"],
+    ["Evidence bridge", "Are the transition claims grounded in documented examples?"],
+    ["Learning and growth", "Does the record show preparation for the new direction?"],
+    ["Narrative credibility", "Is the transition story persuasive without claiming undocumented experience?"],
+    ["Gaps to address", "What skills, context, or proof should be strengthened next?"],
+  ],
+};
+
+const FEEDBACK_SECTIONS = [
+  ["Strengths / what stands out", MessageSquareText],
+  ["Corrections or factual changes", PenLine],
+  ["Questions / clarification needed", RotateCcw],
+  ["Recommended next steps", ClipboardCheck],
+];
+
+function themeClass(packet) {
+  return `packet-theme-${packet?.render_config?.theme || "modern-minimal"}`;
+}
+
+function PacketReviewerPage({ packet, page, index = 10 }) {
+  const criteria = packet?.reviewer_guide?.criteria?.length
+    ? packet.reviewer_guide.criteria.map((item) => [item.label, item.prompt])
+    : REVIEWER_GUIDES[packet?.kind] || REVIEWER_GUIDES["performance-review"];
+  const reviewerName = packet?.branding?.reviewer_name || "";
+
+  return (
+    <section className={`packet-sheet packet-document-page packet-reviewer-page ${themeClass(packet)}`}>
+      <header className="packet-page-header">
+        <div>
+          <p>{String(index).padStart(2, "0")} · Reviewer Worksheet</p>
+          <h2>Grade the evidence. Leave the record better.</h2>
+        </div>
+        <div className="packet-page-header-mark">BRAGSTACK</div>
+      </header>
+
+      <p className="packet-reviewer-intro">
+        Use this page to assess the packet, flag factual corrections, and leave actionable feedback. Ratings are completed by the reviewer—not generated by BragStack.
+      </p>
+
+      <div className="packet-reviewer-meta">
+        <div><span>Reviewer</span><strong>{reviewerName || "____________________________"}</strong></div>
+        <div><span>Role / relationship</span><strong>____________________________</strong></div>
+        <div><span>Date</span><strong>________________</strong></div>
+        <div><span>Overall assessment</span><strong>____ / 5 &nbsp; or &nbsp; N/A</strong></div>
+      </div>
+
+      <section className="packet-reviewer-rubric" aria-label="Reviewer grading rubric">
+        <div className="packet-reviewer-rubric-header">
+          <div><strong>Section to review</strong><span>1 = needs clarification · 3 = solid · 5 = especially strong</span></div>
+          <strong>Grade</strong>
+          <strong>Reviewer note</strong>
+        </div>
+        {criteria.slice(0, 6).map(([label, prompt]) => (
+          <div className="packet-reviewer-rubric-row" key={label}>
+            <div><strong>{label}</strong><span>{prompt}</span></div>
+            <div className="packet-reviewer-grade">____ / 5</div>
+            <div className="packet-reviewer-note-line" aria-hidden="true" />
+          </div>
+        ))}
+      </section>
+
+      <div className="packet-reviewer-feedback-grid">
+        {FEEDBACK_SECTIONS.map(([label, Icon]) => (
+          <section key={label}>
+            <div><Icon size={15} /><strong>{label}</strong></div>
+            <span className="packet-reviewer-write-line" />
+            <span className="packet-reviewer-write-line" />
+            <span className="packet-reviewer-write-line" />
+          </section>
+        ))}
+      </div>
+
+      <aside className="packet-reviewer-safety-note">
+        <strong>Corrections are suggestions, not automatic edits.</strong>
+        <p>Reviewer notes do not overwrite accomplishments, Impact Receipts, evidence, or recognition in BragStack. The packet owner decides what source records should be updated.</p>
+      </aside>
+
+      <footer className="packet-page-footer"><span>BragStack · Reviewer Worksheet</span><span>Page {page}</span></footer>
+    </section>
+  );
+}
+
+export default PacketReviewerPage;

--- a/frontend/src/PerformancePacketPages.jsx
+++ b/frontend/src/PerformancePacketPages.jsx
@@ -14,6 +14,7 @@ import {
   UsersRound,
 } from "lucide-react";
 
+import PacketReviewerPage from "./PacketReviewerPage.jsx";
 import "./PerformancePacketPages.css";
 
 function formatShortDate(value) {
@@ -64,9 +65,18 @@ function SkillsPage({ packet, page }) {
   return <section className={`packet-sheet packet-document-page ${themeClass(packet)}`}><PacketHeader index={5} eyebrow="Skills & Growth" title="Capabilities demonstrated in real work" /><p className="packet-page-lead">Frequency reflects how often a capability appears in documented work—not a proficiency score.</p>{skills.length ? <div className="packet-skill-evidence-list">{skills.slice(0, 12).map((item, index) => <article key={item.skill}><div className="packet-skill-rank">{index + 1}</div><div className="packet-skill-main"><div><strong>{item.skill}</strong><span>{item.count} documented use{item.count === 1 ? "" : "s"}</span></div><div className="packet-skill-track"><span style={{ width: `${Math.max(8, (item.count / maxCount) * 100)}%` }} /></div></div><div className="packet-skill-dates"><span>First shown</span><strong>{formatShortDate(item.first_seen)}</strong><span>Most recent</span><strong>{formatShortDate(item.last_seen)}</strong></div></article>)}</div> : <EmptyState>Add skills to accomplishments or Impact Receipts to build capability evidence.</EmptyState>}<div className="packet-growth-callout"><Sparkles size={19} /><div><strong>Career-neutral by design</strong><p>Clinical, instructional, interpersonal, operational, technical, creative, sales, trade, management, and other capabilities use the same evidence model.</p></div></div><PacketFooter page={page} /></section>;
 }
 
-function ContributionPage({ packet, page }) {
-  const contributions = packet?.contribution_records ?? []; const confirmed = packet?.scorecard?.confirmed_assertions ?? 0;
-  return <section className={`packet-sheet packet-document-page ${themeClass(packet)}`}><PacketHeader index={6} eyebrow="Contribution & Verified Recognition" title="What you moved forward and who recognized it" /><div className="packet-contribution-summary"><div><UsersRound size={21} /><strong>{contributions.length}</strong><span>contribution records</span></div><div><BadgeCheck size={21} /><strong>{confirmed}</strong><span>confirmed recognitions</span></div></div>{contributions.length ? <div className="packet-contribution-list">{contributions.slice(0, 8).map((item) => <article key={item.reference}><div className="packet-contribution-topline"><span>{item.reference}</span>{item.verified && <span className="packet-verified-chip"><BadgeCheck size={12} /> Recognized</span>}</div><h3>{item.accomplishment}</h3>{item.contribution && <p><strong>Contribution:</strong> {item.contribution}</p>}{item.result && <p><strong>Result:</strong> {item.result}</p>}{item.recognition?.length > 0 && <div className="packet-recognition-list">{item.recognition.map((recognition, index) => <span key={`${item.reference}-${recognition.label}-${index}`}>{recognition.label}{recognition.name ? ` · ${recognition.name}` : ""}</span>)}</div>}<ItemNote packet={packet} itemKey={item.reference} /></article>)}</div> : <EmptyState>Create Impact Receipts to document the contribution behind each result.</EmptyState>}<PacketFooter page={page} /></section>;
+function ContributionPages({ packet, startPage }) {
+  const contributions = packet?.contribution_records ?? [];
+  const confirmed = packet?.scorecard?.confirmed_assertions ?? 0;
+  const pages = chunk(contributions, 4);
+  return pages.map((items, pageIndex) => (
+    <section key={`contribution-${pageIndex}`} className={`packet-sheet packet-document-page ${themeClass(packet)}`}>
+      <PacketHeader index={6} eyebrow="Contribution & Verified Recognition" title={pageIndex ? "Contribution & recognition · continued" : "What you moved forward and who recognized it"} />
+      {pageIndex === 0 && <div className="packet-contribution-summary"><div><UsersRound size={21} /><strong>{contributions.length}</strong><span>contribution records</span></div><div><BadgeCheck size={21} /><strong>{confirmed}</strong><span>confirmed recognitions</span></div></div>}
+      {items.length ? <div className="packet-contribution-list">{items.map((item) => <article key={item.reference}><div className="packet-contribution-topline"><span>{item.reference}</span>{item.verified && <span className="packet-verified-chip"><BadgeCheck size={12} /> Recognized</span>}</div><h3>{item.accomplishment}</h3>{item.contribution && <p><strong>Contribution:</strong> {item.contribution}</p>}{item.result && <p><strong>Result:</strong> {item.result}</p>}{item.recognition?.length > 0 && <div className="packet-recognition-list">{item.recognition.map((recognition, index) => <span key={`${item.reference}-${recognition.label}-${index}`}>{recognition.label}{recognition.name ? ` · ${recognition.name}` : ""}</span>)}</div>}<ItemNote packet={packet} itemKey={item.reference} /></article>)}</div> : <EmptyState>Create Impact Receipts to document the contribution behind each result.</EmptyState>}
+      <PacketFooter page={startPage + pageIndex} />
+    </section>
+  ));
 }
 
 function ReceiptPages({ packet, startPage }) {
@@ -92,10 +102,11 @@ function PerformancePacketPages({ packet }) {
   if (enabled.has("signature-accomplishments")) { nodes.push(<SignaturePage key="signatures" packet={packet} page={page} />); page += 1; }
   if (enabled.has("measurable-results")) { nodes.push(<ResultsPage key="results" packet={packet} page={page} />); page += 1; }
   if (enabled.has("skills-growth")) { nodes.push(<SkillsPage key="skills" packet={packet} page={page} />); page += 1; }
-  if (enabled.has("contribution-recognition")) { nodes.push(<ContributionPage key="contribution" packet={packet} page={page} />); page += 1; }
+  if (enabled.has("contribution-recognition")) { const count = Math.max(1, Math.ceil((packet?.contribution_records?.length ?? 0) / 4)); nodes.push(<ContributionPages key="contribution" packet={packet} startPage={page} />); page += count; }
   if (enabled.has("impact-receipts")) { const count = Math.max(1, Math.ceil((packet?.receipt_records?.length ?? 0) / 2)); nodes.push(<ReceiptPages key="receipts" packet={packet} startPage={page} />); page += count; }
   if (enabled.has("evidence-index")) { const count = Math.max(1, Math.ceil((packet?.evidence_index?.length ?? 0) / 10)); nodes.push(<EvidencePages key="evidence" packet={packet} startPage={page} />); page += count; }
-  if (enabled.has("review-summary")) nodes.push(<SummaryPage key="summary" packet={packet} page={page} />);
+  if (enabled.has("review-summary")) { nodes.push(<SummaryPage key="summary" packet={packet} page={page} />); page += 1; }
+  nodes.push(<PacketReviewerPage key="reviewer" packet={packet} page={page} index={10} />);
   return <>{nodes}</>;
 }
 

--- a/frontend/src/packetsPageSource.test.js
+++ b/frontend/src/packetsPageSource.test.js
@@ -10,6 +10,11 @@ const pageCss = read("./PacketsPage.css");
 const builder = read("./PacketBuilderPanel.jsx");
 const api = read("./api.js");
 const preview = read("./PerformancePacketPreview.jsx");
+const performancePages = read("./PerformancePacketPages.jsx");
+const genericPages = read("./GenericPacketPages.jsx");
+const reviewerPage = read("./PacketReviewerPage.jsx");
+const reviewerCss = read("./PacketReviewerPage.css");
+const platformCss = read("./PacketPlatformPreview.css");
 const sidebar = read("./AppSidebar.jsx");
 const careerPage = read("./ProCareerPage.jsx");
 
@@ -56,6 +61,31 @@ test("packet generation and download use the catalog API and nonblank client gua
   assert.match(preview, /Download PDF/);
   assert.match(preview, /Download DOCX/);
   assert.match(preview, /The generated file was empty/);
+});
+
+test("performance packet paginates contribution records before the fixed footer", () => {
+  assert.match(performancePages, /function ContributionPages/);
+  assert.match(performancePages, /const pages = chunk\(contributions, 4\)/);
+  assert.match(performancePages, /contribution_records\?\.length \?\? 0\) \/ 4/);
+  assert.doesNotMatch(performancePages, /contributions\.slice\(0, 8\)/);
+});
+
+test("all packet previews include a reviewer worksheet with grading corrections and feedback", () => {
+  assert.match(performancePages, /<PacketReviewerPage/);
+  assert.match(genericPages, /<PacketReviewerPage/);
+  assert.match(reviewerPage, /Overall assessment/);
+  assert.match(reviewerPage, /Corrections or factual changes/);
+  assert.match(reviewerPage, /Questions \/ clarification needed/);
+  assert.match(reviewerPage, /Recommended next steps/);
+  assert.match(reviewerPage, /Corrections are suggestions, not automatic edits/);
+  assert.match(reviewerCss, /packet-reviewer-rubric-row/);
+  assert.match(reviewerCss, /grid-template-columns: repeat\(2, minmax\(0, 1fr\)\)/);
+});
+
+test("light packet themes keep the skills callout readable", () => {
+  assert.match(platformCss, /\.packet-theme-modern-minimal \.packet-growth-callout[\s\S]*color: var\(--packet-ink\)/);
+  assert.match(platformCss, /\.packet-theme-modern-minimal \.packet-growth-callout p[\s\S]*color: var\(--packet-muted\)/);
+  assert.match(platformCss, /\.packet-theme-modern-minimal \.packet-growth-callout svg[\s\S]*color: var\(--packet-highlight\)/);
 });
 
 test("Career packets opens the dedicated catalog experience from career tools", () => {


### PR DESCRIPTION
## What changed
- Fixes the washed-out `Career-neutral by design` callout in light packet themes by restoring readable ink/muted text colors.
- Paginates Contribution & Verified Recognition records four per page so cards cannot run into the fixed footer/page boundary on iPad/tablet previews.
- Adds a reviewer worksheet to every packet preview with packet-specific grading criteria, overall assessment, feedback, factual corrections, clarification questions, and recommended next steps.
- Makes reviewer corrections explicitly advisory: they never overwrite accomplishments, Impact Receipts, evidence, or recognition automatically.
- Appends the same reviewer worksheet to downloaded PDF and DOCX packets.
- Adds backend coverage across all eight packet types to verify reviewer worksheet content is present in real PDF/DOCX exports.
- Adds frontend regression tests for contribution pagination, reviewer worksheet coverage, and light-theme callout contrast.

## Reviewer design
The worksheet is intentionally human-authored. BragStack supplies the evidence and rubric structure; the reviewer supplies the grade and comments. No automatic performance score, promotion-readiness score, admission prediction, or source-record correction is generated.