### PR TITLE
Make all public profile templates responsive across devices

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,9 +13,9 @@
     "test:resume": "node --test src/resumeStructured.test.js src/dashboardTags.test.js",
     "test:safety": "node --test src/ndaSafety.test.js src/ndaInformationGateSource.test.js src/ndaGuidanceSource.test.js src/ndaApiSource.test.js",
     "test:seo": "node --test src/proofPortfolioSource.test.js src/marketingClaritySource.test.js && node scripts/verify-search-appearance.mjs",
-    "test:settings": "node --test src/settingsAccountClosureSource.test.js src/settingsBackNavigationSource.test.js src/packetsPageSource.test.js src/appearanceUiAuditSource.test.js src/wholeAppUiAuditSource.test.js src/profileTemplateRegressionSource.test.js",
+    "test:settings": "node --test src/settingsAccountClosureSource.test.js src/settingsBackNavigationSource.test.js src/packetsPageSource.test.js src/appearanceUiAuditSource.test.js src/wholeAppUiAuditSource.test.js src/profileTemplateRegressionSource.test.js src/profileResponsiveAuditSource.test.js",
     "test:clicks": "node scripts/run-click-audit.mjs",
-    "test:layout": "node scripts/audit-responsive-layout.mjs",
+    "test:layout": "node scripts/audit-responsive-layout.mjs && node scripts/audit-public-profile-layouts.mjs",
     "test:bundle": "node scripts/verify-bundle-budget.mjs",
     "preview": "vite preview"
   },

