### PR TITLE
Audit and polish profile appearance UI

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,7 @@
     "test:resume": "node --test src/resumeStructured.test.js src/dashboardTags.test.js",
     "test:safety": "node --test src/ndaSafety.test.js src/ndaInformationGateSource.test.js src/ndaGuidanceSource.test.js src/ndaApiSource.test.js",
     "test:seo": "node --test src/proofPortfolioSource.test.js && node scripts/verify-search-appearance.mjs",
-    "test:settings": "node --test src/settingsAccountClosureSource.test.js src/settingsBackNavigationSource.test.js src/packetsPageSource.test.js",
+    "test:settings": "node --test src/settingsAccountClosureSource.test.js src/settingsBackNavigationSource.test.js src/packetsPageSource.test.js src/appearanceUiAuditSource.test.js",
     "test:clicks": "node scripts/run-click-audit.mjs",
     "test:layout": "node scripts/audit-responsive-layout.mjs",
     "test:bundle": "node scripts/verify-bundle-budget.mjs",

--- a/frontend/src/AppearanceSettingsPage.jsx
+++ b/frontend/src/AppearanceSettingsPage.jsx
@@ -1,8 +1,14 @@
-import { ArrowLeft, Palette, RotateCcw, Save } from "lucide-react";
+import { ArrowLeft, Check, Eye, Palette, RotateCcw, Save } from "lucide-react";
 import { useEffect, useState } from "react";
 import { getCurrentUser, updateCurrentUserProfile } from "./api";
 import BragStackLoader from "./BragStackLoader.jsx";
-import { getProfileLayout, getProfileTheme, PROFILE_LAYOUTS, PROFILE_THEMES } from "./profileThemes";
+import {
+  getContrastText,
+  getProfileLayout,
+  getProfileTheme,
+  PROFILE_LAYOUTS,
+  PROFILE_THEMES,
+} from "./profileThemes";
 import "./ProfilePage.css";
 import "./FlowerLayoutPreviews.css";
 
@@ -14,17 +20,9 @@ const EMPTY_APPEARANCE = {
   profile_background_color: "",
 };
 
