### PR TITLE
Guard staged BOASTED domain migration without changing OAuth providers

### DIFF
--- a/backend/tests/test_boasted_staged_domain_migration.py
+++ b/backend/tests/test_boasted_staged_domain_migration.py
@@ -1,0 +1,63 @@
+"""Regression guards for the staged BOASTED domain migration.
+
+The public BOASTED frontend can move to boasted.io before the OAuth provider
+callbacks move off the legacy API hostname. Keeping those two origins
+decoupled lets existing Google/GitHub OAuth registrations keep working while
+the customer-facing brand/domain changes.
+"""
+
+from fastapi import Request
+
+import app.oauth_routes as oauth_routes
+
+
+def _request() -> Request:
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "scheme": "https",
+        "path": "/auth/google/login",
+        "raw_path": b"/auth/google/login",
+        "query_string": b"",
+        "headers": [(b"host", b"internal-service")],
+        "client": ("127.0.0.1", 12345),
+        "server": ("internal-service", 443),
+    }
+    return Request(scope)
+
+
+def test_boasted_frontend_keeps_legacy_google_callback(monkeypatch):
+    monkeypatch.setattr(oauth_routes, "FRONTEND_URL", "https://boasted.io")
+    monkeypatch.setattr(
+        oauth_routes,
+        "OAUTH_CALLBACK_BASE_URL",
+        "https://api.usebragstack.com",
+    )
+
+    assert oauth_routes._redirect_uri(_request(), "google") == (
+        "https://api.usebragstack.com/auth/google/callback"
+    )
+
+
+def test_boasted_frontend_keeps_legacy_github_callback(monkeypatch):
+    monkeypatch.setattr(oauth_routes, "FRONTEND_URL", "https://boasted.io")
+    monkeypatch.setattr(
+        oauth_routes,
+        "OAUTH_CALLBACK_BASE_URL",
+        "https://api.usebragstack.com",
+    )
+
+    assert oauth_routes._redirect_uri(_request(), "github") == (
+        "https://api.usebragstack.com/auth/github/callback"
+    )
+
+
+def test_oauth_success_returns_existing_user_to_boasted(monkeypatch):
+    monkeypatch.setattr(oauth_routes, "FRONTEND_URL", "https://boasted.io")
+    monkeypatch.setattr(oauth_routes, "create_access_token", lambda _payload: "test-token")
+
+    response = oauth_routes._frontend_success_redirect({"_id": "existing-user-id"})
+
+    assert response.headers["location"] == (
+        "https://boasted.io/login#oauth_token=test-token"
+    )


### PR DESCRIPTION
## What this protects
- BOASTED frontend can move to `https://boasted.io`.
- Google and GitHub OAuth callbacks can remain on the existing legacy API origin during the transition.
- Successful OAuth returns users to BOASTED.
- Existing provider registrations/client credentials do not need to be replaced for this stage.

## Why
The OAuth implementation already separates `FRONTEND_URL` from `OAUTH_CALLBACK_BASE_URL` and resolves existing users by stable provider IDs before email. This PR adds regression coverage so that staged migration behavior does not accidentally regress.

## Intentionally not changed
- Google OAuth client/app configuration
- GitHub OAuth app configuration
- OAuth client IDs/secrets
- Existing user IDs/data
- Legacy callback hostname

This is the low-risk bridge for the BragStack → BOASTED domain migration.