### PR TITLE
Fix profile template UI regressions

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,7 @@
     "test:resume": "node --test src/resumeStructured.test.js src/dashboardTags.test.js",
     "test:safety": "node --test src/ndaSafety.test.js src/ndaInformationGateSource.test.js src/ndaGuidanceSource.test.js src/ndaApiSource.test.js",
     "test:seo": "node --test src/proofPortfolioSource.test.js src/marketingClaritySource.test.js && node scripts/verify-search-appearance.mjs",
-    "test:settings": "node --test src/settingsAccountClosureSource.test.js src/settingsBackNavigationSource.test.js src/packetsPageSource.test.js src/appearanceUiAuditSource.test.js src/wholeAppUiAuditSource.test.js",
+    "test:settings": "node --test src/settingsAccountClosureSource.test.js src/settingsBackNavigationSource.test.js src/packetsPageSource.test.js src/appearanceUiAuditSource.test.js src/wholeAppUiAuditSource.test.js src/profileTemplateRegressionSource.test.js",
     "test:clicks": "node scripts/run-click-audit.mjs",
     "test:layout": "node scripts/audit-responsive-layout.mjs",
     "test:bundle": "node scripts/verify-bundle-budget.mjs",

--- a/frontend/src/ProfileTemplateRegressionFixes.css
+++ b/frontend/src/ProfileTemplateRegressionFixes.css
@@ -1,0 +1,83 @@
+/*
+ * Public profile template regression fixes.
+ *
+ * These selectors intentionally load after the app-wide UI foundation so
+ * template-specific composition wins without weakening global accessibility
+ * guardrails.
+ */
+
+/* Skill cards should size to their content, never become tall vertical pills. */
+.proof-portfolio .portfolio-skill-cloud > span {
+  min-height: 0;
+  height: auto;
+}
+
+.proof-portfolio .portfolio-skill-cloud strong {
+  word-break: normal;
+  overflow-wrap: break-word;
+}
+
+/*
+ * Magnolia and Poppy put the skills section inside a 260–290px sidebar on
+ * desktop. The base three-column skill cloud is far too narrow there and can
+ * collapse the skill label to a few characters per line. Use a deliberate
+ * single-column stack while those sidebars are active.
+ */
+@media (min-width: 981px) {
+  .proof-portfolio[data-layout="executive-sidebar"] .portfolio-skill-cloud,
+  .proof-portfolio[data-layout="modern-resume"] .portfolio-skill-cloud {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .proof-portfolio[data-layout="executive-sidebar"] .portfolio-skill-cloud > span,
+  .proof-portfolio[data-layout="modern-resume"] .portfolio-skill-cloud > span {
+    align-items: flex-start;
+    justify-content: flex-start;
+    flex-direction: column;
+    gap: 4px;
+    padding: 12px 14px;
+    border-radius: 12px;
+  }
+
+  .proof-portfolio[data-layout="executive-sidebar"] .portfolio-skill-cloud small,
+  .proof-portfolio[data-layout="modern-resume"] .portfolio-skill-cloud small {
+    flex: 0 1 auto;
+    white-space: normal;
+  }
+}
+
+/* Once the résumé sidebars stack, let the skills breathe in two columns. */
+@media (min-width: 641px) and (max-width: 980px) {
+  .proof-portfolio[data-layout="executive-sidebar"] .portfolio-skill-cloud,
+  .proof-portfolio[data-layout="modern-resume"] .portfolio-skill-cloud {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+/*
+ * Lotus is a mosaic, but sparse proof cards should not become giant empty
+ * rectangles. Keep the mosaic spans while allowing each card to hug content.
+ */
+.proof-portfolio[data-layout="portfolio-grid"] .portfolio-impact-card,
+.proof-portfolio[data-layout="portfolio-grid"] .portfolio-work-card {
+  min-height: 0;
+  height: auto;
+  align-self: start;
+}
+
+.proof-portfolio[data-layout="portfolio-grid"] .portfolio-impact-card.featured {
+  min-height: 0;
+}
+
+/* Evidence rows should hug their links instead of inheriting excess track size. */
+.proof-portfolio .portfolio-evidence-list {
+  align-items: flex-start;
+  align-self: start;
+}
+
+.proof-portfolio .portfolio-evidence-list > a,
+.proof-portfolio .portfolio-evidence-list > span {
+  height: auto;
+  max-width: 100%;
+  overflow-wrap: break-word;
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -10,6 +10,7 @@ import "./VerifiedImpact.css";
 import "./ProfileUploadPolish.css";
 import "./ProfileAppearancePreview.css";
 import "./UiUxFoundation.css";
+import "./ProfileTemplateRegressionFixes.css";
 import NDAInformationGate from "./NDAInformationGate.jsx";
 import PublicAuthHeader from "./PublicAuthHeader.jsx";
 import RootContent from "./RootContent.jsx";

--- a/frontend/src/profileTemplateRegressionSource.test.js
+++ b/frontend/src/profileTemplateRegressionSource.test.js
@@ -23,7 +23,7 @@ const layouts = [
 
 test("all 12 public profile templates remain represented", () => {
   for (const layout of layouts) {
-    assert.match(structures, new RegExp(`data-layout=[\\\"']${layout}[\\\"']`));
+    assert.match(structures, new RegExp(`data-layout=["']${layout}["']`));
   }
 });
 

--- a/frontend/src/profileTemplateRegressionSource.test.js
+++ b/frontend/src/profileTemplateRegressionSource.test.js
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const fixes = readFileSync(new URL("./ProfileTemplateRegressionFixes.css", import.meta.url), "utf8");
+const main = readFileSync(new URL("./main.jsx", import.meta.url), "utf8");
+const structures = readFileSync(new URL("./ProfileStructureThemes.css", import.meta.url), "utf8");
+
+const layouts = [
+  "editorial",
+  "executive-sidebar",
+  "career-timeline",
+  "studio-split",
+  "minimal-column",
+  "portfolio-grid",
+  "case-study",
+  "modern-resume",
+  "command-center",
+  "academic",
+  "founder",
+  "compact",
+];
+
+test("all 12 public profile templates remain represented", () => {
+  for (const layout of layouts) {
+    assert.match(structures, new RegExp(`data-layout=[\\\"']${layout}[\\\"']`));
+  }
+});
+
+test("profile regression overrides load after the global UI foundation", () => {
+  const foundationIndex = main.indexOf('import "./UiUxFoundation.css";');
+  const fixesIndex = main.indexOf('import "./ProfileTemplateRegressionFixes.css";');
+  assert.ok(foundationIndex >= 0, "UI foundation import is missing");
+  assert.ok(fixesIndex > foundationIndex, "profile template fixes must load after the UI foundation");
+});
+
+test("sidebar templates never use the three-column skill cloud while narrow", () => {
+  assert.match(fixes, /data-layout="executive-sidebar"[^\n]*\.portfolio-skill-cloud/);
+  assert.match(fixes, /data-layout="modern-resume"[^\n]*\.portfolio-skill-cloud/);
+  assert.match(fixes, /grid-template-columns:\s*minmax\(0,\s*1fr\)/);
+  assert.match(fixes, /flex-direction:\s*column/);
+  assert.match(fixes, /min-height:\s*0/);
+  assert.match(fixes, /height:\s*auto/);
+});
+
+test("Lotus sparse cards hug their content instead of forcing blank space", () => {
+  assert.match(fixes, /data-layout="portfolio-grid"[^\n]*\.portfolio-impact-card/);
+  assert.match(fixes, /data-layout="portfolio-grid"[^\n]*\.portfolio-work-card/);
+  assert.match(fixes, /align-self:\s*start/);
+  assert.match(fixes, /\.portfolio-impact-card\.featured\s*\{[^}]*min-height:\s*0/s);
+});
+
+test("evidence links are bounded and content-sized", () => {
+  assert.match(fixes, /\.portfolio-evidence-list\s*\{[^}]*align-items:\s*flex-start/s);
+  assert.match(fixes, /\.portfolio-evidence-list\s*>\s*a/);
+  assert.match(fixes, /max-width:\s*100%/);
+  assert.match(fixes, /overflow-wrap:\s*break-word/);
+});


### PR DESCRIPTION
Fix the public profile template UI regressions visible in the skills/evidence sections.

Changes:
- Prevent Magnolia and Poppy sidebar skill clouds from collapsing into tall narrow pills.
- Use a single-column skill stack while the desktop sidebar is active and two columns once the sidebar stacks on tablet.
- Make skill cards content-sized and preserve readable word wrapping.
- Keep Lotus's mosaic composition while stopping sparse proof/work cards from stretching into giant empty rectangles.
- Bound evidence links to their content and available width.
- Load the profile-specific fixes after the global UI foundation so the whole-app accessibility guardrails remain intact.
- Add regression tests covering all 12 layouts, sidebar skill behavior, Lotus sparse-card sizing, evidence sizing, and CSS load order.

Merge only after required CI is green.