### PR TITLE
Audit and harden whole-app UI/UX

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -105,6 +105,7 @@ jobs:
           npm run test:safety
           npm run test:seo
           npm run test:settings
+          npm run test:layout
       - name: Lint
         run: npm run lint
       - name: Build

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,7 @@
     "test:resume": "node --test src/resumeStructured.test.js src/dashboardTags.test.js",
     "test:safety": "node --test src/ndaSafety.test.js src/ndaInformationGateSource.test.js src/ndaGuidanceSource.test.js src/ndaApiSource.test.js",
     "test:seo": "node --test src/proofPortfolioSource.test.js && node scripts/verify-search-appearance.mjs",
-    "test:settings": "node --test src/settingsAccountClosureSource.test.js src/settingsBackNavigationSource.test.js src/packetsPageSource.test.js src/appearanceUiAuditSource.test.js",
+    "test:settings": "node --test src/settingsAccountClosureSource.test.js src/settingsBackNavigationSource.test.js src/packetsPageSource.test.js src/appearanceUiAuditSource.test.js src/wholeAppUiAuditSource.test.js",
     "test:clicks": "node scripts/run-click-audit.mjs",
     "test:layout": "node scripts/audit-responsive-layout.mjs",
     "test:bundle": "node scripts/verify-bundle-budget.mjs",

--- a/frontend/scripts/audit-responsive-layout.mjs
+++ b/frontend/scripts/audit-responsive-layout.mjs
@@ -25,6 +25,10 @@ const ROUTES = [
   { path: "/app/accomplishments" },
   { path: "/app/impact-receipts" },
   { path: "/app/profile" },
+  { path: "/app/settings" },
+  { path: "/app/settings/appearance" },
+  { path: "/app/settings/billing" },
+  { path: "/app/intelligence" },
 ];
 
 const proUser = {
@@ -41,6 +45,7 @@ const proUser = {
     advanced_reports: true,
     interview_practice: true,
     impact_receipts: true,
+    executive_command_center: true,
   },
 };
 

