### PR TITLE
Simplify auth header to a single Return button

### DIFF
--- a/frontend/src/PublicAuthHeader.jsx
+++ b/frontend/src/PublicAuthHeader.jsx
@@ -7,29 +7,9 @@ export default function PublicAuthHeader() {
 
   if (!isRegister && !isLogin) return null;
 
-  if (isRegister) {
-    return (
-      <div className="public-auth-register-actions" aria-label="Registration shortcuts">
-        <a className="public-auth-button public-auth-button-secondary" href="/docs">Docs</a>
-        <a className="public-auth-button public-auth-button-primary" href="/">Return</a>
-      </div>
-    );
-  }
-
   return (
-    <header className="public-auth-header" aria-label="Boasted public navigation">
-      <a className="public-auth-brand" href="/">Boasted</a>
-
-      <nav className="public-auth-links" aria-label="Public site navigation">
-        <a href="/#how-it-works">How it works</a>
-        <a href="/#product">Product</a>
-        <a href="/#pricing">Pricing</a>
-      </nav>
-
-      <div className="public-auth-actions">
-        <a className="public-auth-button public-auth-button-secondary" href="/docs">Docs</a>
-        <a className="public-auth-button public-auth-button-primary" href="/register">Start free</a>
-      </div>
-    </header>
+    <div className="public-auth-register-actions" aria-label="Return to Boasted">
+      <a className="public-auth-button public-auth-button-primary" href="/">Return</a>
+    </div>
   );
 }

--- a/frontend/src/PublicAuthHeader.jsx
+++ b/frontend/src/PublicAuthHeader.jsx
@@ -7,6 +7,15 @@ export default function PublicAuthHeader() {
 
   if (!isRegister && !isLogin) return null;
 
+  if (isRegister) {
+    return (
+      <div className="public-auth-register-actions" aria-label="Registration shortcuts">
+        <a className="public-auth-button public-auth-button-secondary" href="/docs">Docs</a>
+        <a className="public-auth-button public-auth-button-primary" href="/">Return</a>
+      </div>
+    );
+  }
+
   return (
     <div className="public-auth-register-actions" aria-label="Return to Boasted">
       <a className="public-auth-button public-auth-button-primary" href="/">Return</a>


### PR DESCRIPTION
Removes the full public navigation bar from the login page and leaves only a simple Return button back to the Boasted landing page. The registration-page shortcuts are unchanged.