### PR TITLE
Harden Aisha dictation and add selectable voice styles

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint .",
     "test:analytics": "node --test src/analytics.test.js",
     "test:education": "node --test src/applicationsHubSource.test.js src/accomplishmentsEducationSource.test.js src/educationToolkitSource.test.js src/educationOpportunitySource.test.js",
-    "test:interview": "node --test src/interviewEngine*.test.js",
+    "test:interview": "node --test src/interviewEngine*.test.js src/interviewTranscript.test.js src/interviewVoice.test.js",
     "test:resume": "node --test src/resumeStructured.test.js src/dashboardTags.test.js",
     "test:safety": "node --test src/ndaSafety.test.js src/ndaInformationGateSource.test.js src/ndaGuidanceSource.test.js src/ndaApiSource.test.js",
     "test:seo": "node --test src/proofPortfolioSource.test.js src/marketingClaritySource.test.js && node scripts/verify-search-appearance.mjs",

--- a/frontend/src/InterviewPracticePage.jsx
+++ b/frontend/src/InterviewPracticePage.jsx
@@ -345,7 +345,7 @@ export default function InterviewPracticePage() {
   }
 
   function speakAisha(text, options = {}) {
-    return speakAisha(text, { ...options, voiceStyle: setup.voiceStyle });
+    return speakSoftText(text, { ...options, voiceStyle: setup.voiceStyle });
   }
 
   async function primeMicrophonePermission() {

--- a/frontend/src/InterviewPracticePage.jsx
+++ b/frontend/src/InterviewPracticePage.jsx
@@ -5,6 +5,8 @@ import AnimatedInterviewerAvatar from "./AnimatedInterviewerAvatar.jsx";
 import { getImpactReceipts, reportInterviewIntelligenceVerification } from "./api.js";
 import { EXPERIENCE_LEVELS, INTERVIEW_TYPES } from "./interviewKnowledgeBase.js";
 import { analyzeAnswer, buildInterviewPlan, getBrowserInterviewCapabilities, summarizeInterview } from "./interviewEngine.js";
+import { buildTranscriptContext, resolveTranscriptAlternatives } from "./interviewTranscript.js";
+import { chooseInterviewVoice, getInterviewVoiceStyle, INTERVIEW_VOICE_STYLES } from "./interviewVoice.js";
 import {
   INITIAL_INTERVIEW_CONVERSATION,
   INTERVIEW_PHASES,
@@ -135,28 +137,23 @@ function wait(ms) {
   return new Promise((resolve) => window.setTimeout(resolve, ms));
 }
 
-function chooseSoftVoice(voices = []) {
-  const preferred = ["Samantha", "Ava", "Serena", "Tessa", "Moira", "Nicky", "Karen", "Microsoft Aria", "Google US English"];
-  return preferred.map((name) => voices.find((voice) => voice.lang?.startsWith("en") && voice.name.includes(name))).find(Boolean)
-    || voices.find((voice) => voice.lang?.startsWith("en-US") && /premium|enhanced|natural|neural/i.test(voice.name))
-    || voices.find((voice) => voice.lang?.startsWith("en-US"))
-    || voices.find((voice) => voice.lang?.startsWith("en"))
-    || null;
+function chooseSoftVoice(voices = [], style = "warm") {
+  return chooseInterviewVoice(voices, style);
 }
 
 function warmSpeechVoices() {
   const synth = window.speechSynthesis;
   if (!synth?.getVoices) return () => {};
   const refresh = () => {
-    const next = chooseSoftVoice(synth.getVoices());
-    if (next) cachedSoftVoice = next;
+    const next = chooseSoftVoice(synth.getVoices(), "warm");
+    if (next) cachedSoftVoice = { style: "warm", voice: next };
   };
   refresh();
   synth.addEventListener?.("voiceschanged", refresh);
   return () => synth.removeEventListener?.("voiceschanged", refresh);
 }
 
-function speakSoftText(text, { cancelFirst = false } = {}) {
+function speakSoftText(text, { cancelFirst = false, voiceStyle = "warm" } = {}) {
   return new Promise((resolve) => {
     const synth = window.speechSynthesis;
     if (!synth?.speak || !text) {
@@ -165,13 +162,16 @@ function speakSoftText(text, { cancelFirst = false } = {}) {
     }
     if (cancelFirst) synth.cancel();
     const utterance = new SpeechSynthesisUtterance(text);
-    const voice = cachedSoftVoice || chooseSoftVoice(synth.getVoices?.() || []);
+    const settings = getInterviewVoiceStyle(voiceStyle);
+    const voice = cachedSoftVoice?.style === voiceStyle
+      ? cachedSoftVoice.voice
+      : chooseSoftVoice(synth.getVoices?.() || [], voiceStyle);
     if (voice) {
-      cachedSoftVoice = voice;
+      cachedSoftVoice = { style: voiceStyle, voice };
       utterance.voice = voice;
     }
-    utterance.rate = 0.92;
-    utterance.pitch = 0.99;
+    utterance.rate = settings.rate;
+    utterance.pitch = settings.pitch;
     utterance.volume = 0.86;
     let settled = false;
     let timeoutId = null;
@@ -223,7 +223,7 @@ function playSoftChime() {
 
 export default function InterviewPracticePage() {
   const [stage, setStage] = useState("setup");
-  const [setup, setSetup] = useState({ roleTitle: "", careerArea: "", experienceLevel: "experienced", interviewType: "mixed", questionCount: 8, responseMinutes: 3, jobDescription: "", useReceipts: true });
+  const [setup, setSetup] = useState({ roleTitle: "", careerArea: "", experienceLevel: "experienced", interviewType: "mixed", questionCount: 8, responseMinutes: 3, voiceStyle: "warm", jobDescription: "", useReceipts: true });
   const [receipts, setReceipts] = useState([]);
   const [plan, setPlan] = useState(null);
   const [questionIndex, setQuestionIndex] = useState(0);
@@ -256,6 +256,7 @@ export default function InterviewPracticePage() {
   const timeoutHandledRef = useRef(false);
   const autoListenRef = useRef(false);
   const dictationBaseRef = useRef("");
+  const dictationRawFinalRef = useRef("");
   const dictationFinalRef = useRef("");
   const dictationLiveRef = useRef("");
   const recognitionRestartRef = useRef(null);
@@ -343,6 +344,10 @@ export default function InterviewPracticePage() {
     setSetup((current) => ({ ...current, [name]: type === "checkbox" ? checked : value }));
   }
 
+  function speakAisha(text, options = {}) {
+    return speakAisha(text, { ...options, voiceStyle: setup.voiceStyle });
+  }
+
   async function primeMicrophonePermission() {
     if (!navigator.mediaDevices?.getUserMedia) return true;
     try {
@@ -383,9 +388,10 @@ export default function InterviewPracticePage() {
     recognition.lang = "en-US";
     recognition.interimResults = true;
     recognition.continuous = !appleMobile;
-    recognition.maxAlternatives = 1;
+    recognition.maxAlternatives = 3;
 
     dictationBaseRef.current = answerRef.current.trim();
+    dictationRawFinalRef.current = "";
     dictationFinalRef.current = "";
     dictationLiveRef.current = dictationBaseRef.current;
 
@@ -399,10 +405,24 @@ export default function InterviewPracticePage() {
       let interim = "";
       for (let index = event.resultIndex; index < event.results.length; index += 1) {
         const result = event.results[index];
-        const transcript = String(result[0]?.transcript || "").trim();
-        if (!transcript) continue;
-        if (result.isFinal) dictationFinalRef.current = `${dictationFinalRef.current} ${transcript}`.trim();
-        else interim = `${interim} ${transcript}`.trim();
+        const alternatives = Array.from(result).slice(0, 3).map((alternative) => ({
+          transcript: alternative?.transcript,
+          confidence: alternative?.confidence,
+        }));
+        const transcriptContext = buildTranscriptContext({
+          roleTitle: setup.roleTitle,
+          careerArea: setup.careerArea,
+          jobDescription: setup.jobDescription,
+          question: currentPrompt,
+        });
+        const resolved = resolveTranscriptAlternatives(alternatives, transcriptContext);
+        if (!resolved.display) continue;
+        if (result.isFinal) {
+          dictationRawFinalRef.current = `${dictationRawFinalRef.current} ${resolved.raw}`.trim();
+          dictationFinalRef.current = `${dictationFinalRef.current} ${resolved.display}`.trim();
+        } else {
+          interim = `${interim} ${resolved.display}`.trim();
+        }
       }
       const next = [dictationBaseRef.current, dictationFinalRef.current, interim].filter(Boolean).join(" ").replace(/\s+/g, " ").trim();
       if (next) {
@@ -492,10 +512,10 @@ export default function InterviewPracticePage() {
       return true;
     }
 
-    let spoken = await speakSoftText(prompt);
+    let spoken = await speakAisha(prompt);
     if (!spoken) {
       await wait(250);
-      spoken = await speakSoftText(prompt, { cancelFirst: true });
+      spoken = await speakAisha(prompt, { cancelFirst: true });
     }
     if (!spoken) {
       setAudioError("Aisha Jordan’s audio was blocked or interrupted. The interview is continuing in text mode; Replay question can retry the audio.");
@@ -513,13 +533,13 @@ export default function InterviewPracticePage() {
 
     if (!spoken && capabilities.speechSynthesis) {
       await wait(200);
-      spoken = await speakSoftText(INTRO_SEGMENTS[0], { cancelFirst: true });
+      spoken = await speakAisha(INTRO_SEGMENTS[0], { cancelFirst: true });
     }
 
     if (spoken) {
       for (let index = 1; index < INTRO_SEGMENTS.length; index += 1) {
         await wait(INTRO_PAUSE_MS);
-        const ok = await speakSoftText(INTRO_SEGMENTS[index]);
+        const ok = await speakAisha(INTRO_SEGMENTS[index]);
         if (!ok) {
           setAudioError("Aisha Jordan’s intro was interrupted. The interview will continue with the first question.");
           break;
@@ -573,7 +593,7 @@ export default function InterviewPracticePage() {
     });
 
     scrollInterviewToTop();
-    const firstSegmentPromise = speakSoftText(INTRO_SEGMENTS[0]);
+    const firstSegmentPromise = speakAisha(INTRO_SEGMENTS[0]);
     const catalogPromise = enrichInterviewPlanWithCatalog(fallbackPlan, setup);
     void continueGreeting(firstSegmentPromise, fallbackPlan, catalogPromise);
   }
@@ -595,7 +615,7 @@ export default function InterviewPracticePage() {
     setInterviewPhase(INTERVIEW_PHASES.SPEAKING);
     playSoftChime();
     await wait(450);
-    await speakSoftText("Okay, that’s time. Thank you.");
+    await speakAisha("Okay, that’s time. Thank you.");
     evaluateAnswer(answerRef.current, { timedOut: true });
   }
 
@@ -768,6 +788,7 @@ export default function InterviewPracticePage() {
             <label>Questions<select name="questionCount" value={setup.questionCount} onChange={updateSetup}><option value="5">5 · Quick practice</option><option value="8">8 · Standard</option><option value="10">10 · Full interview</option></select></label>
             <label>Response time<select name="responseMinutes" value={setup.responseMinutes} onChange={updateSetup}><option value="1">1 minute</option><option value="3">3 minutes</option><option value="5">5 minutes</option></select></label>
           </div>
+          <label>Aisha&apos;s voice<select name="voiceStyle" value={setup.voiceStyle} onChange={updateSetup}>{Object.entries(INTERVIEW_VOICE_STYLES).map(([value, style]) => <option value={value} key={value}>{style.label}</option>)}</select></label>
           <label>Job description <small>optional</small><textarea name="jobDescription" value={setup.jobDescription} onChange={updateSetup} rows="5" placeholder="Paste the job description for more targeted questions." /></label>
           <label className="receipt-personalization"><input type="checkbox" name="useReceipts" checked={setup.useReceipts} onChange={updateSetup} /><span><strong>Personalize with my career proof</strong><small>{receipts.length ? `${receipts.length} Impact Receipt${receipts.length === 1 ? "" : "s"} available` : "No Impact Receipts loaded yet — the interview still works normally."}</small></span></label>
           <button className="start-interview-button" type="submit">Start practice interview <ChevronRight size={18} /></button>

--- a/frontend/src/interviewTranscript.js
+++ b/frontend/src/interviewTranscript.js
@@ -1,0 +1,55 @@
+const CORRECTION_RULES = [
+  {
+    id: "sprint-meeting",
+    heard: /\bspirit (meeting|meetings)\b/gi,
+    intended: /\bsprint (meeting|meetings)\b/i,
+    context: /\b(agile|scrum|sprint|software(?: engineer(?:ing)?)?|developer|devops|platform engineer|front[ -]?end|back[ -]?end)\b/i,
+    replace: (_, number) => `sprint ${number}`,
+  },
+  {
+    id: "pull-request",
+    heard: /\bpool (request|requests)\b/gi,
+    intended: /\bpull (request|requests)\b/i,
+    context: /\b(git|github|gitlab|repository|repo|code review|software(?: engineer(?:ing)?)?|developer|devops|platform engineer|front[ -]?end|back[ -]?end)\b/i,
+    replace: (_, number) => `pull ${number}`,
+  },
+];
+
+export function buildTranscriptContext({ roleTitle = "", careerArea = "", jobDescription = "", question = "" } = {}) {
+  return [roleTitle, careerArea, jobDescription, question].map(String).join(" ").replace(/\s+/g, " ").trim();
+}
+
+function applicableRules(context) {
+  return CORRECTION_RULES.filter((rule) => rule.context.test(context));
+}
+
+export function correctTranscript(transcript = "", context = "") {
+  return applicableRules(String(context)).reduce(
+    (display, rule) => display.replace(rule.heard, rule.replace),
+    String(transcript),
+  );
+}
+
+export function resolveTranscriptAlternatives(alternatives = [], context = "") {
+  const candidates = alternatives
+    .slice(0, 3)
+    .map((alternative) => ({
+      transcript: String(alternative?.transcript || "").trim(),
+      confidence: Number.isFinite(alternative?.confidence) ? alternative.confidence : null,
+    }))
+    .filter((alternative) => alternative.transcript);
+  const raw = candidates[0]?.transcript || "";
+  let selected = raw;
+
+  for (const rule of applicableRules(String(context))) {
+    if (!rule.heard.test(raw)) continue;
+    rule.heard.lastIndex = 0;
+    const domainAlternative = candidates.slice(1).find((candidate) => rule.intended.test(candidate.transcript));
+    if (domainAlternative) {
+      selected = domainAlternative.transcript;
+      break;
+    }
+  }
+
+  return { raw, display: correctTranscript(selected, context), selected };
+}

--- a/frontend/src/interviewTranscript.test.js
+++ b/frontend/src/interviewTranscript.test.js
@@ -1,0 +1,29 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { buildTranscriptContext, correctTranscript, resolveTranscriptAlternatives } from "./interviewTranscript.js";
+
+const software = buildTranscriptContext({ roleTitle: "Software Engineer", question: "How do you work in Agile teams?" });
+
+test("corrects only known substitutions in trusted software context", () => {
+  assert.equal(correctTranscript("I joined the spirit meetings and planned the next sprint", software), "I joined the sprint meetings and planned the next sprint");
+  assert.equal(correctTranscript("I opened a pool request after testing", software), "I opened a pull request after testing");
+});
+
+test("preserves genuine phrases outside technical context", () => {
+  const context = buildTranscriptContext({ roleTitle: "Community Chaplain", question: "How do you organize gatherings?" });
+  assert.equal(correctTranscript("I attended a spirit meeting by the pool", context), "I attended a spirit meeting by the pool");
+});
+
+test("prefers a matching domain alternative without combining alternatives", () => {
+  const result = resolveTranscriptAlternatives([
+    { transcript: "I opened a pool request", confidence: 0.8 },
+    { transcript: "I opened a pull request", confidence: 0.7 },
+  ], software);
+  assert.deepEqual(result, { raw: "I opened a pool request", selected: "I opened a pull request", display: "I opened a pull request" });
+});
+
+test("falls back to the first result and preserves unrelated wording", () => {
+  const result = resolveTranscriptAlternatives([{ transcript: "I reduced errors by 30 percent" }], software);
+  assert.equal(result.raw, result.display);
+  assert.equal(result.display, "I reduced errors by 30 percent");
+});

--- a/frontend/src/interviewTranscript.test.js
+++ b/frontend/src/interviewTranscript.test.js
@@ -1,5 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { analyzeAnswer } from "./interviewEngine.js";
 import { buildTranscriptContext, correctTranscript, resolveTranscriptAlternatives } from "./interviewTranscript.js";
 
 const software = buildTranscriptContext({ roleTitle: "Software Engineer", question: "How do you work in Agile teams?" });
@@ -26,4 +27,26 @@ test("falls back to the first result and preserves unrelated wording", () => {
   const result = resolveTranscriptAlternatives([{ transcript: "I reduced errors by 30 percent" }], software);
   assert.equal(result.raw, result.display);
   assert.equal(result.display, "I reduced errors by 30 percent");
+});
+
+test("restores intended terminology without changing scoring behavior", () => {
+  const raw = "I joined the spirit meetings, reviewed the logs, fixed the defect, and reduced failures by 30 percent.";
+  const intended = "I joined the sprint meetings, reviewed the logs, fixed the defect, and reduced failures by 30 percent.";
+  const corrected = correctTranscript(raw, software);
+  const options = {
+    roleTitle: "Software Engineer",
+    question: "Tell me about a technical problem you solved during a sprint.",
+    competency: "problem_solving",
+  };
+  assert.equal(corrected, intended);
+  assert.deepEqual(analyzeAnswer(corrected, options), analyzeAnswer(intended, options));
+});
+
+test("does not change meaning or scoring outside an applicable context", () => {
+  const answer = "I organized a spirit meeting for our community.";
+  const context = buildTranscriptContext({ roleTitle: "Community Chaplain" });
+  const display = correctTranscript(answer, context);
+  const options = { roleTitle: "Community Chaplain", question: "How did you organize the gathering?" };
+  assert.equal(display, answer);
+  assert.deepEqual(analyzeAnswer(display, options), analyzeAnswer(answer, options));
 });

--- a/frontend/src/interviewVoice.js
+++ b/frontend/src/interviewVoice.js
@@ -1,0 +1,36 @@
+export const INTERVIEW_VOICE_STYLES = {
+  warm: {
+    label: "Warm & professional",
+    preferredNames: ["Samantha", "Ava", "Serena", "Microsoft Aria"],
+    rate: 0.92,
+    pitch: 0.99,
+  },
+  bright: {
+    label: "Bright & friendly",
+    preferredNames: ["Ava", "Samantha", "Tessa", "Nicky"],
+    rate: 0.96,
+    pitch: 1.08,
+  },
+  calm: {
+    label: "Calm & steady",
+    preferredNames: ["Serena", "Moira", "Karen", "Google US English"],
+    rate: 0.87,
+    pitch: 0.96,
+  },
+};
+
+export function getInterviewVoiceStyle(style = "warm") {
+  return INTERVIEW_VOICE_STYLES[style] || INTERVIEW_VOICE_STYLES.warm;
+}
+
+export function chooseInterviewVoice(voices = [], style = "warm") {
+  const englishVoices = voices.filter((voice) => String(voice?.lang || "").toLowerCase().startsWith("en"));
+  const settings = getInterviewVoiceStyle(style);
+  return settings.preferredNames
+    .map((name) => englishVoices.find((voice) => String(voice.name || "").includes(name)))
+    .find(Boolean)
+    || englishVoices.find((voice) => /^en-us\b/i.test(voice.lang) && /premium|enhanced|natural|neural/i.test(voice.name))
+    || englishVoices.find((voice) => /^en-us\b/i.test(voice.lang))
+    || englishVoices[0]
+    || null;
+}

--- a/frontend/src/interviewVoice.test.js
+++ b/frontend/src/interviewVoice.test.js
@@ -1,0 +1,22 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { chooseInterviewVoice, getInterviewVoiceStyle } from "./interviewVoice.js";
+
+test("uses warm voice settings by default and falls back for unknown styles", () => {
+  assert.deepEqual(getInterviewVoiceStyle("missing"), getInterviewVoiceStyle("warm"));
+});
+
+test("keeps the three styles distinct", () => {
+  assert.notEqual(getInterviewVoiceStyle("bright").pitch, getInterviewVoiceStyle("warm").pitch);
+  assert.notEqual(getInterviewVoiceStyle("calm").rate, getInterviewVoiceStyle("warm").rate);
+});
+
+test("selects a preferred English voice and never falls back to non-English", () => {
+  const voices = [
+    { name: "Ava", lang: "fr-FR" },
+    { name: "Generic English", lang: "en-US" },
+    { name: "Samantha", lang: "en-US" },
+  ];
+  assert.equal(chooseInterviewVoice(voices, "bright").name, "Samantha");
+  assert.equal(chooseInterviewVoice([{ name: "Ava", lang: "fr-FR" }], "bright"), null);
+});


### PR DESCRIPTION
Closes #324.

## What changed
- request up to three browser speech-recognition alternatives
- preserve the first raw transcript in session memory only
- display only conservative, context-gated corrections for `spirit meeting` / `sprint meeting` and `pool request` / `pull request`
- keep the editable display answer as the sole scoring input
- add Warm, Bright, and Calm Aisha voice styles to interview setup
- add meaning, scoring, fallback, and voice-selection regression tests

## Privacy and safety
Raw transcript text is held only in a ref for the active recognition session. It is not added to responses, history, telemetry, or API payloads.

## Validation
- focused transcript and voice unit tests: 7 passed locally
- full repository checks delegated to GitHub Actions before merge