### PR TITLE
Paginate Impact Receipts and show verified first

### DIFF
--- a/frontend/src/ImpactReceiptsPage.jsx
+++ b/frontend/src/ImpactReceiptsPage.jsx
@@ -1,8 +1,28 @@
 import "./ProductPolish.css";
+import "./ImpactReceiptsPolish.css";
 import { useEffect, useMemo, useState } from "react";
-import { CheckCircle2, ExternalLink, Pencil, Plus, ReceiptText, ShieldCheck, Trash2, X } from "lucide-react";
+import {
+  CheckCircle2,
+  ChevronLeft,
+  ChevronRight,
+  ExternalLink,
+  Pencil,
+  Plus,
+  ReceiptText,
+  ShieldCheck,
+  Trash2,
+  X,
+} from "lucide-react";
 import BragStackLoader from "./BragStackLoader.jsx";
-import { createImpactReceipt, deleteImpactReceipt, getImpactReceipts, updateImpactReceipt } from "./api";
+import { createImpactReceipt, deleteImpactReceipt, updateImpactReceipt } from "./api";
+import { getAllImpactReceipts } from "./impactReceiptLibraryApi.js";
+import {
+  RECEIPTS_PER_PAGE,
+  getImpactReceiptPage,
+  getImpactReceiptPageNumbers,
+  isReceiptVerified,
+  sortImpactReceiptsVerifiedFirst,
+} from "./impactReceiptLibrary.js";
 
 const EMPTY_EVIDENCE = { evidence_type: "other", title: "", reference: "", description: "", is_public: false };
 const EMPTY_FORM = { accomplishment: "", contribution: "", result: "", metricLabel: "", metricValue: "", metricContext: "", evidence: [{ ...EMPTY_EVIDENCE }], skills: "", isPublic: false };