--- a/frontend/src/UiUxFoundation.css
+++ b/frontend/src/UiUxFoundation.css
@@ -1,0 +1,136 @@
+/*
+ * App-wide UI/UX guardrails for Boasted.
+ * These rules intentionally sit at the end of the global cascade so every
+ * public and authenticated surface shares the same baseline for focus,
+ * responsive containment, readable forms, motion preferences, and touch use.
+ */
+:root {
+  --ui-space-1: 8px;
+  --ui-space-2: 16px;
+  --ui-space-3: 24px;
+  --ui-space-4: 32px;
+  --ui-space-5: 40px;
+  --ui-space-6: 48px;
+  --ui-content-max: 1440px;
+  --ui-reading-max: 72ch;
+  --ui-touch-target: 44px;
+  --ui-focus: #7dd3fc;
+  --ui-page-gutter: 32px;
+}
+
+:where(main, section, article, aside, nav, header, footer, form, fieldset, div) {
+  min-width: 0;
+}
+
+:where(h1, h2, h3, h4, h5, h6, p, li, dd, dt, label, legend, small, strong, span) {
+  overflow-wrap: anywhere;
+}
+
+:where(img, video, canvas, iframe, object, embed) {
+  max-width: 100%;
+}
+
+:where(img, video, canvas) {
+  height: auto;
+}
+
+:where(pre) {
+  max-width: 100%;
+  overflow-x: auto;
+  overscroll-behavior-inline: contain;
+  -webkit-overflow-scrolling: touch;
+}
+
+:where(button, input, select, textarea) {
+  max-width: 100%;
+}
+
+:where(textarea) {
+  resize: vertical;
+}
+
+:where(a, button, input, select, textarea, summary, [role="button"], [role="link"], [tabindex]):focus-visible {
+  outline: 3px solid var(--ui-focus);
+  outline-offset: 3px;
+}
+
+:where(button, input, select, textarea, [role="button"]):disabled,
+:where(button, input, select, textarea, [role="button"])[aria-disabled="true"] {
+  cursor: not-allowed;
+  opacity: 0.58;
+}
+
+:where(button, [role="button"], summary) {
+  touch-action: manipulation;
+}
+
+:where(dialog, [role="dialog"], .modal, .dialog, .sheet, .drawer-panel, .modal-card, .modal-content) {
+  max-width: min(760px, calc(100vw - (2 * var(--ui-space-2))));
+  max-height: calc(100dvh - (2 * var(--ui-space-2)));
+  overflow: auto;
+  overscroll-behavior: contain;
+}
+
+:where(.page, .profile-settings, .settings-page, .command-center, .accomplishments-page, .impact-receipts-page, .resume-builder-page) {
+  min-width: 0;
+}
+
+:where(.page, .profile-settings, .settings-page) > :where(header, section, article, div) {
+  max-width: 100%;
+}
+
+@media (max-width: 1280px) {
+  :root { --ui-page-gutter: 24px; }
+}
+
+@media (max-width: 1024px) {
+  :root { --ui-page-gutter: 20px; }
+}
+
+@media (max-width: 768px) {
+  :root { --ui-page-gutter: 16px; }
+
+  :where(button, [role="button"], summary, input:not([type="checkbox"]):not([type="radio"]), select, textarea) {
+    min-height: var(--ui-touch-target);
+  }
+
+  :where(input:not([type="checkbox"]):not([type="radio"]), select, textarea) {
+    font-size: 16px;
+  }
+
+  :where(.actions, .button-row, .form-actions, .profile-settings-actions, .command-header-actions) {
+    flex-wrap: wrap;
+  }
+}
+
+@media (max-width: 600px) {
+  :root { --ui-page-gutter: 12px; }
+
+  :where(dialog, [role="dialog"], .modal, .dialog, .sheet, .drawer-panel, .modal-card, .modal-content) {
+    max-width: calc(100vw - 16px);
+    max-height: calc(100dvh - 16px);
+  }
+}
+
+@media (pointer: coarse) {
+  :where(button, [role="button"], summary, .btn, .button, .icon-button, .sidebar-nav a, .profile-public-link) {
+    min-height: var(--ui-touch-target);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html { scroll-behavior: auto !important; }
+
+  *, *::before, *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+
+@media (forced-colors: active) {
+  :where(a, button, input, select, textarea, summary, [role="button"], [role="link"], [tabindex]):focus-visible {
+    outline: 3px solid Highlight;
+  }
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -9,6 +9,7 @@ import "./ImpactReceiptsResponsive.css";
 import "./VerifiedImpact.css";
 import "./ProfileUploadPolish.css";
 import "./ProfileAppearancePreview.css";
+import "./UiUxFoundation.css";
 import NDAInformationGate from "./NDAInformationGate.jsx";
 import PublicAuthHeader from "./PublicAuthHeader.jsx";
 import RootContent from "./RootContent.jsx";

--- a/frontend/src/wholeAppUiAuditSource.test.js
+++ b/frontend/src/wholeAppUiAuditSource.test.js
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(here, "..");
+
+const read = (relativePath) => fs.readFileSync(path.join(root, relativePath), "utf8");
+
+const mainSource = read("src/main.jsx");
+const foundation = read("src/UiUxFoundation.css");
+const routeSource = read("src/RootContent.jsx");
+const responsiveAudit = read("scripts/audit-responsive-layout.mjs");
+
+const expectedUserFacingRoutes = [
+  "/",
+  "/support",
+  "/education",
+  "/docs",
+  "/security",
+  "/how-it-works",
+  "/use-cases",
+  "/contact",
+  "/team",
+  "/enterprise",
+  "/app",
+  "/app/settings",
+  "/app/profile",
+  "/app/settings/appearance",
+  "/app/settings/billing",
+  "/app/accomplishments",
+  "/app/impact-receipts",
+  "/app/applications",
+  "/app/intelligence",
+  "/app/resume-builder",
+  "/app/reports",
+  "/app/interview-practice",
+];
+
+test("app-wide UI foundation is loaded after feature styles", () => {
+  const foundationImport = mainSource.lastIndexOf('import "./UiUxFoundation.css";');
+  assert.ok(foundationImport >= 0, "main.jsx must load the app-wide UI/UX foundation");
+  assert.ok(
+    foundationImport > mainSource.lastIndexOf('import "./ProfileAppearancePreview.css";'),
+    "the UI/UX foundation must be the final global stylesheet so guardrails apply consistently",
+  );
+});
+
+test("foundation encodes responsive, accessibility, touch, and motion guardrails", () => {
+  for (const token of [
+    "--ui-space-1: 8px",
+    "--ui-touch-target: 44px",
+    ":focus-visible",
+    "prefers-reduced-motion: reduce",
+    "forced-colors: active",
+    "pointer: coarse",
+    "font-size: 16px",
+    "max-height: calc(100dvh",
+    "@media (max-width: 1280px)",
+    "@media (max-width: 1024px)",
+    "@media (max-width: 768px)",
+    "@media (max-width: 600px)",
+  ]) {
+    assert.ok(foundation.includes(token), `missing whole-app UI guardrail: ${token}`);
+  }
+});
+
+test("route inventory keeps the UI audit scoped to the whole customer app", () => {
+  for (const route of expectedUserFacingRoutes) {
+    assert.ok(routeSource.includes(`"${route}"`), `RootContent route inventory no longer contains ${route}`);
+  }
+});
+
+test("browser responsive regression covers core navigation and settings surfaces", () => {
+  for (const route of [
+    "/app",
+    "/app/accomplishments",
+    "/app/impact-receipts",
+    "/app/profile",
+    "/app/settings",
+    "/app/settings/appearance",
+    "/app/settings/billing",
+    "/app/intelligence",
+  ]) {
+    assert.ok(responsiveAudit.includes(`path: "${route}"`), `responsive browser audit must cover ${route}`);
+  }
+
+  for (const width of [360, 390, 768, 1024, 1440, 1920]) {
+    assert.ok(responsiveAudit.includes(`width: ${width}`), `responsive audit must retain ${width}px coverage`);
+  }
+});


### PR DESCRIPTION
Whole-app UI/UX audit and regression pass informed by the Zero To Mastery UI/UX design cheat sheet.

Key changes:
- Adds a final global UI/UX foundation with 8px spacing tokens, responsive containment, readable mobile form sizing, 44px touch targets, keyboard focus visibility, reduced-motion support, forced-colors focus fallback, safe media/code/dialog sizing, and wrapping safeguards.
- Applies the foundation to all public and authenticated routes by importing it last in the global cascade.
- Adds a whole-app source regression contract that inventories customer-facing routes and verifies the responsive/accessibility guardrails stay wired.
- Expands the real-browser responsive audit from 4 to 8 core authenticated surfaces: dashboard, accomplishments, impact receipts, profile, settings, appearance, billing, and career intelligence.
- Keeps six viewport sizes from 360px phones through 1920px wide desktop.
- Makes the responsive browser audit a required frontend CI step before lint/build.

Merge only after the full required CI set is clean.