-function FlowerLayoutMini({ id, primary, secondary, background }) {
+function FlowerLayoutMini({ id }) {
   return (
-    <span
-      className={`flower-layout-mini flower-layout-mini-${id}`}
-      style={{
-        "--preview-primary": primary,
-        "--preview-secondary": secondary,
-        "--preview-background": background,
-      }}
-      aria-hidden="true"
-    >
+    <span className={`flower-layout-mini flower-layout-mini-${id}`} aria-hidden="true">
       <i className="mini-hero" />
       <i className="mini-side" />
       <i className="mini-main" />
@@ -35,39 +33,271 @@ function FlowerLayoutMini({ id, primary, secondary, background }) {
   );
 }
 
-export default function AppearanceSettingsPage(){
-  const[user,setUser]=useState(null),[form,setForm]=useState(null),[saving,setSaving]=useState(false),[error,setError]=useState("");
-  useEffect(()=>{let active=true;getCurrentUser().then(u=>{if(!active)return;setUser(u);setForm({
-    profile_theme:u.profile_theme||"default",
-    profile_layout:u.profile_layout||"editorial",
-    profile_primary_color:u.profile_primary_color||"",
-    profile_secondary_color:u.profile_secondary_color||"",
-    profile_background_color:u.profile_background_color||"",
-  });}).catch(()=>{if(active)setError("Appearance settings could not be loaded.");});return()=>{active=false};},[]);
-  if(!form&&!error)return <BragStackLoader compact message="Loading your appearance…" detail="Preparing your flower templates, themes, colors, and public profile preview."/>;
-  if(!form)return <main className="profile-settings"><div className="profile-loading">{error}</div></main>;
-  const theme=getProfileTheme(form.profile_theme),layout=getProfileLayout(form.profile_layout),primary=form.profile_primary_color||theme.primary,secondary=form.profile_secondary_color||theme.secondary,background=form.profile_background_color||theme.background;
-  const previewQuery=new URLSearchParams({appearancePreview:"1",layout:form.profile_layout,theme:form.profile_theme,primary,secondary,background}).toString();
-  const previewHref=user?.public_slug?`/brag/${user.public_slug}?${previewQuery}`:"";
-  function chooseTheme(id){setForm(c=>({...c,profile_theme:id,profile_primary_color:"",profile_secondary_color:"",profile_background_color:""}));}
-  function chooseLayout(id){setForm(c=>({...c,profile_layout:id}));}
-  function change(e){setForm(c=>({...c,[e.target.name]:e.target.value}));}
-  function reset(){setForm(c=>({...c,profile_primary_color:"",profile_secondary_color:"",profile_background_color:""}));}
-  async function save(){
-    setSaving(true);setError("");
-    try{
-      const saved=await updateCurrentUserProfile({...EMPTY_APPEARANCE,...form});
-      if(saved.profile_theme!==form.profile_theme){throw new Error("Saved theme did not match the selected theme.");}
-      if((saved.profile_layout||"editorial")!==form.profile_layout){throw new Error("Saved layout did not match the selected profile structure.");}
-      sessionStorage.setItem("bragstack_settings_notice","Profile appearance saved.");
+export default function AppearanceSettingsPage() {
+  const [user, setUser] = useState(null);
+  const [form, setForm] = useState(null);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    let active = true;
+    getCurrentUser()
+      .then((u) => {
+        if (!active) return;
+        setUser(u);
+        setForm({
+          profile_theme: u.profile_theme || "default",
+          profile_layout: u.profile_layout || "editorial",
+          profile_primary_color: u.profile_primary_color || "",
+          profile_secondary_color: u.profile_secondary_color || "",
+          profile_background_color: u.profile_background_color || "",
+        });
+      })
+      .catch(() => {
+        if (active) setError("Appearance settings could not be loaded.");
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  if (!form && !error) {
+    return (
+      <BragStackLoader
+        compact
+        message="Loading your appearance…"
+        detail="Preparing your flower templates, themes, colors, and public profile preview."
+      />
+    );
+  }
+
+  if (!form) {
+    return (
+      <main className="profile-settings appearance-settings-page">
+        <div className="profile-loading" role="alert">{error}</div>
+      </main>
+    );
+  }
+
+  const theme = getProfileTheme(form.profile_theme);
+  const layout = getProfileLayout(form.profile_layout);
+  const primary = form.profile_primary_color || theme.primary;
+  const secondary = form.profile_secondary_color || theme.secondary;
+  const background = form.profile_background_color || theme.background;
+  const previewText = getContrastText(background);
+  const previewButtonText = getContrastText(primary);
+  const previewQuery = new URLSearchParams({
+    appearancePreview: "1",
+    layout: form.profile_layout,
+    theme: form.profile_theme,
+    primary,
+    secondary,
+    background,
+  }).toString();
+  const previewHref = user?.public_slug ? `/brag/${user.public_slug}?${previewQuery}` : "";
+
+  function chooseTheme(id) {
+    setForm((current) => ({
+      ...current,
+      profile_theme: id,
+      profile_primary_color: "",
+      profile_secondary_color: "",
+      profile_background_color: "",
+    }));
+  }
+
+  function chooseLayout(id) {
+    setForm((current) => ({ ...current, profile_layout: id }));
+  }
+
+  function change(event) {
+    setForm((current) => ({ ...current, [event.target.name]: event.target.value }));
+  }
+
+  function reset() {
+    setForm((current) => ({
+      ...current,
+      profile_primary_color: "",
+      profile_secondary_color: "",
+      profile_background_color: "",
+    }));
+  }
+
+  async function save() {
+    setSaving(true);
+    setError("");
+    try {
+      const saved = await updateCurrentUserProfile({ ...EMPTY_APPEARANCE, ...form });
+      if (saved.profile_theme !== form.profile_theme) {
+        throw new Error("Saved theme did not match the selected theme.");
+      }
+      if ((saved.profile_layout || "editorial") !== form.profile_layout) {
+        throw new Error("Saved layout did not match the selected profile structure.");
+      }
+      sessionStorage.setItem("bragstack_settings_notice", "Profile appearance saved.");
       window.location.assign("/app/settings?saved=appearance");
-    }catch(e){
-      const detail=e.response?.data?.detail;
-      setError(typeof detail==="string"?detail:e.message||"Appearance could not be saved.");
+    } catch (saveError) {
+      const detail = saveError.response?.data?.detail;
+      setError(typeof detail === "string" ? detail : saveError.message || "Appearance could not be saved.");
       setSaving(false);
     }
   }
-  return <main className="profile-settings"><header className="profile-settings-header"><div><a className="profile-public-link" href="/app/settings"><ArrowLeft size={16}/> Back to settings</a><p className="profile-settings-eyebrow"><Palette size={14}/> Settings</p><h1>Profile appearance</h1><p>Choose one of 12 distinct flower templates, then customize its color palette for your public Proof Profile.</p></div>{previewHref&&<a className="profile-public-link" href={previewHref}>Preview selected design</a>}</header><section className="profile-settings-card appearance-section standalone">{error&&<div className="profile-save-error">{error}</div>}
-    <div className="appearance-heading"><h2>Flower profile templates</h2><p>Each flower changes the actual composition, hierarchy, spacing, card treatment, and responsive behavior. Your selected theme colors flow into every template preview.</p></div>
-    <div className="theme-gallery flower-layout-gallery" data-profile-layout-gallery>{PROFILE_LAYOUTS.map(item=><button type="button" key={item.id} className={`theme-card flower-layout-card ${form.profile_layout===item.id?"selected":""}`} onClick={()=>chooseLayout(item.id)} aria-pressed={form.profile_layout===item.id}><FlowerLayoutMini id={item.id} primary={primary} secondary={secondary} background={background}/><span><strong>{item.name}</strong><small>{item.description}</small></span></button>)}</div>
-    <div className="appearance-heading" style={{marginTop:28}}><h2>Career-inspired color palettes</h2><p>Pick a starting palette, then make it yours.</p></div><div className="theme-gallery">{PROFILE_THEMES.map(t=><button type="button" key={t.id} className={`theme-card ${form.profile_theme===t.id?"selected":""}`} onClick={()=>chooseTheme(t.id)}><span className="theme-swatch" style={{background:`linear-gradient(135deg,${t.primary},${t.secondary} 55%,${t.background} 56%)`}}/><span><strong>{t.name}</strong><small>{t.career}</small></span></button>)}</div><div className="appearance-custom"><div className="appearance-subhead"><div><h3>Your colors</h3><p>Primary, secondary, and background.</p></div><button className="reset-theme" type="button" onClick={reset}><RotateCcw size={15}/> Reset</button></div><div className="color-grid">{[["profile_primary_color","Primary",primary],["profile_secondary_color","Secondary",secondary],["profile_background_color","Background",background]].map(([name,label,value])=><label className="color-control" key={name}><span>{label}</span><div><input className="native-color" type="color" name={name} value={value} onChange={change}/><input className="hex-color" name={name} value={form[name]||value} onChange={change} pattern="#[0-9A-Fa-f]{6}" maxLength={7}/></div></label>)}</div><div className="appearance-preview" style={{background}}><span className="preview-badge" style={{color:primary,borderColor:primary}}>FLOWER TEMPLATE · {layout.name.toUpperCase()}</span><h3>{user?.name||"Your name"}</h3><p>{user?.headline||"Your professional headline"}</p><div className="preview-gradient" style={{background:`linear-gradient(90deg,${primary},${secondary})`}}/><a href={previewHref||"#"} style={{display:"inline-flex",alignItems:"center",minHeight:40,padding:"0 14px",borderRadius:10,background:`linear-gradient(135deg,${primary},${secondary})`,color:"white",fontWeight:900,textDecoration:"none"}}>Open full preview</a></div></div><div className="profile-settings-actions"><span>Saving here updates both the flower template and color theme, then returns you to Settings.</span><button type="button" disabled={saving} onClick={save}><Save size={17}/>{saving?"Saving…":"Save appearance"}</button></div></section></main>}
+
+  return (
+    <main className="profile-settings appearance-settings-page">
+      <header className="profile-settings-header appearance-settings-header">
+        <div>
+          <a className="profile-public-link" href="/app/settings">
+            <ArrowLeft size={16} /> Back to settings
+          </a>
+          <p className="profile-settings-eyebrow"><Palette size={14} /> Settings</p>
+          <h1>Profile appearance</h1>
+          <p>Choose a flower layout, then apply a color palette. Layout and color stay independent so you can mix any template with any theme.</p>
+        </div>
+        {previewHref && (
+          <a className="appearance-preview-link" href={previewHref}>
+            <Eye size={17} /> Preview selected design
+          </a>
+        )}
+      </header>
+
+      <section className="profile-settings-card appearance-section standalone">
+        {error && <div className="profile-save-error" role="alert">{error}</div>}
+
+        <div className="appearance-heading appearance-audit-heading">
+          <p className="appearance-step">01 · Choose a layout</p>
+          <h2>Flower profile templates</h2>
+          <p>These are full-page layout previews, not decorative icons. Pick the structure that best fits how you want your work to be scanned.</p>
+        </div>
+
+        <div className="theme-gallery flower-layout-gallery" data-profile-layout-gallery>
+          {PROFILE_LAYOUTS.map((item) => {
+            const selected = form.profile_layout === item.id;
+            return (
+              <button
+                type="button"
+                key={item.id}
+                className={`theme-card flower-layout-card ${selected ? "selected" : ""}`}
+                onClick={() => chooseLayout(item.id)}
+                aria-pressed={selected}
+                aria-label={`${item.name}. ${item.description}${selected ? ". Selected" : ""}`}
+                style={{
+                  "--preview-primary": primary,
+                  "--preview-secondary": secondary,
+                  "--preview-background": background,
+                }}
+              >
+                <FlowerLayoutMini id={item.id} />
+                <span className="flower-layout-card-copy">
+                  <span className="flower-layout-title-row">
+                    <strong>{item.name}</strong>
+                    {selected && (
+                      <span className="flower-layout-selected" aria-hidden="true">
+                        <Check size={13} /> Selected
+                      </span>
+                    )}
+                  </span>
+                  <small>{item.description}</small>
+                </span>
+              </button>
+            );
+          })}
+        </div>
+
+        <div className="appearance-heading appearance-audit-heading appearance-audit-section">
+          <p className="appearance-step">02 · Choose colors</p>
+          <h2>Career-inspired color palettes</h2>
+          <p>Pick a starting palette, then fine-tune the three colors below.</p>
+        </div>
+
+        <div className="theme-gallery appearance-theme-gallery">
+          {PROFILE_THEMES.map((item) => {
+            const selected = form.profile_theme === item.id;
+            return (
+              <button
+                type="button"
+                key={item.id}
+                className={`theme-card ${selected ? "selected" : ""}`}
+                onClick={() => chooseTheme(item.id)}
+                aria-pressed={selected}
+              >
+                <span
+                  className="theme-swatch"
+                  style={{ background: `linear-gradient(135deg,${item.primary},${item.secondary} 55%,${item.background} 56%)` }}
+                  aria-hidden="true"
+                />
+                <span>
+                  <strong>{item.name}</strong>
+                  <small>{item.career}</small>
+                </span>
+              </button>
+            );
+          })}
+        </div>
+
+        <div className="appearance-custom">
+          <div className="appearance-subhead">
+            <div>
+              <p className="appearance-step">03 · Fine-tune & preview</p>
+              <h3>Your colors</h3>
+              <p>Primary, secondary, and background. The preview updates immediately.</p>
+            </div>
+            <button className="reset-theme" type="button" onClick={reset}>
+              <RotateCcw size={15} /> Reset colors
+            </button>
+          </div>
+
+          <div className="color-grid">
+            {[
+              ["profile_primary_color", "Primary", primary],
+              ["profile_secondary_color", "Secondary", secondary],
+              ["profile_background_color", "Background", background],
+            ].map(([name, label, value]) => (
+              <label className="color-control" key={name}>
+                <span>{label}</span>
+                <div>
+                  <input className="native-color" type="color" name={name} value={value} onChange={change} />
+                  <input
+                    className="hex-color"
+                    name={name}
+                    value={form[name] || value}
+                    onChange={change}
+                    pattern="#[0-9A-Fa-f]{6}"
+                    maxLength={7}
+                    aria-label={`${label} hex color`}
+                  />
+                </div>
+              </label>
+            ))}
+          </div>
+
+          <div className="appearance-preview" style={{ background, color: previewText }}>
+            <span className="preview-badge" style={{ color: previewText, borderColor: primary }}>
+              {layout.name.toUpperCase()} · LIVE PREVIEW
+            </span>
+            <h3>{user?.name || "Your name"}</h3>
+            <p style={{ color: previewText, opacity: 0.78 }}>{user?.headline || "Your professional headline"}</p>
+            <div className="preview-gradient" style={{ background: `linear-gradient(90deg,${primary},${secondary})` }} />
+            <a
+              className="appearance-open-preview"
+              href={previewHref || "#"}
+              style={{
+                background: `linear-gradient(135deg,${primary},${secondary})`,
+                color: previewButtonText,
+              }}
+            >
+              <Eye size={16} /> Open full preview
+            </a>
+          </div>
+        </div>
+
+        <div className="profile-settings-actions appearance-save-actions">
+          <span>Nothing changes publicly until you save.</span>
+          <button type="button" disabled={saving} onClick={save}>
+            <Save size={17} /> {saving ? "Saving…" : "Save appearance"}
+          </button>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/frontend/src/AppearanceSettingsPage.jsx
+++ b/frontend/src/AppearanceSettingsPage.jsx
@@ -47,7 +47,7 @@ export default function AppearanceSettingsPage() {
         setUser(u);
         setForm({
           profile_theme: u.profile_theme || "default",
-          profile_layout: u.profile_layout || "editorial",
+          profile_layout:u.profile_layout||"editorial",
           profile_primary_color: u.profile_primary_color || "",
           profile_secondary_color: u.profile_secondary_color || "",
           profile_background_color: u.profile_background_color || "",
@@ -107,7 +107,7 @@ export default function AppearanceSettingsPage() {
   }
 
   function chooseLayout(id) {
-    setForm((current) => ({ ...current, profile_layout: id }));
+    setForm((current) => ({ ...current, profile_layout:id }));
   }
 
   function change(event) {

--- a/frontend/src/FlowerLayoutPreviews.css
+++ b/frontend/src/FlowerLayoutPreviews.css
@@ -1,14 +1,123 @@
-.flower-layout-gallery{grid-template-columns:repeat(3,minmax(0,1fr));gap:14px}.flower-layout-card{min-height:126px;display:grid;grid-template-columns:104px minmax(0,1fr);align-items:start;gap:12px;padding:12px}.flower-layout-card>span:last-child{align-self:start;padding-top:2px}.flower-layout-card strong{font-size:.92rem;white-space:normal}.flower-layout-card small{margin-top:5px;white-space:normal;line-height:1.35}.flower-layout-mini{position:relative;display:block;width:104px;height:82px;border:1px solid color-mix(in srgb,var(--preview-primary,#7dd3fc) 30%,transparent);border-radius:12px;background:var(--preview-background,#050816);overflow:hidden;box-shadow:inset 0 0 0 1px rgba(255,255,255,.04)}.flower-layout-mini i{position:absolute;display:block;border-radius:3px;background:color-mix(in srgb,var(--preview-primary,#7dd3fc) 22%,#ffffff)}.flower-layout-mini .mini-hero{background:linear-gradient(135deg,var(--preview-primary,#7dd3fc),var(--preview-secondary,#c4b5fd))}.flower-layout-mini .mini-side{background:color-mix(in srgb,var(--preview-primary,#7dd3fc) 38%,var(--preview-background,#050816))}.flower-layout-mini .mini-main{background:color-mix(in srgb,var(--preview-secondary,#c4b5fd) 60%,#ffffff)}.flower-layout-mini .mini-card{background:color-mix(in srgb,var(--preview-background,#050816) 72%,#ffffff)}
-.flower-layout-mini-editorial .mini-hero{left:8px;top:8px;width:58px;height:12px}.flower-layout-mini-editorial .mini-side{right:8px;top:8px;width:22px;height:30px}.flower-layout-mini-editorial .mini-main{left:8px;top:26px;width:58px;height:4px}.flower-layout-mini-editorial .mini-card-one{left:8px;top:40px;width:38px;height:30px}.flower-layout-mini-editorial .mini-card-two{left:50px;top:40px;width:42px;height:13px}.flower-layout-mini-editorial .mini-card-three{left:50px;top:57px;width:42px;height:13px}
-.flower-layout-mini-executive-sidebar .mini-side{left:0;top:0;width:30px;height:82px;border-radius:0}.flower-layout-mini-executive-sidebar .mini-hero{left:7px;top:8px;width:16px;height:16px;border-radius:50%}.flower-layout-mini-executive-sidebar .mini-main{left:38px;top:8px;width:56px;height:8px}.flower-layout-mini-executive-sidebar .mini-card-one{left:38px;top:23px;width:56px;height:18px}.flower-layout-mini-executive-sidebar .mini-card-two{left:38px;top:47px;width:56px;height:8px}.flower-layout-mini-executive-sidebar .mini-card-three{left:38px;top:61px;width:56px;height:8px}
-.flower-layout-mini-career-timeline .mini-main{left:20px;top:10px;width:4px;height:62px;border-radius:999px}.flower-layout-mini-career-timeline .mini-hero{left:8px;top:8px;width:26px;height:10px}.flower-layout-mini-career-timeline .mini-card-one{left:34px;top:25px;width:58px;height:12px}.flower-layout-mini-career-timeline .mini-card-two{left:34px;top:43px;width:48px;height:12px}.flower-layout-mini-career-timeline .mini-card-three{left:34px;top:61px;width:58px;height:9px}.flower-layout-mini-career-timeline .mini-side{left:15px;top:29px;width:14px;height:14px;border-radius:50%}
-.flower-layout-mini-studio-split .mini-hero{left:0;top:0;width:52px;height:46px;border-radius:0}.flower-layout-mini-studio-split .mini-side{right:0;top:0;width:52px;height:46px;border-radius:0}.flower-layout-mini-studio-split .mini-main{left:8px;top:54px;width:42px;height:20px}.flower-layout-mini-studio-split .mini-card-one{left:56px;top:54px;width:17px;height:20px}.flower-layout-mini-studio-split .mini-card-two{left:77px;top:54px;width:17px;height:20px}.flower-layout-mini-studio-split .mini-card-three{display:none}
-.flower-layout-mini-minimal-column .mini-hero{left:31px;top:10px;width:42px;height:10px}.flower-layout-mini-minimal-column .mini-main{left:25px;top:27px;width:54px;height:4px}.flower-layout-mini-minimal-column .mini-card-one{left:25px;top:40px;width:54px;height:8px}.flower-layout-mini-minimal-column .mini-card-two{left:25px;top:54px;width:54px;height:8px}.flower-layout-mini-minimal-column .mini-card-three{left:25px;top:68px;width:54px;height:4px}.flower-layout-mini-minimal-column .mini-side{display:none}
-.flower-layout-mini-portfolio-grid .mini-hero{left:8px;top:8px;width:88px;height:12px}.flower-layout-mini-portfolio-grid .mini-main{left:8px;top:28px;width:56px;height:46px}.flower-layout-mini-portfolio-grid .mini-card-one{right:8px;top:28px;width:24px;height:20px}.flower-layout-mini-portfolio-grid .mini-card-two{right:8px;top:54px;width:24px;height:20px}.flower-layout-mini-portfolio-grid .mini-card-three{display:none}
-.flower-layout-mini-case-study .mini-hero{left:8px;top:8px;width:88px;height:16px}.flower-layout-mini-case-study .mini-main{left:8px;top:32px;width:88px;height:8px}.flower-layout-mini-case-study .mini-card-one{left:8px;top:48px;width:88px;height:26px}.flower-layout-mini-case-study .mini-card-two,.flower-layout-mini-case-study .mini-card-three,.flower-layout-mini-case-study .mini-side{display:none}
-.flower-layout-mini-modern-resume .mini-side{left:8px;top:8px;width:26px;height:66px}.flower-layout-mini-modern-resume .mini-hero{left:42px;top:8px;width:54px;height:10px}.flower-layout-mini-modern-resume .mini-main{left:42px;top:25px;width:54px;height:5px}.flower-layout-mini-modern-resume .mini-card-one{left:42px;top:38px;width:54px;height:13px}.flower-layout-mini-modern-resume .mini-card-two{left:42px;top:57px;width:54px;height:17px}.flower-layout-mini-modern-resume .mini-card-three{display:none}
-.flower-layout-mini-command-center .mini-hero{left:6px;top:6px;width:92px;height:12px}.flower-layout-mini-command-center .mini-main{left:6px;top:25px;width:28px;height:21px}.flower-layout-mini-command-center .mini-side{left:38px;top:25px;width:28px;height:21px}.flower-layout-mini-command-center .mini-card-one{left:70px;top:25px;width:28px;height:21px}.flower-layout-mini-command-center .mini-card-two{left:6px;top:52px;width:44px;height:22px}.flower-layout-mini-command-center .mini-card-three{right:6px;top:52px;width:44px;height:22px}
-.flower-layout-mini-academic .mini-hero{left:8px;top:8px;width:62px;height:9px}.flower-layout-mini-academic .mini-side{right:8px;top:8px;width:20px;height:9px}.flower-layout-mini-academic .mini-main{left:8px;top:25px;width:88px;height:2px}.flower-layout-mini-academic .mini-card-one{left:8px;top:34px;width:88px;height:8px}.flower-layout-mini-academic .mini-card-two{left:8px;top:49px;width:76px;height:8px}.flower-layout-mini-academic .mini-card-three{left:8px;top:64px;width:84px;height:7px}
-.flower-layout-mini-founder .mini-hero{left:6px;top:6px;width:92px;height:34px}.flower-layout-mini-founder .mini-main{left:8px;top:49px;width:27px;height:25px}.flower-layout-mini-founder .mini-card-one{left:39px;top:49px;width:27px;height:25px}.flower-layout-mini-founder .mini-card-two{left:70px;top:49px;width:26px;height:25px}.flower-layout-mini-founder .mini-side,.flower-layout-mini-founder .mini-card-three{display:none}
-.flower-layout-mini-compact .mini-side{left:8px;top:8px;width:28px;height:66px}.flower-layout-mini-compact .mini-hero{left:44px;top:8px;width:52px;height:12px}.flower-layout-mini-compact .mini-main{left:44px;top:29px;width:52px;height:12px}.flower-layout-mini-compact .mini-card-one{left:44px;top:50px;width:22px;height:24px}.flower-layout-mini-compact .mini-card-two{right:8px;top:50px;width:22px;height:24px}.flower-layout-mini-compact .mini-card-three{display:none}
-@media(max-width:900px){.flower-layout-gallery{grid-template-columns:repeat(2,minmax(0,1fr))}}@media(max-width:620px){.flower-layout-gallery{grid-template-columns:1fr}.flower-layout-card{grid-template-columns:116px minmax(0,1fr);min-height:118px}.flower-layout-mini{width:116px;height:86px}}@media(max-width:390px){.flower-layout-card{grid-template-columns:1fr}.flower-layout-mini{width:100%;height:76px}.flower-layout-card small{font-size:.74rem}}
+.appearance-settings-page{width:min(1120px,calc(100% - 48px))}
+.appearance-settings-header{align-items:flex-start}
+.appearance-preview-link,.appearance-open-preview{display:inline-flex;align-items:center;justify-content:center;gap:8px;min-height:44px;padding:0 15px;border:1px solid rgba(148,163,184,.22);border-radius:12px;background:#101722;color:#eef4ff;text-decoration:none;font-weight:900}
+.appearance-preview-link:hover,.appearance-open-preview:hover{filter:brightness(1.06)}
+.appearance-step{margin:0 0 8px;color:#8ea3ff!important;font-size:.68rem!important;font-weight:900;letter-spacing:.14em;text-transform:uppercase}
+.appearance-audit-heading p:last-child{max-width:780px}
+.appearance-audit-section{margin-top:36px;padding-top:30px;border-top:1px solid rgba(148,163,184,.12)}
+
+.appearance-settings-page .flower-layout-gallery{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:16px;margin-top:20px}
+.appearance-settings-page .flower-layout-card{min-height:228px;display:grid;grid-template-rows:auto 1fr;align-content:start;align-items:stretch;gap:12px;padding:14px;border-radius:18px;background:linear-gradient(180deg,#0a0f17,#090d14);transition:border-color .16s ease,box-shadow .16s ease,transform .16s ease}
+.appearance-settings-page .flower-layout-card.selected{border-color:var(--preview-primary,#8b9cff);box-shadow:0 0 0 3px color-mix(in srgb,var(--preview-primary,#8b9cff) 18%,transparent)}
+.appearance-settings-page .flower-layout-card-copy{display:grid;gap:7px;min-width:0;padding:0 2px 2px}
+.appearance-settings-page .flower-layout-title-row{display:flex;align-items:center;justify-content:space-between;gap:10px}
+.appearance-settings-page .flower-layout-card strong{font-size:.96rem;line-height:1.2;white-space:normal;overflow:visible;text-overflow:clip}
+.appearance-settings-page .flower-layout-card small{margin:0;color:#91a0b7;font-size:.76rem;line-height:1.45;white-space:normal;overflow:visible;text-overflow:clip}
+.flower-layout-selected{display:inline-flex;align-items:center;gap:4px;flex:0 0 auto;padding:4px 7px;border:1px solid color-mix(in srgb,var(--preview-primary,#8b9cff) 38%,transparent);border-radius:999px;background:color-mix(in srgb,var(--preview-primary,#8b9cff) 10%,transparent);color:#dfe8ff;font-size:.62rem;font-weight:900;letter-spacing:.02em}
+
+.flower-layout-mini{position:relative;display:block;width:100%;aspect-ratio:16/9;min-height:0;border:1px solid color-mix(in srgb,var(--preview-primary,#7dd3fc) 28%,transparent);border-radius:12px;background:linear-gradient(180deg,color-mix(in srgb,var(--preview-background,#050816) 93%,white 4%),var(--preview-background,#050816));overflow:hidden;box-shadow:inset 0 0 0 1px rgba(255,255,255,.035)}
+.flower-layout-mini::before{content:"";position:absolute;inset:0 0 auto 0;height:9%;background:color-mix(in srgb,var(--preview-background,#050816) 76%,white 10%);border-bottom:1px solid rgba(255,255,255,.06)}
+.flower-layout-mini::after{content:"";position:absolute;left:3.5%;top:3.1%;width:2.2%;aspect-ratio:1;border-radius:50%;background:var(--preview-primary,#7dd3fc);box-shadow:5px 0 0 color-mix(in srgb,var(--preview-secondary,#c4b5fd) 75%,#fff),10px 0 0 rgba(255,255,255,.28)}
+.flower-layout-mini i{position:absolute;display:block;border-radius:4px;background:color-mix(in srgb,var(--preview-primary,#7dd3fc) 22%,#fff)}
+.flower-layout-mini .mini-hero{background:linear-gradient(135deg,var(--preview-primary,#7dd3fc),var(--preview-secondary,#c4b5fd))}
+.flower-layout-mini .mini-side{background:color-mix(in srgb,var(--preview-primary,#7dd3fc) 32%,var(--preview-background,#050816))}
+.flower-layout-mini .mini-main{background:color-mix(in srgb,var(--preview-secondary,#c4b5fd) 62%,#fff)}
+.flower-layout-mini .mini-card{background:color-mix(in srgb,var(--preview-background,#050816) 68%,#fff)}
+
+.flower-layout-mini-editorial .mini-hero{left:6%;top:18%;width:55%;height:14%}
+.flower-layout-mini-editorial .mini-side{right:6%;top:18%;width:24%;height:34%}
+.flower-layout-mini-editorial .mini-main{left:6%;top:37%;width:55%;height:4%}
+.flower-layout-mini-editorial .mini-card-one{left:6%;bottom:8%;width:39%;height:34%}
+.flower-layout-mini-editorial .mini-card-two{left:49%;top:57%;width:45%;height:13%}
+.flower-layout-mini-editorial .mini-card-three{left:49%;bottom:8%;width:45%;height:13%}
+
+.flower-layout-mini-executive-sidebar .mini-side{left:0;top:9%;width:29%;height:91%;border-radius:0}
+.flower-layout-mini-executive-sidebar .mini-hero{left:8%;top:19%;width:13%;aspect-ratio:1;height:auto;border-radius:50%}
+.flower-layout-mini-executive-sidebar .mini-main{left:36%;top:18%;width:56%;height:8%}
+.flower-layout-mini-executive-sidebar .mini-card-one{left:36%;top:33%;width:56%;height:22%}
+.flower-layout-mini-executive-sidebar .mini-card-two{left:36%;top:62%;width:56%;height:8%}
+.flower-layout-mini-executive-sidebar .mini-card-three{left:36%;top:77%;width:56%;height:8%}
+
+.flower-layout-mini-career-timeline .mini-main{left:49%;top:18%;width:2%;height:70%;border-radius:999px}
+.flower-layout-mini-career-timeline .mini-hero{left:6%;top:17%;width:28%;height:10%}
+.flower-layout-mini-career-timeline .mini-side{left:45.5%;top:34%;width:9%;aspect-ratio:1;height:auto;border-radius:50%}
+.flower-layout-mini-career-timeline .mini-card-one{left:56%;top:28%;width:36%;height:14%}
+.flower-layout-mini-career-timeline .mini-card-two{left:8%;top:49%;width:35%;height:14%}
+.flower-layout-mini-career-timeline .mini-card-three{left:56%;top:70%;width:36%;height:12%}
+
+.flower-layout-mini-studio-split .mini-hero{left:0;top:9%;width:50%;height:52%;border-radius:0}
+.flower-layout-mini-studio-split .mini-side{right:0;top:9%;width:50%;height:52%;border-radius:0}
+.flower-layout-mini-studio-split .mini-main{left:6%;bottom:8%;width:42%;height:22%}
+.flower-layout-mini-studio-split .mini-card-one{left:54%;bottom:8%;width:18%;height:22%}
+.flower-layout-mini-studio-split .mini-card-two{right:6%;bottom:8%;width:18%;height:22%}
+.flower-layout-mini-studio-split .mini-card-three{display:none}
+
+.flower-layout-mini-minimal-column .mini-hero{left:34%;top:19%;width:32%;height:10%}
+.flower-layout-mini-minimal-column .mini-main{left:29%;top:37%;width:42%;height:4%}
+.flower-layout-mini-minimal-column .mini-card-one{left:29%;top:50%;width:42%;height:8%}
+.flower-layout-mini-minimal-column .mini-card-two{left:29%;top:64%;width:42%;height:8%}
+.flower-layout-mini-minimal-column .mini-card-three{left:29%;top:79%;width:42%;height:4%}
+.flower-layout-mini-minimal-column .mini-side{display:none}
+
+.flower-layout-mini-portfolio-grid .mini-hero{left:6%;top:17%;width:88%;height:11%}
+.flower-layout-mini-portfolio-grid .mini-main{left:6%;top:35%;width:55%;height:53%}
+.flower-layout-mini-portfolio-grid .mini-card-one{right:6%;top:35%;width:27%;height:23%}
+.flower-layout-mini-portfolio-grid .mini-card-two{right:6%;bottom:12%;width:27%;height:23%}
+.flower-layout-mini-portfolio-grid .mini-card-three{display:none}
+
+.flower-layout-mini-case-study .mini-hero{left:6%;top:17%;width:88%;height:15%}
+.flower-layout-mini-case-study .mini-main{left:6%;top:40%;width:88%;height:8%}
+.flower-layout-mini-case-study .mini-card-one{left:6%;top:57%;width:88%;height:29%}
+.flower-layout-mini-case-study .mini-card-two,.flower-layout-mini-case-study .mini-card-three,.flower-layout-mini-case-study .mini-side{display:none}
+
+.flower-layout-mini-modern-resume .mini-hero{left:6%;top:17%;width:88%;height:10%}
+.flower-layout-mini-modern-resume .mini-side{left:6%;top:34%;width:25%;height:54%}
+.flower-layout-mini-modern-resume .mini-main{left:38%;top:34%;width:56%;height:5%}
+.flower-layout-mini-modern-resume .mini-card-one{left:38%;top:47%;width:56%;height:16%}
+.flower-layout-mini-modern-resume .mini-card-two{left:38%;top:70%;width:56%;height:18%}
+.flower-layout-mini-modern-resume .mini-card-three{display:none}
+
+.flower-layout-mini-command-center .mini-hero{left:5%;top:16%;width:90%;height:11%}
+.flower-layout-mini-command-center .mini-main{left:5%;top:35%;width:28%;height:22%}
+.flower-layout-mini-command-center .mini-side{left:36%;top:35%;width:28%;height:22%}
+.flower-layout-mini-command-center .mini-card-one{right:5%;top:35%;width:28%;height:22%}
+.flower-layout-mini-command-center .mini-card-two{left:5%;bottom:9%;width:43%;height:23%}
+.flower-layout-mini-command-center .mini-card-three{right:5%;bottom:9%;width:43%;height:23%}
+
+.flower-layout-mini-academic .mini-hero{left:6%;top:17%;width:58%;height:8%}
+.flower-layout-mini-academic .mini-side{right:6%;top:17%;width:18%;height:8%}
+.flower-layout-mini-academic .mini-main{left:6%;top:34%;width:88%;height:2%}
+.flower-layout-mini-academic .mini-card-one{left:6%;top:44%;width:88%;height:8%}
+.flower-layout-mini-academic .mini-card-two{left:6%;top:61%;width:72%;height:8%}
+.flower-layout-mini-academic .mini-card-three{left:6%;top:78%;width:82%;height:7%}
+
+.flower-layout-mini-founder .mini-hero{left:5%;top:16%;width:90%;height:36%}
+.flower-layout-mini-founder .mini-main{left:6%;bottom:10%;width:27%;height:24%}
+.flower-layout-mini-founder .mini-card-one{left:36.5%;bottom:10%;width:27%;height:24%}
+.flower-layout-mini-founder .mini-card-two{right:6%;bottom:10%;width:27%;height:24%}
+.flower-layout-mini-founder .mini-side,.flower-layout-mini-founder .mini-card-three{display:none}
+
+.flower-layout-mini-compact .mini-side{left:8%;top:18%;width:26%;height:68%}
+.flower-layout-mini-compact .mini-hero{left:41%;top:18%;width:51%;height:12%}
+.flower-layout-mini-compact .mini-main{left:41%;top:40%;width:51%;height:12%}
+.flower-layout-mini-compact .mini-card-one{left:41%;bottom:13%;width:22%;height:24%}
+.flower-layout-mini-compact .mini-card-two{right:8%;bottom:13%;width:22%;height:24%}
+.flower-layout-mini-compact .mini-card-three{display:none}
+
+.appearance-settings-page .appearance-theme-gallery{grid-template-columns:repeat(4,minmax(0,1fr));gap:12px}
+.appearance-settings-page .appearance-theme-gallery .theme-card{min-height:64px;padding:11px 12px}
+.appearance-settings-page .appearance-theme-gallery .theme-card strong,.appearance-settings-page .appearance-theme-gallery .theme-card small{white-space:normal;overflow:visible;text-overflow:clip}
+.appearance-settings-page .appearance-theme-gallery .theme-card small{line-height:1.3}
+.appearance-settings-page .appearance-custom{margin-top:28px;padding:22px}
+.appearance-settings-page .appearance-preview{display:grid;gap:4px;min-height:180px;align-content:center;padding:24px}
+.appearance-settings-page .appearance-preview h3{margin:10px 0 3px}
+.appearance-settings-page .appearance-open-preview{width:max-content;margin-top:6px;border:0}
+.appearance-settings-page .appearance-save-actions{position:sticky;bottom:12px;z-index:8;margin:28px -8px -8px;padding:16px;border:1px solid rgba(148,163,184,.14);border-radius:16px;background:rgba(9,13,20,.92);backdrop-filter:blur(16px);-webkit-backdrop-filter:blur(16px)}
+
+.appearance-settings-page .theme-card:focus-visible,.appearance-settings-page .appearance-preview-link:focus-visible,.appearance-settings-page .appearance-open-preview:focus-visible,.appearance-settings-page .reset-theme:focus-visible,.appearance-settings-page .profile-settings-actions button:focus-visible,.appearance-settings-page input:focus-visible{outline:3px solid #93c5fd;outline-offset:3px}
+
+@media(hover:hover) and (pointer:fine){.appearance-settings-page .flower-layout-card:hover{transform:translateY(-2px);border-color:color-mix(in srgb,var(--preview-primary,#8b9cff) 50%,transparent)}}
+@media(max-width:1024px){.appearance-settings-page{width:min(100% - 36px,980px)}.appearance-settings-page .flower-layout-gallery{grid-template-columns:repeat(2,minmax(0,1fr))}.appearance-settings-page .appearance-theme-gallery{grid-template-columns:repeat(3,minmax(0,1fr))}}
+@media(max-width:768px){.appearance-settings-page{width:min(100% - 28px,760px)}.appearance-settings-page .appearance-theme-gallery{grid-template-columns:repeat(2,minmax(0,1fr))}.appearance-settings-page .appearance-settings-header{gap:18px}.appearance-settings-page .appearance-preview-link{width:100%}.appearance-settings-page .appearance-save-actions{bottom:8px;margin-left:-4px;margin-right:-4px}.appearance-settings-page .appearance-save-actions button{min-height:48px}}
+@media(max-width:600px){.appearance-settings-page{width:calc(100% - 20px)}.appearance-settings-page .flower-layout-gallery,.appearance-settings-page .appearance-theme-gallery{grid-template-columns:1fr}.appearance-settings-page .flower-layout-card{min-height:0;padding:12px}.appearance-settings-page .flower-layout-card small{font-size:.78rem}.appearance-settings-page .appearance-custom{padding:16px}.appearance-settings-page .appearance-open-preview{width:100%}.appearance-settings-page .appearance-save-actions{position:static;margin:24px 0 0}.flower-layout-selected{font-size:.6rem}}
+@media(prefers-reduced-motion:reduce){.appearance-settings-page .flower-layout-card{transition:none}.appearance-settings-page .flower-layout-card:hover{transform:none}}

--- a/frontend/src/appearanceUiAuditSource.test.js
+++ b/frontend/src/appearanceUiAuditSource.test.js
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const appearance = readFileSync(new URL("./AppearanceSettingsPage.jsx", import.meta.url), "utf8");
+const previews = readFileSync(new URL("./FlowerLayoutPreviews.css", import.meta.url), "utf8");
+
+test("flower previews are full-page landscape previews, not narrow device icons", () => {
+  assert.match(previews, /aspect-ratio:16\/9/);
+  assert.match(previews, /flower-layout-gallery\{display:grid;grid-template-columns:repeat\(3,minmax\(0,1fr\)\)/);
+  assert.match(previews, /@media\(max-width:1024px\)/);
+  assert.match(previews, /@media\(max-width:768px\)/);
+  assert.match(previews, /@media\(max-width:600px\)/);
+});
+
+test("appearance controls expose keyboard focus and reduced-motion behavior", () => {
+  assert.match(previews, /:focus-visible/);
+  assert.match(previews, /prefers-reduced-motion:reduce/);
+});
+
+test("template and theme selection expose pressed state and visible feedback", () => {
+  assert.match(appearance, /aria-pressed=\{selected\}/);
+  assert.match(appearance, /flower-layout-selected/);
+  assert.match(appearance, /Selected/);
+});
+
+test("appearance preview uses contrast-aware foreground colors", () => {
+  assert.match(appearance, /getContrastText/);
+  assert.match(appearance, /previewText/);
+  assert.match(appearance, /previewButtonText/);
+});
+
+test("flower cards keep full names and descriptions readable", () => {
+  assert.match(previews, /flower-layout-card strong\{[^}]*white-space:normal/);
+  assert.match(previews, /flower-layout-card small\{[^}]*white-space:normal/);
+  assert.doesNotMatch(previews, /flower-layout-card small\{[^}]*text-overflow:ellipsis/);
+});


### PR DESCRIPTION
UI/UX audit and fix for Profile Appearance, informed by the Zero To Mastery UI/UX design checklist and the provided screenshots.

Key fixes:
- Replaces the narrow phone-like flower thumbnails with large 16:9 full-page layout previews that better communicate each template's actual composition.
- Keeps all flower names and descriptions fully readable instead of truncating them.
- Adds clearer 01/02/03 hierarchy for layout, color, and fine-tune/preview steps.
- Adds visible selected-state feedback plus aria-pressed states.
- Adds keyboard focus treatment, reduced-motion handling, larger touch targets, and responsive 3/2/1-column behavior at desktop/tablet/mobile widths.
- Uses contrast-aware text in the live color preview.
- Improves Preview selected design and Save appearance affordances.
- Adds regression tests for preview geometry, breakpoints, focus states, selection feedback, contrast handling, and text visibility.

The public flower layouts remain independent from color themes; this PR focuses on making the Appearance UI clearer, more usable, and more representative of the actual profiles.