@@ -91,7 +111,7 @@ function ReceiptVerificationStatus({ receipt }) {
           <div className="receipt-confirmation-detail" key={confirmation.id || `${confirmation.name}-${index}`}>
             <header>
               <div>
-                <strong>{confirmation.name || "Verifier"}</strong>
+                <strong className="receipt-verifier-name" title="Verifier name hidden for privacy">{confirmation.name || "Verifier"}</strong>
                 {confirmation.role && <small>{confirmation.role}</small>}
               </div>
               <span><CheckCircle2 size={13} /> Confirmed</span>
@@ -111,6 +131,7 @@ function ReceiptVerificationStatus({ receipt }) {
 
 function ImpactReceiptsPage() {
   const [receipts, setReceipts] = useState([]);
+  const [page, setPage] = useState(1);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState("");
   const [success, setSuccess] = useState("");
@@ -123,7 +144,7 @@ function ImpactReceiptsPage() {
 
   async function loadReceipts() {
     try {
-      const data = await getImpactReceipts();
+      const data = await getAllImpactReceipts();
       setReceipts(data.receipts ?? []);
       setError("");
     } catch (err) {
@@ -143,11 +164,22 @@ function ImpactReceiptsPage() {
     return () => window.clearTimeout(timeoutId);
   }, []);
 
+  const sortedReceipts = useMemo(() => sortImpactReceiptsVerifiedFirst(receipts), [receipts]);
+  const pageCount = Math.max(1, Math.ceil(sortedReceipts.length / RECEIPTS_PER_PAGE));
+  const pageReceipts = useMemo(() => getImpactReceiptPage(sortedReceipts, page), [sortedReceipts, page]);
+  const pageNumbers = useMemo(() => getImpactReceiptPageNumbers(page, pageCount), [page, pageCount]);
+  const pageStart = sortedReceipts.length === 0 ? 0 : (page - 1) * RECEIPTS_PER_PAGE + 1;
+  const pageEnd = Math.min(page * RECEIPTS_PER_PAGE, sortedReceipts.length);
+
+  useEffect(() => {
+    if (page > pageCount) setPage(pageCount);
+  }, [page, pageCount]);
+
   const stats = useMemo(() => ({
     publicCount: receipts.filter((receipt) => receipt.is_public).length,
     evidenceCount: receipts.reduce((total, receipt) => total + (receipt.evidence?.length ?? 0), 0),
     confirmedCount: receipts.reduce((total, receipt) => total + (receipt.confirmations?.filter((confirmation) => confirmation.status === "confirmed").length ?? 0), 0),
-    verifiedReceiptCount: receipts.filter((receipt) => receipt.confirmations?.some((confirmation) => confirmation.status === "confirmed")).length,
+    verifiedReceiptCount: receipts.filter(isReceiptVerified).length,
   }), [receipts]);
 
   function updateForm(field, value) { setForm((current) => ({ ...current, [field]: value })); }
@@ -163,7 +195,7 @@ function ImpactReceiptsPage() {
     const evidence = normalizeEvidence(form.evidence).map((item) => ({ ...item, reference: item.reference.trim() || null, description: item.description.trim() || null, title: item.title.trim() }));
     try {
       await createImpactReceipt({ accomplishment: form.accomplishment.trim(), contribution: form.contribution.trim(), result: form.result.trim(), metrics, evidence, skills, credit: [], is_public: form.isPublic });
-      setForm(EMPTY_FORM); setShowCreate(false); setSuccess("Impact Receipt saved with evidence."); await loadReceipts();
+      setForm(EMPTY_FORM); setShowCreate(false); setPage(1); setSuccess("Impact Receipt saved with evidence."); await loadReceipts();
     } catch (err) {
       const detail = err.response?.data?.detail;
       setError(typeof detail === "string" ? detail : "Impact Receipt could not be saved. Check the required fields.");
@@ -210,6 +242,11 @@ function ImpactReceiptsPage() {
     finally { setUpdatingId(null); }
   }
 
+  function goToPage(nextPage) {
+    const safePage = Math.min(Math.max(1, nextPage), pageCount);
+    setPage(safePage);
+  }
+
   return <main className="product-page receipt-library-page">
     <section className="product-page-hero">
       <div><p className="mini-label">Evidence-backed career proof</p><h1>Impact Receipts</h1><p>Capture what you accomplished, what changed, the evidence behind it, and the skills you demonstrated. Receipts and evidence stay private unless you explicitly choose to share them.</p></div>
@@ -244,39 +281,51 @@ function ImpactReceiptsPage() {
     {isLoading ? <BragStackLoader compact message="Loading your Impact Receipts…" detail="Gathering evidence-backed outcomes, proof, and confirmation signals." /> : receipts.length === 0 ? (
       <section className="product-empty"><h2>No receipts yet.</h2><p>Create your first evidence-backed receipt, or turn an existing accomplishment into one.</p><a href="/app/accomplishments">Create from an accomplishment <ExternalLink size={16} /></a></section>
     ) : (
-      <section className="receipt-library-grid">
-        {receipts.map((receipt) => {
-          const isVerified = receipt.confirmations?.some((confirmation) => confirmation.status === "confirmed");
-          return <article className={`receipt-library-card ${isVerified ? "is-verified" : ""}`} key={receipt.id}>
-            <div className="receipt-library-card-top">
-              <div><p className="mini-label">Impact Receipt</p><h2>{receipt.accomplishment}</h2></div>
-              <div className="receipt-card-actions">
-                <button type="button" className={`visibility-pill ${receipt.is_public ? "public" : "private"}`} disabled={updatingId === receipt.id} onClick={() => toggleVisibility(receipt)}>{updatingId === receipt.id ? "Saving…" : receipt.is_public ? "Public" : "Private"}</button>
-                <button type="button" aria-label="Edit Impact Receipt" onClick={() => beginEdit(receipt)}><Pencil size={16} /></button>
-                <button type="button" aria-label="Delete Impact Receipt" disabled={updatingId === receipt.id} onClick={() => removeReceipt(receipt)}><Trash2 size={16} /></button>
+      <>
+        <div className="receipt-library-order-note"><CheckCircle2 size={16} /> Verified receipts appear first. Newest receipts stay first within each group.</div>
+        <section className="receipt-library-grid">
+          {pageReceipts.map((receipt) => {
+            const isVerified = isReceiptVerified(receipt);
+            return <article className={`receipt-library-card ${isVerified ? "is-verified" : ""}`} key={receipt.id}>
+              <div className="receipt-library-card-top">
+                <div><p className="mini-label">Impact Receipt</p><h2>{receipt.accomplishment}</h2></div>
+                <div className="receipt-card-actions">
+                  <button type="button" className={`visibility-pill ${receipt.is_public ? "public" : "private"}`} disabled={updatingId === receipt.id} onClick={() => toggleVisibility(receipt)}>{updatingId === receipt.id ? "Saving…" : receipt.is_public ? "Public" : "Private"}</button>
+                  <button type="button" aria-label="Edit Impact Receipt" onClick={() => beginEdit(receipt)}><Pencil size={16} /></button>
+                  <button type="button" aria-label="Delete Impact Receipt" disabled={updatingId === receipt.id} onClick={() => removeReceipt(receipt)}><Trash2 size={16} /></button>
+                </div>
               </div>
-            </div>
 
-            <ReceiptVerificationStatus receipt={receipt} />
+              <ReceiptVerificationStatus receipt={receipt} />
 
-            {editingId === receipt.id && editForm && <div className="receipt-create-form receipt-edit-form">
-              <label>Accomplishment<input value={editForm.accomplishment} onChange={(event) => updateEdit("accomplishment", event.target.value)} /></label>
-              <label>Your contribution<textarea value={editForm.contribution} onChange={(event) => updateEdit("contribution", event.target.value)} /></label>
-              <label>Result / impact<textarea value={editForm.result} onChange={(event) => updateEdit("result", event.target.value)} /></label>
-              <EvidenceFields items={editForm.evidence} onChange={updateEditEvidence} onAdd={addEditEvidence} onRemove={removeEditEvidence} />
-              <label>Skills<input value={editForm.skills} onChange={(event) => updateEdit("skills", event.target.value)} /></label>
-              <label><input type="checkbox" checked={editForm.is_public} onChange={(event) => updateEdit("is_public", event.target.checked)} /> This receipt may be shared publicly</label>
-              <button type="button" disabled={updatingId === receipt.id} onClick={() => saveEdit(receipt.id)}>Save changes</button>
-              <button type="button" onClick={() => { setEditingId(null); setEditForm(null); }}>Cancel</button>
-            </div>}
+              {editingId === receipt.id && editForm && <div className="receipt-create-form receipt-edit-form">
+                <label>Accomplishment<input value={editForm.accomplishment} onChange={(event) => updateEdit("accomplishment", event.target.value)} /></label>
+                <label>Your contribution<textarea value={editForm.contribution} onChange={(event) => updateEdit("contribution", event.target.value)} /></label>
+                <label>Result / impact<textarea value={editForm.result} onChange={(event) => updateEdit("result", event.target.value)} /></label>
+                <EvidenceFields items={editForm.evidence} onChange={updateEditEvidence} onAdd={addEditEvidence} onRemove={removeEditEvidence} />
+                <label>Skills<input value={editForm.skills} onChange={(event) => updateEdit("skills", event.target.value)} /></label>
+                <label><input type="checkbox" checked={editForm.is_public} onChange={(event) => updateEdit("is_public", event.target.checked)} /> This receipt may be shared publicly</label>
+                <button type="button" disabled={updatingId === receipt.id} onClick={() => saveEdit(receipt.id)}>Save changes</button>
+                <button type="button" onClick={() => { setEditingId(null); setEditForm(null); }}>Cancel</button>
+              </div>}
 
-            <div className="receipt-proof-columns"><div><span>Contribution</span><p>{receipt.contribution}</p></div><div><span>Result</span><p>{receipt.result}</p></div></div>
-            {receipt.metrics?.length > 0 && <div className="receipt-signal-row">{receipt.metrics.map((metric, index) => <span key={`${metric.label}-${index}`}>{metric.label}: <strong>{metric.value}</strong>{metric.context ? ` · ${metric.context}` : ""}</span>)}</div>}
-            <div className="receipt-chip-row">{receipt.skills?.map((skill) => <span key={skill}>{skill}</span>)}</div>
-            {receipt.evidence?.length > 0 && <div className="receipt-evidence-list"><span className="receipt-evidence-heading">Evidence</span>{receipt.evidence.map((item, index) => <div className="receipt-evidence-row" key={`${item.title}-${index}`}><div><strong>{item.title}</strong><span>{formatLabel(item.evidence_type)}</span>{item.description && <p>{item.description}</p>}</div><div className="receipt-evidence-actions">{item.reference && <a href={item.reference.startsWith("http") ? item.reference : undefined} title={item.reference}>{item.reference.startsWith("http") ? <ExternalLink size={15} /> : item.reference}</a>}<span className={`visibility-pill ${item.is_public ? "public" : "private"}`}>{item.is_public ? "Public evidence" : "Private evidence"}</span></div></div>)}</div>}
-          </article>;
-        })}
-      </section>
+              <div className="receipt-proof-columns"><div><span>Contribution</span><p>{receipt.contribution}</p></div><div><span>Result</span><p>{receipt.result}</p></div></div>
+              {receipt.metrics?.length > 0 && <div className="receipt-signal-row">{receipt.metrics.map((metric, index) => <span key={`${metric.label}-${index}`}>{metric.label}: <strong>{metric.value}</strong>{metric.context ? ` · ${metric.context}` : ""}</span>)}</div>}
+              <div className="receipt-chip-row">{receipt.skills?.map((skill) => <span key={skill}>{skill}</span>)}</div>
+              {receipt.evidence?.length > 0 && <div className="receipt-evidence-list"><span className="receipt-evidence-heading">Evidence</span>{receipt.evidence.map((item, index) => <div className="receipt-evidence-row" key={`${item.title}-${index}`}><div><strong>{item.title}</strong><span>{formatLabel(item.evidence_type)}</span>{item.description && <p>{item.description}</p>}</div><div className="receipt-evidence-actions">{item.reference && <a href={item.reference.startsWith("http") ? item.reference : undefined} title={item.reference}>{item.reference.startsWith("http") ? <ExternalLink size={15} /> : item.reference}</a>}<span className={`visibility-pill ${item.is_public ? "public" : "private"}`}>{item.is_public ? "Public evidence" : "Private evidence"}</span></div></div>)}</div>}
+            </article>;
+          })}
+        </section>
+
+        {sortedReceipts.length > RECEIPTS_PER_PAGE && <div className="pagination-shell receipt-library-pagination">
+          <span className="pagination-summary">Showing {pageStart}–{pageEnd} of {sortedReceipts.length} Impact Receipts · Page {page} of {pageCount}</span>
+          <div className="pagination-controls" aria-label="Impact Receipt pages">
+            <button type="button" aria-label="Previous page" disabled={page === 1} onClick={() => goToPage(page - 1)}><ChevronLeft size={16} /> Prev</button>
+            {pageNumbers.map((pageNumber) => <button type="button" key={pageNumber} className={pageNumber === page ? "active" : ""} aria-current={pageNumber === page ? "page" : undefined} onClick={() => goToPage(pageNumber)}>{pageNumber}</button>)}
+            <button type="button" aria-label="Next page" disabled={page === pageCount} onClick={() => goToPage(page + 1)}>Next <ChevronRight size={16} /></button>
+          </div>
+        </div>}
+      </>
     )}
   </main>;
 }

--- a/frontend/src/ImpactReceiptsPage.jsx
+++ b/frontend/src/ImpactReceiptsPage.jsx
@@ -166,14 +166,11 @@ function ImpactReceiptsPage() {
 
   const sortedReceipts = useMemo(() => sortImpactReceiptsVerifiedFirst(receipts), [receipts]);
   const pageCount = Math.max(1, Math.ceil(sortedReceipts.length / RECEIPTS_PER_PAGE));
-  const pageReceipts = useMemo(() => getImpactReceiptPage(sortedReceipts, page), [sortedReceipts, page]);
-  const pageNumbers = useMemo(() => getImpactReceiptPageNumbers(page, pageCount), [page, pageCount]);
-  const pageStart = sortedReceipts.length === 0 ? 0 : (page - 1) * RECEIPTS_PER_PAGE + 1;
-  const pageEnd = Math.min(page * RECEIPTS_PER_PAGE, sortedReceipts.length);
-
-  useEffect(() => {
-    if (page > pageCount) setPage(pageCount);
-  }, [page, pageCount]);
+  const activePage = Math.min(page, pageCount);
+  const pageReceipts = useMemo(() => getImpactReceiptPage(sortedReceipts, activePage), [sortedReceipts, activePage]);
+  const pageNumbers = useMemo(() => getImpactReceiptPageNumbers(activePage, pageCount), [activePage, pageCount]);
+  const pageStart = sortedReceipts.length === 0 ? 0 : (activePage - 1) * RECEIPTS_PER_PAGE + 1;
+  const pageEnd = Math.min(activePage * RECEIPTS_PER_PAGE, sortedReceipts.length);
 
   const stats = useMemo(() => ({
     publicCount: receipts.filter((receipt) => receipt.is_public).length,
@@ -318,11 +315,11 @@ function ImpactReceiptsPage() {
         </section>
 
         {sortedReceipts.length > RECEIPTS_PER_PAGE && <div className="pagination-shell receipt-library-pagination">
-          <span className="pagination-summary">Showing {pageStart}–{pageEnd} of {sortedReceipts.length} Impact Receipts · Page {page} of {pageCount}</span>
+          <span className="pagination-summary">Showing {pageStart}–{pageEnd} of {sortedReceipts.length} Impact Receipts · Page {activePage} of {pageCount}</span>
           <div className="pagination-controls" aria-label="Impact Receipt pages">
-            <button type="button" aria-label="Previous page" disabled={page === 1} onClick={() => goToPage(page - 1)}><ChevronLeft size={16} /> Prev</button>
-            {pageNumbers.map((pageNumber) => <button type="button" key={pageNumber} className={pageNumber === page ? "active" : ""} aria-current={pageNumber === page ? "page" : undefined} onClick={() => goToPage(pageNumber)}>{pageNumber}</button>)}
-            <button type="button" aria-label="Next page" disabled={page === pageCount} onClick={() => goToPage(page + 1)}>Next <ChevronRight size={16} /></button>
+            <button type="button" aria-label="Previous page" disabled={activePage === 1} onClick={() => goToPage(activePage - 1)}><ChevronLeft size={16} /> Prev</button>
+            {pageNumbers.map((pageNumber) => <button type="button" key={pageNumber} className={pageNumber === activePage ? "active" : ""} aria-current={pageNumber === activePage ? "page" : undefined} onClick={() => goToPage(pageNumber)}>{pageNumber}</button>)}
+            <button type="button" aria-label="Next page" disabled={activePage === pageCount} onClick={() => goToPage(activePage + 1)}>Next <ChevronRight size={16} /></button>
           </div>
         </div>}
       </>

--- a/frontend/src/ImpactReceiptsPolish.css
+++ b/frontend/src/ImpactReceiptsPolish.css
@@ -1,0 +1,72 @@
+.receipt-verifier-name {
+  display: inline-block;
+  max-width: 180px;
+  filter: blur(5px);
+  user-select: none;
+  pointer-events: none;
+}
+
+.receipt-library-order-note {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 18px 0 12px;
+  color: #a7f3d0;
+  font-size: .86rem;
+  font-weight: 800;
+}
+
+.receipt-library-order-note svg {
+  flex: 0 0 auto;
+}
+
+.receipt-library-pagination {
+  margin-top: 22px;
+}
+
+.receipt-library-pagination .pagination-controls button {
+  min-width: 38px;
+  height: 38px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+  padding: 0 11px;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, .18);
+  background: rgba(30, 41, 59, .7);
+  color: #dbeafe;
+  font: inherit;
+  font-weight: 900;
+  cursor: pointer;
+}
+
+.receipt-library-pagination .pagination-controls button:hover:not(:disabled) {
+  border-color: rgba(125, 211, 252, .45);
+  background: rgba(30, 64, 175, .22);
+}
+
+.receipt-library-pagination .pagination-controls button.active {
+  color: #020617;
+  background: linear-gradient(135deg, #f8fafc, #bae6fd);
+}
+
+.receipt-library-pagination .pagination-controls button:disabled {
+  opacity: .38;
+  cursor: not-allowed;
+}
+
+.receipt-library-pagination .pagination-controls button:focus-visible {
+  outline: 2px solid #7dd3fc;
+  outline-offset: 2px;
+}
+
+@media (max-width: 620px) {
+  .receipt-library-pagination .pagination-controls {
+    width: 100%;
+  }
+
+  .receipt-library-pagination .pagination-controls button {
+    flex: 1 1 40px;
+  }
+}

--- a/frontend/src/impactReceiptLibrary.js
+++ b/frontend/src/impactReceiptLibrary.js
@@ -1,0 +1,44 @@
+export const RECEIPTS_PER_PAGE = 6;
+
+export function isReceiptVerified(receipt) {
+  return Boolean(
+    receipt?.confirmations?.some((confirmation) => confirmation?.status === "confirmed"),
+  );
+}
+
+function receiptTimestamp(receipt) {
+  const value = receipt?.created_at || receipt?.updated_at || "";
+  const timestamp = Date.parse(value);
+  return Number.isNaN(timestamp) ? 0 : timestamp;
+}
+
+export function sortImpactReceiptsVerifiedFirst(receipts = []) {
+  return [...receipts].sort((left, right) => {
+    const verifiedDifference = Number(isReceiptVerified(right)) - Number(isReceiptVerified(left));
+    if (verifiedDifference !== 0) return verifiedDifference;
+
+    const dateDifference = receiptTimestamp(right) - receiptTimestamp(left);
+    if (dateDifference !== 0) return dateDifference;
+
+    return String(right?.id || "").localeCompare(String(left?.id || ""));
+  });
+}
+
+export function getImpactReceiptPage(receipts = [], page = 1, pageSize = RECEIPTS_PER_PAGE) {
+  const safePage = Math.max(1, Number(page) || 1);
+  const safePageSize = Math.max(1, Number(pageSize) || RECEIPTS_PER_PAGE);
+  const start = (safePage - 1) * safePageSize;
+  return receipts.slice(start, start + safePageSize);
+}
+
+export function getImpactReceiptPageNumbers(page, pageCount, windowSize = 5) {
+  const safePageCount = Math.max(1, Number(pageCount) || 1);
+  const safeWindow = Math.max(1, Math.min(Number(windowSize) || 5, safePageCount));
+  const safePage = Math.min(Math.max(1, Number(page) || 1), safePageCount);
+  const halfWindow = Math.floor(safeWindow / 2);
+  let start = Math.max(1, safePage - halfWindow);
+  let end = Math.min(safePageCount, start + safeWindow - 1);
+  start = Math.max(1, end - safeWindow + 1);
+
+  return Array.from({ length: end - start + 1 }, (_, index) => start + index);
+}

--- a/frontend/src/impactReceiptLibraryApi.js
+++ b/frontend/src/impactReceiptLibraryApi.js
@@ -1,0 +1,42 @@
+import axios from "axios";
+
+const API_PAGE_LIMIT = 100;
+
+function apiBase() {
+  if (window.location.hostname.endsWith(".app.github.dev")) return "/api";
+  return import.meta.env.VITE_API_BASE_URL || import.meta.env.VITE_API_URL || "http://localhost:8000";
+}
+
+const impactReceiptApi = axios.create({ baseURL: apiBase() });
+impactReceiptApi.interceptors.request.use((config) => {
+  const token = localStorage.getItem("bragstack_token");
+  if (token) config.headers.Authorization = `Bearer ${token}`;
+  return config;
+});
+
+export async function getAllImpactReceipts() {
+  const receipts = [];
+  let skip = 0;
+  let totalReceipts = null;
+
+  while (true) {
+    const response = await impactReceiptApi.get("/impact-receipts", {
+      params: { limit: API_PAGE_LIMIT, skip },
+    });
+    const data = response.data || {};
+    const batch = Array.isArray(data.receipts) ? data.receipts : [];
+
+    receipts.push(...batch);
+    totalReceipts = Number.isFinite(data.total_receipts)
+      ? data.total_receipts
+      : receipts.length;
+
+    if (!data.has_more || batch.length === 0 || receipts.length >= totalReceipts) break;
+    skip += batch.length;
+  }
+
+  return {
+    receipts,
+    total_receipts: totalReceipts ?? receipts.length,
+  };
+}

--- a/frontend/src/impactReceiptLibraryApi.js
+++ b/frontend/src/impactReceiptLibraryApi.js
@@ -17,7 +17,6 @@ impactReceiptApi.interceptors.request.use((config) => {
 export async function getAllImpactReceipts() {
   const receipts = [];
   let skip = 0;
-  let totalReceipts = null;
 
   while (true) {
     const response = await impactReceiptApi.get("/impact-receipts", {
@@ -27,16 +26,12 @@ export async function getAllImpactReceipts() {
     const batch = Array.isArray(data.receipts) ? data.receipts : [];
 
     receipts.push(...batch);
-    totalReceipts = Number.isFinite(data.total_receipts)
-      ? data.total_receipts
-      : receipts.length;
-
-    if (!data.has_more || batch.length === 0 || receipts.length >= totalReceipts) break;
+    if (!data.has_more || batch.length === 0) break;
     skip += batch.length;
   }
 
   return {
     receipts,
-    total_receipts: totalReceipts ?? receipts.length,
+    total_receipts: receipts.length,
   };
 }

--- a/frontend/src/wholeAppUiAuditSource.test.js
+++ b/frontend/src/wholeAppUiAuditSource.test.js
@@ -3,6 +3,11 @@ import fs from "node:fs";
 import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
+import {
+  getImpactReceiptPage,
+  isReceiptVerified,
+  sortImpactReceiptsVerifiedFirst,
+} from "./impactReceiptLibrary.js";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const root = path.resolve(here, "..");
@@ -15,6 +20,9 @@ const routeSource = read("src/RootContent.jsx");
 const responsiveAudit = read("scripts/audit-responsive-layout.mjs");
 const careerAnalyticsSource = read("src/ProCareerPage.jsx");
 const careerAnalyticsStyles = read("src/ProCareerPage.css");
+const impactReceiptsSource = read("src/ImpactReceiptsPage.jsx");
+const impactReceiptsStyles = read("src/ImpactReceiptsPolish.css");
+const impactReceiptsApiSource = read("src/impactReceiptLibraryApi.js");
 
 const expectedUserFacingRoutes = [
   "/",
@@ -136,4 +144,32 @@ test("career analytics animation is distinctive, responsive, and reduced-motion 
   ]) {
     assert.ok(careerAnalyticsStyles.includes(token), `career analytics styles are missing: ${token}`);
   }
+});
+
+test("Impact Receipts prioritize verified proof, paginate the full library, and mask verifier names", () => {
+  const receipts = [
+    { id: "unverified-new", created_at: "2026-09-03T00:00:00Z", confirmations: [] },
+    { id: "verified-old", created_at: "2026-01-01T00:00:00Z", confirmations: [{ status: "confirmed" }] },
+    { id: "verified-new", created_at: "2026-08-20T00:00:00Z", confirmations: [{ status: "confirmed" }] },
+  ];
+
+  const sorted = sortImpactReceiptsVerifiedFirst(receipts);
+  assert.deepEqual(sorted.map((receipt) => receipt.id), ["verified-new", "verified-old", "unverified-new"]);
+  assert.equal(isReceiptVerified(sorted[0]), true);
+  assert.deepEqual(getImpactReceiptPage(sorted, 2, 2).map((receipt) => receipt.id), ["unverified-new"]);
+
+  for (const token of [
+    "getAllImpactReceipts",
+    "pageReceipts.map",
+    "Verified receipts appear first",
+    "pagination-shell",
+    "receipt-verifier-name",
+    "RECEIPTS_PER_PAGE",
+  ]) {
+    assert.ok(impactReceiptsSource.includes(token), `Impact Receipts UI is missing: ${token}`);
+  }
+
+  assert.ok(impactReceiptsStyles.includes("filter: blur(5px)"), "verifier names must remain visually obscured");
+  assert.ok(impactReceiptsApiSource.includes("limit: API_PAGE_LIMIT, skip"), "receipt loader must request API pages explicitly");
+  assert.ok(impactReceiptsApiSource.includes("data.has_more"), "receipt loader must continue until the full library is loaded");
 });


### PR DESCRIPTION
## What changed
- loads the complete Impact Receipt library across API pages instead of stopping at the first 20
- sorts verified receipts first, newest-first within verified and unverified groups
- paginates the library at 6 receipts per page with previous/next and numbered controls
- keeps global KPI counts based on the complete library
- visually blurs verifier names while preserving the existing Confirmed treatment
- adds focused ordering/pagination helpers and regression coverage in the whole-app UI audit

## Merge policy
User explicitly approved merge when CI is green.