### PR TITLE
Prevent male-sounding fallback for Aisha

### DIFF
--- a/frontend/src/InterviewPracticePage.jsx
+++ b/frontend/src/InterviewPracticePage.jsx
@@ -166,10 +166,12 @@ function speakSoftText(text, { cancelFirst = false, voiceStyle = "warm" } = {}) 
     const voice = cachedSoftVoice?.style === voiceStyle
       ? cachedSoftVoice.voice
       : chooseSoftVoice(synth.getVoices?.() || [], voiceStyle);
-    if (voice) {
-      cachedSoftVoice = { style: voiceStyle, voice };
-      utterance.voice = voice;
+    if (!voice) {
+      resolve(false);
+      return;
     }
+    cachedSoftVoice = { style: voiceStyle, voice };
+    utterance.voice = voice;
     utterance.rate = settings.rate;
     utterance.pitch = settings.pitch;
     utterance.volume = 0.86;

--- a/frontend/src/interviewVoice.js
+++ b/frontend/src/interviewVoice.js
@@ -1,19 +1,45 @@
+const FEMININE_VOICE_NAMES = [
+  "Microsoft Aria",
+  "Microsoft Jenny",
+  "Microsoft Ava",
+  "Microsoft Emma",
+  "Microsoft Michelle",
+  "Microsoft Zira",
+  "Microsoft Sonia",
+  "Microsoft Libby",
+  "Microsoft Clara",
+  "Microsoft Natasha",
+  "Microsoft Ana",
+  "Samantha",
+  "Ava",
+  "Serena",
+  "Allison",
+  "Susan",
+  "Victoria",
+  "Tessa",
+  "Moira",
+  "Karen",
+  "Fiona",
+  "Nicky",
+  "Google US English",
+];
+
 export const INTERVIEW_VOICE_STYLES = {
   warm: {
     label: "Warm & professional",
-    preferredNames: ["Samantha", "Ava", "Serena", "Microsoft Aria"],
+    preferredNames: ["Microsoft Aria", "Microsoft Jenny", "Samantha", "Ava", "Microsoft Emma", "Serena"],
     rate: 0.92,
     pitch: 0.99,
   },
   bright: {
     label: "Bright & friendly",
-    preferredNames: ["Ava", "Samantha", "Tessa", "Nicky"],
+    preferredNames: ["Microsoft Ava", "Microsoft Jenny", "Ava", "Samantha", "Tessa", "Nicky", "Microsoft Ana"],
     rate: 0.96,
     pitch: 1.08,
   },
   calm: {
     label: "Calm & steady",
-    preferredNames: ["Serena", "Moira", "Karen", "Google US English"],
+    preferredNames: ["Serena", "Samantha", "Microsoft Aria", "Moira", "Karen", "Susan", "Google US English"],
     rate: 0.87,
     pitch: 0.96,
   },
@@ -23,14 +49,16 @@ export function getInterviewVoiceStyle(style = "warm") {
   return INTERVIEW_VOICE_STYLES[style] || INTERVIEW_VOICE_STYLES.warm;
 }
 
+function findNamedVoice(voices, names) {
+  return names
+    .map((name) => voices.find((voice) => String(voice.name || "").toLowerCase().includes(name.toLowerCase())))
+    .find(Boolean);
+}
+
 export function chooseInterviewVoice(voices = [], style = "warm") {
   const englishVoices = voices.filter((voice) => String(voice?.lang || "").toLowerCase().startsWith("en"));
   const settings = getInterviewVoiceStyle(style);
-  return settings.preferredNames
-    .map((name) => englishVoices.find((voice) => String(voice.name || "").includes(name)))
-    .find(Boolean)
-    || englishVoices.find((voice) => /^en-us\b/i.test(voice.lang) && /premium|enhanced|natural|neural/i.test(voice.name))
-    || englishVoices.find((voice) => /^en-us\b/i.test(voice.lang))
-    || englishVoices[0]
+  return findNamedVoice(englishVoices, settings.preferredNames)
+    || findNamedVoice(englishVoices, FEMININE_VOICE_NAMES)
     || null;
 }

--- a/frontend/src/interviewVoice.test.js
+++ b/frontend/src/interviewVoice.test.js
@@ -11,12 +11,26 @@ test("keeps the three styles distinct", () => {
   assert.notEqual(getInterviewVoiceStyle("calm").rate, getInterviewVoiceStyle("warm").rate);
 });
 
-test("selects a preferred English voice and never falls back to non-English", () => {
+test("selects an expanded feminine English voice across major platforms", () => {
   const voices = [
-    { name: "Ava", lang: "fr-FR" },
-    { name: "Generic English", lang: "en-US" },
+    { name: "Microsoft David Online (Natural)", lang: "en-US" },
+    { name: "Microsoft Jenny Online (Natural)", lang: "en-US" },
     { name: "Samantha", lang: "en-US" },
   ];
-  assert.equal(chooseInterviewVoice(voices, "bright").name, "Samantha");
-  assert.equal(chooseInterviewVoice([{ name: "Ava", lang: "fr-FR" }], "bright"), null);
+  assert.equal(chooseInterviewVoice(voices, "warm").name, "Microsoft Jenny Online (Natural)");
+  assert.equal(chooseInterviewVoice([{ name: "Samantha", lang: "en-US" }], "bright").name, "Samantha");
+});
+
+test("never selects a non-English or arbitrary male-sounding fallback", () => {
+  const unsupported = [
+    { name: "Microsoft Ava", lang: "fr-FR" },
+    { name: "Microsoft David Online (Natural)", lang: "en-US" },
+    { name: "Generic English", lang: "en-US" },
+  ];
+  assert.equal(chooseInterviewVoice(unsupported, "bright"), null);
+});
+
+test("falls back to another recognized feminine voice when a style preference is unavailable", () => {
+  const voices = [{ name: "Microsoft Zira Desktop", lang: "en-US" }];
+  assert.equal(chooseInterviewVoice(voices, "calm").name, "Microsoft Zira Desktop");
 });


### PR DESCRIPTION
Refreshes #363 onto the current main branch so required checks are evaluated against the latest base.

- expanded automatic feminine voice allowlist
- no arbitrary first-English-voice fallback
- safe text-mode fallback when no recognized feminine voice is installed
- cross-platform regression tests

Dictation, answer text, and scoring are unchanged.