### PR TITLE
Rebalance Dahlia profile hero on wide screens

### DIFF
--- a/frontend/src/ProfileDesktopBalance.css
+++ b/frontend/src/ProfileDesktopBalance.css
@@ -1,0 +1,99 @@
+/*
+ * Wide-desktop balance for public profile templates.
+ *
+ * Dahlia is intentionally editorial, but its desktop hero should feel composed,
+ * not oversized or boxed into a narrow strip with dead gutters.
+ */
+
+.proof-portfolio[data-layout="editorial"] .proof-profile-inner {
+  width: min(1440px, calc(100% - 48px));
+  max-width: 1440px;
+}
+
+.proof-portfolio[data-layout="editorial"] .portfolio-hero {
+  min-height: 0;
+  grid-template-columns: minmax(0, 1.55fr) minmax(300px, 0.55fr);
+  gap: clamp(32px, 4vw, 56px);
+  align-items: center;
+  padding: clamp(44px, 5vw, 62px) 12px clamp(40px, 4.5vw, 54px);
+}
+
+.proof-portfolio[data-layout="editorial"] .portfolio-identity {
+  align-self: center;
+}
+
+.proof-portfolio[data-layout="editorial"] .portfolio-identity h1 {
+  max-width: 10ch;
+  margin-top: 18px;
+  margin-bottom: 20px;
+  font-size: clamp(4rem, 6.3vw, 6.65rem);
+  line-height: 0.92;
+  text-wrap: balance;
+}
+
+.proof-portfolio[data-layout="editorial"] .portfolio-avatar {
+  width: 78px;
+  height: 78px;
+  margin-top: 20px;
+  margin-bottom: 18px;
+}
+
+.proof-portfolio[data-layout="editorial"] .portfolio-proof-passport {
+  align-self: center;
+  padding: 28px 0 28px 30px;
+}
+
+.proof-portfolio[data-layout="editorial"] .portfolio-proof-passport .portfolio-proof-number strong {
+  font-size: clamp(3.2rem, 5vw, 5rem);
+  line-height: 0.95;
+}
+
+.proof-portfolio[data-layout="editorial"] .proof-actions {
+  margin-top: 22px;
+}
+
+.proof-portfolio[data-layout="editorial"] .portfolio-featured-impact {
+  margin-top: 14px;
+}
+
+/* Keep the same editorial hierarchy on laptop widths without the giant-name jump. */
+@media (min-width: 761px) and (max-width: 1279px) {
+  .proof-portfolio[data-layout="editorial"] .proof-profile-inner {
+    width: min(1180px, calc(100% - 40px));
+  }
+
+  .proof-portfolio[data-layout="editorial"] .portfolio-hero {
+    grid-template-columns: minmax(0, 1.48fr) minmax(260px, 0.62fr);
+    gap: 30px;
+    padding-top: 42px;
+    padding-bottom: 40px;
+  }
+
+  .proof-portfolio[data-layout="editorial"] .portfolio-identity h1 {
+    font-size: clamp(3.7rem, 7vw, 5.65rem);
+  }
+}
+
+/* Phone layouts should use the viewport instead of inheriting desktop gutters. */
+@media (max-width: 760px) {
+  .proof-portfolio[data-layout="editorial"] .proof-profile-inner {
+    width: calc(100% - 24px);
+  }
+
+  .proof-portfolio[data-layout="editorial"] .portfolio-hero {
+    padding: 34px 0 30px;
+    gap: 24px;
+  }
+
+  .proof-portfolio[data-layout="editorial"] .portfolio-identity h1 {
+    max-width: 100%;
+    margin-top: 16px;
+    margin-bottom: 16px;
+    font-size: clamp(3rem, 15vw, 4.4rem);
+    line-height: 0.95;
+  }
+
+  .proof-portfolio[data-layout="editorial"] .portfolio-proof-passport {
+    padding: 22px 0 0;
+  }
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -11,6 +11,7 @@ import "./ProfileUploadPolish.css";
 import "./ProfileAppearancePreview.css";
 import "./UiUxFoundation.css";
 import "./ProfileTemplateRegressionFixes.css";
+import "./ProfileDesktopBalance.css";
 import NDAInformationGate from "./NDAInformationGate.jsx";
 import PublicAuthHeader from "./PublicAuthHeader.jsx";
 import RootContent from "./RootContent.jsx";

--- a/frontend/src/profileDesktopBalanceSource.test.js
+++ b/frontend/src/profileDesktopBalanceSource.test.js
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const css = readFileSync(new URL("./ProfileDesktopBalance.css", import.meta.url), "utf8");
+const main = readFileSync(new URL("./main.jsx", import.meta.url), "utf8");
+
+test("Dahlia desktop balance overrides load after profile regression fixes", () => {
+  const regressionIndex = main.indexOf('import "./ProfileTemplateRegressionFixes.css";');
+  const balanceIndex = main.indexOf('import "./ProfileDesktopBalance.css";');
+  assert.ok(regressionIndex >= 0, "profile regression fixes import is missing");
+  assert.ok(balanceIndex > regressionIndex, "desktop balance overrides must load last");
+});
+
+test("Dahlia uses wider desktop space without giant gutters", () => {
+  assert.match(css, /data-layout="editorial"[^\n]*\.proof-profile-inner\s*\{[^}]*width:\s*min\(1440px,\s*calc\(100%\s*-\s*48px\)\)/s);
+  assert.match(css, /max-width:\s*1440px/);
+});
+
+test("Dahlia hero and name are bounded on wide screens", () => {
+  assert.match(css, /data-layout="editorial"[^\n]*\.portfolio-hero\s*\{[^}]*min-height:\s*0/s);
+  assert.match(css, /grid-template-columns:\s*minmax\(0,\s*1\.55fr\)\s*minmax\(300px,\s*0\.55fr\)/);
+  assert.match(css, /font-size:\s*clamp\(4rem,\s*6\.3vw,\s*6\.65rem\)/);
+  assert.match(css, /text-wrap:\s*balance/);
+  assert.match(css, /\.portfolio-proof-passport\s*\{[^}]*align-self:\s*center/s);
+});
+
+test("Dahlia keeps usable gutters on laptop and phone widths", () => {
+  assert.match(css, /@media\s*\(min-width:\s*761px\)\s*and\s*\(max-width:\s*1279px\)/);
+  assert.match(css, /@media\s*\(max-width:\s*760px\)/);
+  assert.match(css, /width:\s*calc\(100%\s*-\s*24px\)/);
+});


### PR DESCRIPTION
Fix the desktop composition issue visible in real Dahlia public-profile previews.

Changes:
- widen Dahlia's usable desktop canvas so it does not sit inside large dead side gutters
- reduce the oversized name treatment and hero vertical footprint
- rebalance identity vs portfolio snapshot columns
- vertically center and tighten the snapshot block
- preserve Dahlia's editorial serif identity
- keep laptop and phone gutters responsive
- add deterministic regression coverage for import order, desktop width, bounded hero typography, and responsive gutters

Merge only after required CI is green.