--- a/frontend/scripts/audit-public-profile-layouts.mjs
+++ b/frontend/scripts/audit-public-profile-layouts.mjs
@@ -1,0 +1,416 @@
+import assert from "node:assert/strict";
+import { spawn, spawnSync } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { createServer } from "vite";
+
+const HOST = "127.0.0.1";
+const APP_PORT = 41742;
+const DEBUG_PORT = 9225;
+const BASE_URL = `http://${HOST}:${APP_PORT}`;
+const SCREENSHOT_DIR = path.join(process.cwd(), "artifacts", "public-profile-layout");
+
+const VIEWPORTS = [
+  { name: "phone-360", width: 360, height: 800 },
+  { name: "phone-390", width: 390, height: 844 },
+  { name: "tablet-768", width: 768, height: 1024 },
+  { name: "desktop-narrow-1024", width: 1024, height: 768 },
+  { name: "desktop-1440", width: 1440, height: 900 },
+  { name: "desktop-wide-1920", width: 1920, height: 1080 },
+];
+
+const LAYOUTS = [
+  "editorial",
+  "executive-sidebar",
+  "career-timeline",
+  "studio-split",
+  "minimal-column",
+  "portfolio-grid",
+  "case-study",
+  "modern-resume",
+  "command-center",
+  "academic",
+  "founder",
+  "compact",
+];
+
+const longSkills = {
+  "Software Engineering": 5,
+  FastAPI: 5,
+  "UX Design": 5,
+  "Platform Engineering": 4,
+  React: 4,
+  "Product Development": 4,
+  "Career Technology": 4,
+  "CI/CD": 4,
+  SaaS: 3,
+  Docker: 3,
+  DNS: 3,
+  DevOps: 3,
+  "Software Architecture": 3,
+  "Data Modeling": 3,
+  Python: 3,
+  Networking: 3,
+  Git: 2,
+  "API Integration": 2,
+};
+
+const sampleEntry = {
+  id: "public-entry-1",
+  title: "Reduced incident response time across a high-volume production support workflow",
+  category: "Reliability Engineering",
+  entry_date: "2026-08-20",
+  entry_type: "Current Job",
+  action: "Built an automated triage workflow that connected support context to engineering escalation paths.",
+  impact: "Reduced response time by 42% while preserving escalation quality and customer context.",
+  resume_bullet: "Reduced incident response time by 42% by automating production support triage and escalation routing.",
+  tags: ["Software Engineering", "Platform Engineering", "API Integration", "CI/CD"],
+  is_public: true,
+};
+
+const sampleReceipt = {
+  id: "public-receipt-1",
+  accomplishment: sampleEntry.title,
+  contribution: sampleEntry.action,
+  result: sampleEntry.impact,
+  evidence: [{ title: "Incident response dashboard with a deliberately long evidence title", url: "https://example.com/evidence" }],
+  skills: ["Software Engineering", "Platform Engineering", "API Integration"],
+  metrics: [{ label: "Response time", value: "42%", context: "faster" }],
+  confirmed_count: 1,
+  is_public: true,
+};
+
+function layoutFromSlug(slug = "") {
+  const prefix = "responsive-";
+  const candidate = slug.startsWith(prefix) ? slug.slice(prefix.length) : slug;
+  return LAYOUTS.includes(candidate) ? candidate : "editorial";
+}
+
+function json(res, body, status = 200) {
+  res.statusCode = status;
+  res.setHeader("Content-Type", "application/json");
+  res.end(JSON.stringify(body));
+}
+
+function mockApiResponse(method, rawUrl) {
+  const url = new URL(rawUrl, "http://mock.local");
+  const pathname = url.pathname.replace(/^\/__profile_api/, "");
+  const match = pathname.match(/^\/public\/brag\/([^/]+)(\/.*)?$/);
+
+  if (!match) return {};
+  const slug = decodeURIComponent(match[1]);
+  const suffix = match[2] || "";
+  const layout = layoutFromSlug(slug);
+
+  if (suffix === "/profile") {
+    return {
+      profile: {
+        name: "Responsive Profile QA",
+        headline: "Software engineer building reliable systems and evidence-backed career products",
+        bio: "A deliberately long biography used to verify that every public profile template remains readable across phones, tablets, split panes, laptops, and wide desktop displays without horizontal clipping.",
+        location: "Atlanta, Georgia",
+        profile_layout: layout,
+        profile_theme: "engineer",
+        github_url: "https://github.com/example",
+        portfolio_url: "https://example.com/portfolio",
+        resume_url: "https://example.com/resume.pdf",
+        work_history: [
+          {
+            role: "Senior Platform Support Engineer",
+            company: "Example Company With A Longer Name",
+            start_date: "2024",
+            end_date: "Present",
+            location: "Remote",
+            summary: "Owned production support, incident response, automation, and cross-functional reliability improvements.",
+          },
+        ],
+        projects: [
+          {
+            name: "Evidence-backed career proof platform",
+            role: "Builder",
+            summary: "Designed and shipped a product that turns real accomplishments into reusable proof.",
+            skills: ["Product Development", "Software Architecture", "UX Design"],
+            url: "https://example.com/project",
+          },
+        ],
+      },
+    };
+  }
+  if (suffix === "/impact-receipts") return { receipts: [sampleReceipt] };
+  if (suffix === "/tags/summary") return { total_unique_tags: Object.keys(longSkills).length, tags: longSkills };
+  if (suffix === "/connection") return { calendly_enabled: false, open_to_talk: false };
+  if (suffix === "") {
+    return {
+      entries: [sampleEntry],
+      total_entries: 1,
+      activity_last_6_months: [],
+    };
+  }
+  if (method === "POST") return { ok: true };
+  return {};
+}
+
+function mockApiPlugin() {
+  return {
+    name: "boasted-public-profile-responsive-api",
+    configureServer(server) {
+      server.middlewares.use((req, res, next) => {
+        if (!req.url?.startsWith("/__profile_api")) return next();
+        req.on("data", () => {});
+        req.on("end", () => json(res, mockApiResponse(req.method || "GET", req.url || "/")));
+      });
+    },
+  };
+}
+
+function findChrome() {
+  return ["google-chrome", "chromium", "chromium-browser"]
+    .find((name) => spawnSync("which", [name], { encoding: "utf8" }).status === 0);
+}
+
+async function waitFor(fn, timeoutMs = 12000) {
+  const started = Date.now();
+  let lastError;
+  while (Date.now() - started < timeoutMs) {
+    try {
+      const result = await fn();
+      if (result) return result;
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw lastError || new Error(`Timed out after ${timeoutMs}ms`);
+}
+
+async function findPageTarget() {
+  return waitFor(async () => {
+    const response = await fetch(`http://${HOST}:${DEBUG_PORT}/json/list`);
+    if (!response.ok) return null;
+    const targets = await response.json();
+    return targets.find((target) => target.type === "page" && target.webSocketDebuggerUrl) || null;
+  }, 5000);
+}
+
+class CDP {
+  constructor(wsUrl) {
+    this.ws = new WebSocket(wsUrl);
+    this.nextId = 1;
+    this.pending = new Map();
+  }
+
+  async open() {
+    await new Promise((resolve, reject) => {
+      this.ws.addEventListener("open", resolve, { once: true });
+      this.ws.addEventListener("error", reject, { once: true });
+    });
+    this.ws.addEventListener("message", (event) => {
+      const message = JSON.parse(event.data);
+      if (!message.id || !this.pending.has(message.id)) return;
+      const { resolve, reject } = this.pending.get(message.id);
+      this.pending.delete(message.id);
+      if (message.error) reject(new Error(message.error.message));
+      else resolve(message.result);
+    });
+  }
+
+  send(method, params = {}) {
+    const id = this.nextId++;
+    return new Promise((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+      this.ws.send(JSON.stringify({ id, method, params }));
+    });
+  }
+
+  close() {
+    try { this.ws.close(); } catch { /* ignore */ }
+  }
+}
+
+async function evaluate(cdp, expression) {
+  const result = await cdp.send("Runtime.evaluate", {
+    expression,
+    awaitPromise: true,
+    returnByValue: true,
+  });
+  if (result.exceptionDetails) throw new Error(result.exceptionDetails.text || "Browser evaluation failed");
+  return result.result?.value;
+}
+
+async function setViewport(cdp, viewport) {
+  await cdp.send("Emulation.setDeviceMetricsOverride", {
+    width: viewport.width,
+    height: viewport.height,
+    deviceScaleFactor: 1,
+    mobile: false,
+  });
+}
+
+async function openProfile(cdp, layout) {
+  await cdp.send("Page.navigate", { url: `${BASE_URL}/brag/responsive-${layout}` });
+  await waitFor(async () => evaluate(cdp, `(() => {
+    const root = document.querySelector('.proof-portfolio[data-layout="${layout}"]');
+    return Boolean(root && document.querySelectorAll('.portfolio-skill-cloud > span').length >= 18);
+  })()`));
+  await new Promise((resolve) => setTimeout(resolve, 100));
+}
+
+async function measureProfile(cdp) {
+  return evaluate(cdp, `(() => {
+    const viewportWidth = window.innerWidth;
+    const documentWidth = Math.max(document.documentElement.scrollWidth, document.body.scrollWidth);
+    const visible = (element) => {
+      if (!element) return false;
+      const style = getComputedStyle(element);
+      const rect = element.getBoundingClientRect();
+      return style.display !== 'none' && style.visibility !== 'hidden' && rect.width > 0 && rect.height > 0;
+    };
+    const rectFor = (selector) => {
+      const element = document.querySelector(selector);
+      if (!visible(element)) return null;
+      const rect = element.getBoundingClientRect();
+      return { left: rect.left, right: rect.right, width: rect.width, height: rect.height };
+    };
+    const offenders = [...document.querySelectorAll('.proof-portfolio *')]
+      .filter((element) => {
+        if (!visible(element)) return false;
+        const style = getComputedStyle(element);
+        if (['fixed', 'absolute'].includes(style.position)) return false;
+        if (['auto', 'scroll'].includes(style.overflowX)) return false;
+        const rect = element.getBoundingClientRect();
+        return rect.left < -1 || rect.right > viewportWidth + 1;
+      })
+      .slice(0, 12)
+      .map((element) => {
+        const rect = element.getBoundingClientRect();
+        return {
+          tag: element.tagName.toLowerCase(),
+          className: typeof element.className === 'string' ? element.className.slice(0, 120) : '',
+          left: Math.round(rect.left * 10) / 10,
+          right: Math.round(rect.right * 10) / 10,
+          width: Math.round(rect.width * 10) / 10,
+        };
+      });
+    const skillCards = [...document.querySelectorAll('.portfolio-skill-cloud > span')].map((element) => {
+      const rect = element.getBoundingClientRect();
+      const label = element.querySelector('strong');
+      const labelRect = label?.getBoundingClientRect();
+      return {
+        width: rect.width,
+        height: rect.height,
+        labelWidth: labelRect?.width || 0,
+        labelScrollWidth: label?.scrollWidth || 0,
+      };
+    });
+    const touchTargets = [...document.querySelectorAll('.portfolio-share, .proof-action')]
+      .filter(visible)
+      .map((element) => element.getBoundingClientRect().height);
+    return {
+      viewportWidth,
+      documentWidth,
+      root: rectFor('.proof-portfolio'),
+      inner: rectFor('.proof-profile-inner'),
+      hero: rectFor('.portfolio-hero'),
+      skills: rectFor('.portfolio-skills-section'),
+      offenders,
+      skillCards,
+      touchTargets,
+    };
+  })()`);
+}
+
+function assertWithinViewport(rect, viewportWidth, label) {
+  assert.ok(rect, `${label} is not visible`);
+  assert.ok(rect.left >= -1, `${label} starts outside viewport: left=${rect.left}`);
+  assert.ok(rect.right <= viewportWidth + 1, `${label} is cut off: right=${rect.right}, viewport=${viewportWidth}`);
+  assert.ok(rect.width <= viewportWidth + 1, `${label} is wider than viewport: width=${rect.width}`);
+}
+
+async function captureFailure(cdp, layout, viewport) {
+  await fs.mkdir(SCREENSHOT_DIR, { recursive: true });
+  const result = await cdp.send("Page.captureScreenshot", { format: "png", fromSurface: true });
+  const filename = `${layout}-${viewport.name}.png`;
+  await fs.writeFile(path.join(SCREENSHOT_DIR, filename), Buffer.from(result.data, "base64"));
+  return filename;
+}
+
+const chrome = findChrome();
+assert.ok(chrome, "Chrome/Chromium is required for public profile layout CI");
+process.env.VITE_API_BASE_URL = "/__profile_api";
+
+const server = await createServer({
+  root: process.cwd(),
+  logLevel: "error",
+  plugins: [mockApiPlugin()],
+  server: { host: HOST, port: APP_PORT, strictPort: true },
+});
+const userDataDir = await fs.mkdtemp(path.join(os.tmpdir(), "boasted-public-profile-layout-"));
+let browser;
+let cdp;
+const failures = [];
+
+try {
+  await fs.rm(SCREENSHOT_DIR, { recursive: true, force: true });
+  await server.listen();
+  browser = spawn(chrome, [
+    "--headless=new",
+    "--no-sandbox",
+    "--disable-gpu",
+    "--disable-dev-shm-usage",
+    `--remote-debugging-port=${DEBUG_PORT}`,
+    `--user-data-dir=${userDataDir}`,
+    "about:blank",
+  ], { stdio: ["ignore", "ignore", "pipe"] });
+
+  const target = await findPageTarget();
+  cdp = new CDP(target.webSocketDebuggerUrl);
+  await cdp.open();
+  await Promise.all([cdp.send("Page.enable"), cdp.send("Runtime.enable")]);
+
+  for (const viewport of VIEWPORTS) {
+    await setViewport(cdp, viewport);
+    for (const layout of LAYOUTS) {
+      const label = `${layout} @ ${viewport.width}x${viewport.height}`;
+      try {
+        await openProfile(cdp, layout);
+        const measurement = await measureProfile(cdp);
+        assert.ok(
+          measurement.documentWidth <= measurement.viewportWidth + 1,
+          `${label} has horizontal overflow: document=${measurement.documentWidth}, viewport=${measurement.viewportWidth}`,
+        );
+        assertWithinViewport(measurement.root, measurement.viewportWidth, `${label} profile`);
+        assertWithinViewport(measurement.inner, measurement.viewportWidth, `${label} profile inner`);
+        assertWithinViewport(measurement.hero, measurement.viewportWidth, `${label} hero`);
+        assertWithinViewport(measurement.skills, measurement.viewportWidth, `${label} skills section`);
+        assert.equal(measurement.offenders.length, 0, `${label} has clipped elements: ${JSON.stringify(measurement.offenders)}`);
+        assert.equal(measurement.skillCards.length, 18, `${label} should render all 18 skill cards`);
+        measurement.skillCards.forEach((card, index) => {
+          assert.ok(card.width >= 180, `${label} skill card ${index + 1} is too narrow: ${card.width}px`);
+          assert.ok(card.labelScrollWidth <= card.labelWidth + 1, `${label} skill label ${index + 1} overflows its card`);
+        });
+        measurement.touchTargets.forEach((height, index) => {
+          assert.ok(height >= 44, `${label} touch target ${index + 1} is only ${height}px high`);
+        });
+        console.log(`PUBLIC PROFILE UI PASS ${label}`);
+      } catch (error) {
+        let screenshot = "";
+        try { screenshot = await captureFailure(cdp, layout, viewport); } catch { /* best effort */ }
+        failures.push(`${label}: ${error.message}${screenshot ? ` [screenshot: ${screenshot}]` : ""}`);
+      }
+    }
+  }
+
+  if (failures.length) {
+    console.error("\nPUBLIC PROFILE UI FAILURES");
+    failures.forEach((failure) => console.error(`- ${failure}`));
+    process.exitCode = 1;
+  } else {
+    console.log(`\nPublic profile guard passed ${LAYOUTS.length} templates across ${VIEWPORTS.length} viewport sizes (${LAYOUTS.length * VIEWPORTS.length} checks).`);
+  }
+} finally {
+  cdp?.close();
+  if (browser && browser.exitCode === null && browser.signalCode === null) browser.kill("SIGKILL");
+  await server.close();
+  await fs.rm(userDataDir, { recursive: true, force: true, maxRetries: 8, retryDelay: 150 });
+}

--- a/frontend/src/ProfileResponsiveAudit.css
+++ b/frontend/src/ProfileResponsiveAudit.css
@@ -1,0 +1,359 @@
+/*
+ * Public profile responsive hardening.
+ *
+ * The profile templates can render inside a narrow browser, embedded preview,
+ * split pane, or other constrained surface. Viewport-only media queries cannot
+ * reliably detect those cases, so this layer responds to the profile's actual
+ * inline size while keeping the 12 flower layouts visually distinct.
+ */
+
+.proof-portfolio {
+  container: profile / inline-size;
+  overflow-x: clip;
+}
+
+.proof-portfolio .portfolio-skills-section {
+  container: skills / inline-size;
+}
+
+/* Long user-authored content must wrap as words, not create horizontal scroll. */
+.proof-portfolio :where(
+  .portfolio-identity,
+  .portfolio-proof-passport,
+  .portfolio-section,
+  .portfolio-impact-card,
+  .portfolio-work-card,
+  .portfolio-career-item,
+  .portfolio-evidence-list,
+  .portfolio-skill-chips,
+  .portfolio-passport-grid
+) {
+  min-width: 0;
+  max-width: 100%;
+}
+
+.proof-portfolio :where(h1, h2, h3, p, a, strong, span, small) {
+  word-break: normal;
+}
+
+.proof-portfolio :where(
+  .portfolio-identity h1,
+  .portfolio-impact-card h3,
+  .portfolio-work-card h3,
+  .portfolio-career-item h3,
+  .portfolio-evidence-list a,
+  .portfolio-evidence-list > span,
+  .portfolio-skill-chips span
+) {
+  overflow-wrap: break-word;
+}
+
+/*
+ * Skills are a content-driven grid. This intentionally overrides fixed 3/4
+ * column template rules: a 220px minimum keeps labels such as
+ * "Software Engineering" readable instead of turning cards into vertical pills.
+ */
+.proof-portfolio[data-layout] .portfolio-skill-cloud {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 220px), 1fr));
+  gap: 10px;
+  align-items: start;
+}
+
+.proof-portfolio[data-layout] .portfolio-skill-cloud > span {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: start;
+  gap: 6px 12px;
+  min-width: 0;
+  min-height: 0;
+  height: auto;
+  padding: 14px 16px;
+}
+
+.proof-portfolio[data-layout] .portfolio-skill-cloud strong {
+  min-width: 0;
+  overflow-wrap: break-word;
+  line-height: 1.25;
+}
+
+.proof-portfolio[data-layout] .portfolio-skill-cloud small {
+  min-width: 0;
+  white-space: normal;
+  line-height: 1.35;
+  text-align: right;
+}
+
+/* Interactive controls should remain comfortably tappable on touch screens. */
+.proof-portfolio :where(
+  .proof-action,
+  .portfolio-share,
+  .portfolio-footer button,
+  .proof-filter-row button,
+  .proof-pagination-controls button
+) {
+  min-height: 44px;
+}
+
+.proof-portfolio .proof-search input {
+  min-width: 0;
+  width: 100%;
+}
+
+/* Medium containers: preserve personality, reduce dense desktop grids. */
+@container profile (max-width: 980px) {
+  .proof-portfolio[data-layout="portfolio-grid"] :where(.portfolio-impact-grid, .portfolio-work-grid),
+  .proof-portfolio[data-layout="command-center"] :where(.portfolio-impact-grid, .portfolio-work-grid),
+  .proof-portfolio[data-layout="founder"] .portfolio-impact-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .proof-portfolio[data-layout="portfolio-grid"] .portfolio-impact-card.featured,
+  .proof-portfolio[data-layout="founder"] .portfolio-impact-card.featured {
+    grid-column: span 2;
+    grid-row: auto;
+  }
+
+  .proof-portfolio[data-layout="case-study"] .portfolio-impact-card.featured {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+/* Narrow tablets and split panes: every hero gets a safe single-column mode. */
+@container profile (max-width: 820px) {
+  .proof-portfolio[data-layout] .portfolio-hero {
+    grid-template-columns: minmax(0, 1fr);
+    min-height: 0;
+  }
+
+  .proof-portfolio[data-layout="executive-sidebar"] .portfolio-identity,
+  .proof-portfolio[data-layout="executive-sidebar"] .portfolio-proof-passport,
+  .proof-portfolio[data-layout="studio-split"] .portfolio-identity,
+  .proof-portfolio[data-layout="studio-split"] .portfolio-proof-passport {
+    padding: clamp(28px, 6vw, 40px);
+  }
+
+  .proof-portfolio[data-layout="minimal-column"] .portfolio-proof-passport,
+  .proof-portfolio[data-layout="case-study"] .portfolio-proof-passport {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .proof-portfolio[data-layout] .portfolio-impact-card.featured {
+    grid-template-columns: minmax(0, 1fr);
+    grid-column: auto;
+    grid-row: auto;
+  }
+
+  .proof-portfolio[data-layout] .portfolio-impact-card.featured :where(
+    .portfolio-card-kicker,
+    h3,
+    .portfolio-impact-copy,
+    .portfolio-skill-chips,
+    .portfolio-evidence-list,
+    .portfolio-metric
+  ) {
+    grid-column: 1;
+    grid-row: auto;
+  }
+
+  .proof-portfolio[data-layout] .portfolio-career-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .proof-portfolio[data-layout="editorial"] :where(.portfolio-impact-grid, .portfolio-work-grid),
+  .proof-portfolio[data-layout="studio-split"] .portfolio-work-grid,
+  .proof-portfolio[data-layout="modern-resume"] .portfolio-work-grid,
+  .proof-portfolio[data-layout="compact"] :where(.portfolio-impact-grid, .portfolio-work-grid) {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .proof-portfolio[data-layout="studio-split"] .portfolio-work-card:nth-child(3n),
+  .proof-portfolio[data-layout="portfolio-grid"] .portfolio-work-card:nth-child(4n + 1) {
+    grid-column: auto;
+  }
+}
+
+/* Phones and phone-sized preview panes. */
+@container profile (max-width: 640px) {
+  .proof-portfolio .proof-profile-inner {
+    width: min(100% - 24px, 1180px);
+    padding-bottom: 36px;
+  }
+
+  .proof-portfolio .portfolio-topbar {
+    gap: 10px;
+  }
+
+  .proof-portfolio .portfolio-topbar-actions {
+    min-width: 0;
+    gap: 6px;
+  }
+
+  .proof-portfolio .proof-topbar-tag {
+    display: none;
+  }
+
+  .proof-portfolio[data-layout] .portfolio-hero {
+    gap: 20px;
+    padding: 24px 20px;
+    border-radius: 24px;
+  }
+
+  .proof-portfolio[data-layout="editorial"] .portfolio-hero,
+  .proof-portfolio[data-layout="case-study"] .portfolio-hero,
+  .proof-portfolio[data-layout="academic"] .portfolio-hero {
+    padding-left: 0;
+    padding-right: 0;
+  }
+
+  .proof-portfolio[data-layout] .portfolio-identity h1 {
+    max-width: 100%;
+    font-size: clamp(2.35rem, 13vw, 4rem);
+    line-height: .96;
+    letter-spacing: -.055em;
+    overflow-wrap: break-word;
+  }
+
+  .proof-portfolio[data-layout] .portfolio-section {
+    padding: 22px 18px;
+    border-radius: 22px;
+  }
+
+  .proof-portfolio[data-layout] .portfolio-section-heading {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
+  }
+
+  .proof-portfolio[data-layout] .portfolio-section-heading h2 {
+    max-width: 100%;
+    font-size: clamp(2rem, 10vw, 3.35rem);
+    line-height: 1;
+  }
+
+  .proof-portfolio[data-layout] :where(
+    .portfolio-impact-grid,
+    .portfolio-work-grid,
+    .portfolio-career-grid,
+    .portfolio-impact-copy
+  ) {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .proof-portfolio[data-layout] :where(
+    .portfolio-impact-card,
+    .portfolio-work-card,
+    .portfolio-proof-passport
+  ) {
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  .proof-portfolio[data-layout] .portfolio-proof-passport {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    padding: 19px;
+  }
+
+  .proof-portfolio[data-layout] .portfolio-passport-grid {
+    width: 100%;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .proof-portfolio[data-layout] .portfolio-actions {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    width: 100%;
+  }
+
+  .proof-portfolio[data-layout] .portfolio-actions .proof-action {
+    width: 100%;
+    justify-content: center;
+    text-align: center;
+  }
+
+  .proof-portfolio[data-layout] .portfolio-work-card-head {
+    grid-template-columns: auto minmax(0, 1fr);
+  }
+
+  .proof-portfolio[data-layout] .proof-filter-row {
+    display: flex;
+    flex-wrap: nowrap;
+    max-width: 100%;
+    overflow-x: auto;
+    overscroll-behavior-inline: contain;
+    scrollbar-width: none;
+  }
+
+  .proof-portfolio[data-layout] .proof-filter-row::-webkit-scrollbar {
+    display: none;
+  }
+
+  .proof-portfolio[data-layout] .proof-filter-row button {
+    flex: 0 0 auto;
+  }
+
+  .proof-portfolio[data-layout] :where(.portfolio-footer, .portfolio-pagination) {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .proof-portfolio[data-layout] .portfolio-footer button {
+    width: 100%;
+  }
+}
+
+/* The screenshot regression: a narrow skills section must never keep 3-4 cols. */
+@container skills (max-width: 560px) {
+  .proof-portfolio[data-layout] .portfolio-skill-cloud {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .proof-portfolio[data-layout] .portfolio-skill-cloud > span {
+    grid-template-columns: minmax(0, 1fr) auto;
+  }
+}
+
+@container profile (max-width: 420px) {
+  .proof-portfolio .proof-profile-inner {
+    width: min(100% - 16px, 1180px);
+  }
+
+  .proof-portfolio[data-layout] .portfolio-hero,
+  .proof-portfolio[data-layout] .portfolio-section {
+    padding-left: 16px;
+    padding-right: 16px;
+  }
+
+  .proof-portfolio[data-layout="editorial"] .portfolio-hero,
+  .proof-portfolio[data-layout="case-study"] .portfolio-hero,
+  .proof-portfolio[data-layout="academic"] .portfolio-hero {
+    padding-left: 0;
+    padding-right: 0;
+  }
+
+  .proof-portfolio[data-layout] .portfolio-passport-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .proof-portfolio[data-layout] .portfolio-skill-cloud > span {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .proof-portfolio[data-layout] .portfolio-skill-cloud small {
+    text-align: left;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .proof-portfolio *,
+  .proof-portfolio *::before,
+  .proof-portfolio *::after {
+    scroll-behavior: auto !important;
+    transition-duration: .01ms !important;
+    animation-duration: .01ms !important;
+    animation-iteration-count: 1 !important;
+  }
+}

--- a/frontend/src/ProfileResponsiveAuditOverrides.css
+++ b/frontend/src/ProfileResponsiveAuditOverrides.css
@@ -1,0 +1,27 @@
+/*
+ * High-specificity safeguards for profile CSS that is loaded with the lazy
+ * PublicBragPage chunk after the app-wide responsive audit layer.
+ */
+
+.proof-portfolio[data-layout][data-theme] .portfolio-share,
+.proof-portfolio[data-layout][data-theme] .proof-action,
+.proof-portfolio[data-layout][data-theme] .portfolio-footer button,
+.proof-portfolio[data-layout][data-theme] .proof-pagination-controls button {
+  min-height: 44px;
+}
+
+@container profile (max-width: 640px) {
+  /* Keep every filter visible instead of hiding choices off-canvas on phones. */
+  .proof-portfolio[data-layout][data-theme] .proof-filter-row {
+    flex-wrap: wrap;
+    overflow-x: visible;
+    padding-bottom: 0;
+  }
+
+  .proof-portfolio[data-layout][data-theme] .proof-filter-row button {
+    flex: 0 1 auto;
+    max-width: 100%;
+    white-space: normal;
+    overflow-wrap: break-word;
+  }
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -12,6 +12,7 @@ import "./ProfileAppearancePreview.css";
 import "./UiUxFoundation.css";
 import "./ProfileTemplateRegressionFixes.css";
 import "./ProfileDesktopBalance.css";
+import "./ProfileResponsiveAudit.css";
 import NDAInformationGate from "./NDAInformationGate.jsx";
 import PublicAuthHeader from "./PublicAuthHeader.jsx";
 import RootContent from "./RootContent.jsx";

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -13,6 +13,7 @@ import "./UiUxFoundation.css";
 import "./ProfileTemplateRegressionFixes.css";
 import "./ProfileDesktopBalance.css";
 import "./ProfileResponsiveAudit.css";
+import "./ProfileResponsiveAuditOverrides.css";
 import NDAInformationGate from "./NDAInformationGate.jsx";
 import PublicAuthHeader from "./PublicAuthHeader.jsx";
 import RootContent from "./RootContent.jsx";

--- a/frontend/src/profileResponsiveAuditSource.test.js
+++ b/frontend/src/profileResponsiveAuditSource.test.js
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const css = readFileSync(new URL("./ProfileResponsiveAudit.css", import.meta.url), "utf8");
+const main = readFileSync(new URL("./main.jsx", import.meta.url), "utf8");
+const themes = readFileSync(new URL("./profileThemes.js", import.meta.url), "utf8");
+
+const layouts = [
+  "editorial",
+  "executive-sidebar",
+  "career-timeline",
+  "studio-split",
+  "minimal-column",
+  "portfolio-grid",
+  "case-study",
+  "modern-resume",
+  "command-center",
+  "academic",
+  "founder",
+  "compact",
+];
+
+test("responsive audit layer loads after existing profile overrides", () => {
+  const desktopIndex = main.indexOf('import "./ProfileDesktopBalance.css";');
+  const responsiveIndex = main.indexOf('import "./ProfileResponsiveAudit.css";');
+  assert.ok(desktopIndex >= 0, "desktop profile balance import is missing");
+  assert.ok(responsiveIndex > desktopIndex, "responsive audit must load last among profile override layers");
+});
+
+test("all twelve profile layouts remain part of the responsive contract", () => {
+  for (const layout of layouts) {
+    assert.match(themes, new RegExp(`id:\\s*["']${layout}["']`));
+  }
+  assert.match(css, /\.proof-portfolio\[data-layout\]/);
+});
+
+test("profile and skills respond to their actual container width", () => {
+  assert.match(css, /container:\s*profile\s*\/\s*inline-size/);
+  assert.match(css, /container:\s*skills\s*\/\s*inline-size/);
+  assert.match(css, /@container\s+profile\s*\(max-width:\s*820px\)/);
+  assert.match(css, /@container\s+profile\s*\(max-width:\s*640px\)/);
+  assert.match(css, /@container\s+skills\s*\(max-width:\s*560px\)/);
+});
+
+test("skill cards cannot regress into skinny vertical pills", () => {
+  assert.match(css, /repeat\(auto-fit,\s*minmax\(min\(100%,\s*220px\),\s*1fr\)\)/);
+  assert.match(css, /portfolio-skill-cloud\s*>\s*span[^}]*grid-template-columns:\s*minmax\(0,\s*1fr\)\s+auto/s);
+  assert.match(css, /portfolio-skill-cloud\s+strong[^}]*overflow-wrap:\s*break-word/s);
+  assert.match(css, /@container\s+skills[\s\S]*grid-template-columns:\s*minmax\(0,\s*1fr\)/);
+});
+
+test("phone profile mode collapses dense content without losing touch ergonomics", () => {
+  assert.match(css, /@container\s+profile\s*\(max-width:\s*640px\)[\s\S]*portfolio-impact-grid[\s\S]*grid-template-columns:\s*minmax\(0,\s*1fr\)/);
+  assert.match(css, /portfolio-actions[\s\S]*grid-template-columns:\s*minmax\(0,\s*1fr\)/);
+  assert.match(css, /min-height:\s*44px/);
+  assert.match(css, /overflow-x:\s*auto/);
+});
+
+test("responsive layer respects reduced-motion preferences", () => {
+  assert.match(css, /@media\s*\(prefers-reduced-motion:\s*reduce\)/);
+});


### PR DESCRIPTION
## What changed

- Adds a late-loading `ProfileResponsiveAudit.css` layer that responds to the **profile/container width**, not only the browser viewport.
- Fixes the demonstrated-skills regression where long labels collapse into skinny vertical cards.
- Adds safe single-column modes for narrow tablets, phones, split panes, and embedded previews while preserving the 12 flower template identities on larger screens.
- Hardens long user-authored text, evidence links, action buttons, filter rows, touch targets, and reduced-motion behavior.
- Adds a browser-level public-profile audit covering **all 12 layouts × 6 viewport sizes = 72 checks**.
- Extends source-level regression tests and the existing `test:layout` command so this class of bug is caught before merge.

## Why

The existing responsive CI covered authenticated app routes but did not exercise `/brag/:slug` or each saved profile layout. Some template rules also used fixed column counts based on viewport width, so a narrow profile container could still render as 3–4 columns even when the actual content area was too small.

## QA targets

- Dahlia / editorial
- Magnolia / executive-sidebar
- Iris / career-timeline
- Peony / studio-split
- Camellia / minimal-column
- Lotus / portfolio-grid
- Hibiscus / case-study
- Poppy / modern-resume
- Protea / command-center
- Jasmine / academic
- Marigold / founder
- Lavender / compact

Viewports: 360×800, 390×844, 768×1024, 1024×768, 1440×900, 1920×1080.
