### PR TITLE
Expose all 12 public profile layouts in Appearance settings

### DIFF
--- a/frontend/src/AppearanceSettingsPage.jsx
+++ b/frontend/src/AppearanceSettingsPage.jsx
@@ -1,12 +1,13 @@
-import { ArrowLeft, Palette, RotateCcw, Save } from "lucide-react";
+import { ArrowLeft, LayoutGrid, Palette, RotateCcw, Save } from "lucide-react";
 import { useEffect, useState } from "react";
 import { getCurrentUser, updateCurrentUserProfile } from "./api";
 import BragStackLoader from "./BragStackLoader.jsx";
-import { getProfileTheme, PROFILE_THEMES } from "./profileThemes";
+import { getProfileLayout, getProfileTheme, PROFILE_LAYOUTS, PROFILE_THEMES } from "./profileThemes";
 import "./ProfilePage.css";
 
 const EMPTY_APPEARANCE = {
   profile_theme: "default",
+  profile_layout: "editorial",
   profile_primary_color: "",
   profile_secondary_color: "",
   profile_background_color: "",
@@ -16,14 +17,16 @@ export default function AppearanceSettingsPage(){
   const[user,setUser]=useState(null),[form,setForm]=useState(null),[saving,setSaving]=useState(false),[error,setError]=useState("");
   useEffect(()=>{let active=true;getCurrentUser().then(u=>{if(!active)return;setUser(u);setForm({
     profile_theme:u.profile_theme||"default",
+    profile_layout:u.profile_layout||"editorial",
     profile_primary_color:u.profile_primary_color||"",
     profile_secondary_color:u.profile_secondary_color||"",
     profile_background_color:u.profile_background_color||"",
   });}).catch(()=>{if(active)setError("Appearance settings could not be loaded.");});return()=>{active=false};},[]);
-  if(!form&&!error)return <BragStackLoader compact message="Loading your appearance…" detail="Preparing your themes, colors, and public profile preview."/>;
+  if(!form&&!error)return <BragStackLoader compact message="Loading your appearance…" detail="Preparing your layouts, themes, colors, and public profile preview."/>;
   if(!form)return <main className="profile-settings"><div className="profile-loading">{error}</div></main>;
-  const theme=getProfileTheme(form.profile_theme),primary=form.profile_primary_color||theme.primary,secondary=form.profile_secondary_color||theme.secondary,background=form.profile_background_color||theme.background;
-  function choose(id){setForm(c=>({...c,profile_theme:id,profile_primary_color:"",profile_secondary_color:"",profile_background_color:""}));}
+  const theme=getProfileTheme(form.profile_theme),layout=getProfileLayout(form.profile_layout),primary=form.profile_primary_color||theme.primary,secondary=form.profile_secondary_color||theme.secondary,background=form.profile_background_color||theme.background;
+  function chooseTheme(id){setForm(c=>({...c,profile_theme:id,profile_primary_color:"",profile_secondary_color:"",profile_background_color:""}));}
+  function chooseLayout(id){setForm(c=>({...c,profile_layout:id}));}
   function change(e){setForm(c=>({...c,[e.target.name]:e.target.value}));}
   function reset(){setForm(c=>({...c,profile_primary_color:"",profile_secondary_color:"",profile_background_color:""}));}
   async function save(){
@@ -31,6 +34,7 @@ export default function AppearanceSettingsPage(){
     try{
       const saved=await updateCurrentUserProfile({...EMPTY_APPEARANCE,...form});
       if(saved.profile_theme!==form.profile_theme){throw new Error("Saved theme did not match the selected theme.");}
+      if((saved.profile_layout||"editorial")!==form.profile_layout){throw new Error("Saved layout did not match the selected profile structure.");}
       sessionStorage.setItem("bragstack_settings_notice","Profile appearance saved.");
       window.location.assign("/app/settings?saved=appearance");
     }catch(e){
@@ -39,4 +43,7 @@ export default function AppearanceSettingsPage(){
       setSaving(false);
     }
   }
-  return <main className="profile-settings"><header className="profile-settings-header"><div><a className="profile-public-link" href="/app/settings"><ArrowLeft size={16}/> Back to settings</a><p className="profile-settings-eyebrow"><Palette size={14}/> Settings</p><h1>Profile appearance</h1><p>Choose how your public Proof Profile looks. This is the only place themes and profile colors are edited.</p></div>{user?.public_slug&&<a className="profile-public-link" href={`/brag/${user.public_slug}`} target="_blank" rel="noreferrer">Preview public profile</a>}</header><section className="profile-settings-card appearance-section standalone">{error&&<div className="profile-save-error">{error}</div>}<div className="appearance-heading"><h2>Career-inspired themes</h2><p>Pick a starting style, then make it yours.</p></div><div className="theme-gallery">{PROFILE_THEMES.map(t=><button type="button" key={t.id} className={`theme-card ${form.profile_theme===t.id?"selected":""}`} onClick={()=>choose(t.id)}><span className="theme-swatch" style={{background:`linear-gradient(135deg,${t.primary},${t.secondary} 55%,${t.background} 56%)`}}/><span><strong>{t.name}</strong><small>{t.career}</small></span></button>)}</div><div className="appearance-custom"><div className="appearance-subhead"><div><h3>Your colors</h3><p>Primary, secondary, and background.</p></div><button className="reset-theme" type="button" onClick={reset}><RotateCcw size={15}/> Reset</button></div><div className="color-grid">{[["profile_primary_color","Primary",primary],["profile_secondary_color","Secondary",secondary],["profile_background_color","Background",background]].map(([name,label,value])=><label className="color-control" key={name}><span>{label}</span><div><input className="native-color" type="color" name={name} value={value} onChange={change}/><input className="hex-color" name={name} value={form[name]||value} onChange={change} pattern="#[0-9A-Fa-f]{6}" maxLength={7}/></div></label>)}</div><div className="appearance-preview" style={{background}}><span className="preview-badge" style={{color:primary,borderColor:primary}}>PROOF PROFILE</span><h3>{user?.name||"Your name"}</h3><p>{user?.headline||"Your professional headline"}</p><div className="preview-gradient" style={{background:`linear-gradient(90deg,${primary},${secondary})`}}/><button type="button" style={{background:`linear-gradient(135deg,${primary},${secondary})`}}>View proof</button></div></div><div className="profile-settings-actions"><span>Saving here updates the public Proof Profile theme and then returns you to Settings.</span><button type="button" disabled={saving} onClick={save}><Save size={17}/>{saving?"Saving…":"Save appearance"}</button></div></section></main>}
+  return <main className="profile-settings"><header className="profile-settings-header"><div><a className="profile-public-link" href="/app/settings"><ArrowLeft size={16}/> Back to settings</a><p className="profile-settings-eyebrow"><Palette size={14}/> Settings</p><h1>Profile appearance</h1><p>Choose the structure, color palette, and custom colors for your public Proof Profile.</p></div>{user?.public_slug&&<a className="profile-public-link" href={`/brag/${user.public_slug}`} target="_blank" rel="noreferrer">Preview public profile</a>}</header><section className="profile-settings-card appearance-section standalone">{error&&<div className="profile-save-error">{error}</div>}
+    <div className="appearance-heading"><h2>Public profile structure</h2><p>Choose from all 12 professional portfolio layouts. Structure changes composition; your colors stay independent.</p></div>
+    <div className="theme-gallery" data-profile-layout-gallery>{PROFILE_LAYOUTS.map((item,index)=><button type="button" key={item.id} className={`theme-card ${form.profile_layout===item.id?"selected":""}`} onClick={()=>chooseLayout(item.id)} aria-pressed={form.profile_layout===item.id}><span className="theme-swatch" style={{display:"grid",placeItems:"center",background:`linear-gradient(135deg,#0f172a ${32+(index%3)*8}%,#334155)`}}><LayoutGrid size={19}/></span><span><strong>{item.name}</strong><small>{item.description}</small></span></button>)}</div>
+    <div className="appearance-heading" style={{marginTop:28}}><h2>Career-inspired color palettes</h2><p>Pick a starting palette, then make it yours.</p></div><div className="theme-gallery">{PROFILE_THEMES.map(t=><button type="button" key={t.id} className={`theme-card ${form.profile_theme===t.id?"selected":""}`} onClick={()=>chooseTheme(t.id)}><span className="theme-swatch" style={{background:`linear-gradient(135deg,${t.primary},${t.secondary} 55%,${t.background} 56%)`}}/><span><strong>{t.name}</strong><small>{t.career}</small></span></button>)}</div><div className="appearance-custom"><div className="appearance-subhead"><div><h3>Your colors</h3><p>Primary, secondary, and background.</p></div><button className="reset-theme" type="button" onClick={reset}><RotateCcw size={15}/> Reset</button></div><div className="color-grid">{[["profile_primary_color","Primary",primary],["profile_secondary_color","Secondary",secondary],["profile_background_color","Background",background]].map(([name,label,value])=><label className="color-control" key={name}><span>{label}</span><div><input className="native-color" type="color" name={name} value={value} onChange={change}/><input className="hex-color" name={name} value={form[name]||value} onChange={change} pattern="#[0-9A-Fa-f]{6}" maxLength={7}/></div></label>)}</div><div className="appearance-preview" style={{background}}><span className="preview-badge" style={{color:primary,borderColor:primary}}>PROOF PROFILE · {layout.name.toUpperCase()}</span><h3>{user?.name||"Your name"}</h3><p>{user?.headline||"Your professional headline"}</p><div className="preview-gradient" style={{background:`linear-gradient(90deg,${primary},${secondary})`}}/><button type="button" style={{background:`linear-gradient(135deg,${primary},${secondary})`}}>View proof</button></div></div><div className="profile-settings-actions"><span>Saving here updates both the public profile structure and color theme, then returns you to Settings.</span><button type="button" disabled={saving} onClick={save}><Save size={17}/>{saving?"Saving…":"Save appearance"}</button></div></section></main>}

--- a/frontend/src/proofPortfolioSource.test.js
+++ b/frontend/src/proofPortfolioSource.test.js
@@ -58,6 +58,21 @@ test("Appearance settings are the only profile theme editor and return to Settin
   assert.doesNotMatch(profile, /profile_primary_color:form\.profile_primary_color/);
 });
 
+test("Appearance settings expose and persist all twelve public portfolio structures", () => {
+  const appearance = read("./AppearanceSettingsPage.jsx");
+  const themes = read("./profileThemes.js");
+  const publicProfile = read("./PublicBragPage.jsx");
+  const layoutBlock = themes.split("export const PROFILE_LAYOUTS = [")[1].split("];", 1)[0];
+  const ids = [...layoutBlock.matchAll(/id: "([^"]+)"/g)].map((match) => match[1]);
+  assert.equal(ids.length, 12);
+  assert.match(appearance, /PROFILE_LAYOUTS/);
+  assert.match(appearance, /data-profile-layout-gallery/);
+  assert.match(appearance, /profile_layout:u\.profile_layout\|\|"editorial"/);
+  assert.match(appearance, /profile_layout:id/);
+  assert.match(appearance, /saved\.profile_layout/);
+  assert.match(publicProfile, /data-layout=\{profile\?\.profile_layout \|\| "editorial"\}/);
+});
+
 test("Profile form persists identity fields without resubmitting appearance state", () => {
   const source = read("./ProfilePage.jsx");
   assert.match(source, /name:form\.name,headline:form\.headline,bio:form\.bio,location:form\.location/);


### PR DESCRIPTION
## Root cause
PR #334 successfully added all 12 public profile layouts, backend persistence, and layout CSS, but the selector was placed in `ProfileThemeCustomizer.jsx`, which is not mounted by the active settings flow. The actual `/app/settings/appearance` page still only exposed color themes, so users could not choose the new structures.

## Fix
- Wire `PROFILE_LAYOUTS` into the canonical Profile appearance page.
- Load and persist `profile_layout` alongside the existing color theme state.
- Show all 12 professional structures as responsive selectable cards.
- Keep structure independent from the color palette.
- Show the selected structure in the appearance preview.
- Verify the saved API response matches the selected structure before reporting success.
- Add a regression test proving exactly 12 layouts are exposed, persisted, and consumed by the public profile's `data-layout` rendering.

## Existing layout set
Editorial, Executive Sidebar, Career Timeline, Studio Split, Minimal Column, Portfolio Grid, Case Study, Modern Résumé, Command Center, Academic, Founder, Compact.