### PR TITLE
Allow Boasted and legacy frontend origins during domain migration

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -55,6 +55,19 @@ app = FastAPI(
     version="1.0.0",
 )
 frontend_url = os.getenv("FRONTEND_URL", "http://localhost:5173").rstrip("/")
+cors_origins = list(
+    dict.fromkeys(
+        [
+            frontend_url,
+            "https://boasted.io",
+            "https://www.boasted.io",
+            "https://usebragstack.com",
+            "https://www.usebragstack.com",
+            "http://localhost:5173",
+            "http://127.0.0.1:5173",
+        ]
+    )
+)
 mongo_admin = mongo_client.admin
 
 
@@ -177,7 +190,7 @@ async def add_security_headers_and_telemetry(request: Request, call_next):
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=[frontend_url, "http://localhost:5173", "http://127.0.0.1:5173"],
+    allow_origins=cors_origins,
     allow_origin_regex=r"https://.*\.app\.github\.dev",
     allow_credentials=True,
     allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "HEAD"],

--- a/backend/tests/test_cors_domain_migration.py
+++ b/backend/tests/test_cors_domain_migration.py
@@ -1,0 +1,14 @@
+"""Regression guards for frontend origins during the Boasted domain migration."""
+
+import app.main as main
+
+
+def test_boasted_and_legacy_frontends_are_allowed_by_cors():
+    expected_origins = {
+        "https://boasted.io",
+        "https://www.boasted.io",
+        "https://usebragstack.com",
+        "https://www.usebragstack.com",
+    }
+
+    assert expected_origins.issubset(set(main.cors_origins))


### PR DESCRIPTION
## Summary

Allows the new Boasted frontend domain and the legacy usebragstack.com frontend to call the API at the same time during the staged domain migration.

## Changes

- Adds `https://boasted.io` and `https://www.boasted.io` to CORS origins
- Keeps `https://usebragstack.com` and `https://www.usebragstack.com` allowed during cutover
- Preserves localhost and GitHub Codespaces development behavior
- Adds a regression test to guard the four production frontend origins

## Why

`boasted.io` is now verified in Render and serving over HTTPS, but browser requests to `/health` are currently blocked by CORS because production only allows the single `FRONTEND_URL` origin.

## Rollout

After this merges and the backend redeploys, verify `/health` from both domains. Then `FRONTEND_URL` can safely move to `https://boasted.io` while OAuth callbacks remain on `https://api.usebragstack.com` for the staged migration.