### PR TITLE
P0: harden crawl shells and public profile responsiveness

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,7 @@
     "test:resume": "node --test src/resumeStructured.test.js src/dashboardTags.test.js",
     "test:safety": "node --test src/ndaSafety.test.js src/ndaInformationGateSource.test.js src/ndaGuidanceSource.test.js src/ndaApiSource.test.js",
     "test:seo": "node --test src/proofPortfolioSource.test.js src/marketingClaritySource.test.js && node scripts/verify-search-appearance.mjs",
-    "test:settings": "node --test src/settingsAccountClosureSource.test.js src/settingsBackNavigationSource.test.js src/packetsPageSource.test.js src/appearanceUiAuditSource.test.js src/wholeAppUiAuditSource.test.js src/profileTemplateRegressionSource.test.js",
+    "test:settings": "node --test src/settingsAccountClosureSource.test.js src/settingsBackNavigationSource.test.js src/packetsPageSource.test.js src/appearanceUiAuditSource.test.js src/wholeAppUiAuditSource.test.js src/profileTemplateRegressionSource.test.js src/profileResponsiveSafetySource.test.js",
     "test:clicks": "node scripts/run-click-audit.mjs",
     "test:layout": "node scripts/audit-responsive-layout.mjs",
     "test:bundle": "node scripts/verify-bundle-budget.mjs",

--- a/frontend/scripts/generate-static-route-shells.mjs
+++ b/frontend/scripts/generate-static-route-shells.mjs
@@ -1,4 +1,4 @@
-import { copyFile, mkdir, readFile } from "node:fs/promises";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -29,6 +29,8 @@ const REQUIRED_CLIENT_ROUTES = [
   "/legal/education-data",
 ];
 
+const NOINDEX_ROUTES = new Set(["/upgrade", "/verify-receipt"]);
+
 function normalizeRoute(route) {
   const pathname = route.split(/[?#]/, 1)[0] || "/";
   if (!pathname.startsWith("/")) return null;
@@ -49,7 +51,32 @@ function sitemapRoutes(xml) {
   return routes;
 }
 
-const sitemapXml = await readFile(SITEMAP_FILE, "utf8");
+function routeShell(indexHtml, route) {
+  const canonicalUrl = `${SITE_ORIGIN}${route}`;
+  let html = indexHtml
+    .replace(
+      /<link rel="canonical" href="[^"]*"\s*\/>/,
+      `<link rel="canonical" href="${canonicalUrl}" />`,
+    )
+    .replace(
+      /<meta property="og:url" content="[^"]*"\s*\/>/,
+      `<meta property="og:url" content="${canonicalUrl}" />`,
+    );
+
+  if (NOINDEX_ROUTES.has(route)) {
+    html = html.replace(
+      /<meta name="robots" content="[^"]*"\s*\/>/,
+      '<meta name="robots" content="noindex,nofollow" />',
+    );
+  }
+
+  return html;
+}
+
+const [sitemapXml, indexHtml] = await Promise.all([
+  readFile(SITEMAP_FILE, "utf8"),
+  readFile(INDEX_FILE, "utf8"),
+]);
 const routes = new Set([
   ...sitemapRoutes(sitemapXml),
   ...REQUIRED_CLIENT_ROUTES.map(normalizeRoute).filter(Boolean),
@@ -59,11 +86,12 @@ for (const route of [...routes].sort()) {
   const relativeRoute = route.slice(1);
   const routeDir = path.join(DIST_DIR, relativeRoute);
   await mkdir(routeDir, { recursive: true });
-  await copyFile(INDEX_FILE, path.join(routeDir, "index.html"));
+  await writeFile(path.join(routeDir, "index.html"), routeShell(indexHtml, route), "utf8");
 }
 
 // Render serves a static site, so unknown client-side routes need an SPA shell too.
-// This keeps dynamic public profile/share links from becoming a dead-end 404 page.
-await copyFile(INDEX_FILE, path.join(DIST_DIR, "404.html"));
+// Keep the generic 404 shell canonicalized to the homepage; dynamic public profile
+// metadata is applied client-side after the requested slug loads.
+await writeFile(path.join(DIST_DIR, "404.html"), indexHtml, "utf8");
 
-console.log(`Generated SPA route shells for ${routes.size} public/client routes.`);
+console.log(`Generated route-specific SPA shells for ${routes.size} public/client routes.`);

--- a/frontend/scripts/verify-search-appearance.mjs
+++ b/frontend/scripts/verify-search-appearance.mjs
@@ -9,6 +9,7 @@ const searchMeta = read("src/useSearchAppearanceMeta.js");
 const sitelinksNav = read("src/SearchSitelinksNav.jsx");
 const sitelinksConfig = read("src/seoSitelinks.js");
 const seoLandingPages = read("src/SeoLandingPages.jsx");
+const staticRouteShells = read("scripts/generate-static-route-shells.mjs");
 
 const publicSitelinks = [
   "/resume-accomplishments",
@@ -53,5 +54,15 @@ assert.match(searchMeta, /"\/verify-receipt"/);
 assert.match(searchMeta, /SiteNavigationElement/);
 assert.match(searchMeta, /max-image-preview:large/);
 assert.match(searchMeta, /https:\/\/boasted\.io/);
+
+// Static HTML must not tell crawlers every sitemap route is the homepage.
+assert.match(staticRouteShells, /function routeShell\(indexHtml, route\)/);
+assert.match(staticRouteShells, /canonicalUrl = `\$\{SITE_ORIGIN\}\$\{route\}`/);
+assert.match(staticRouteShells, /<link rel="canonical"/);
+assert.match(staticRouteShells, /<meta property="og:url"/);
+assert.match(staticRouteShells, /writeFile\(path\.join\(routeDir, "index\.html"\), routeShell\(indexHtml, route\)/);
+assert.doesNotMatch(staticRouteShells, /copyFile\(INDEX_FILE, path\.join\(routeDir, "index\.html"\)\)/);
+assert.match(staticRouteShells, /NOINDEX_ROUTES = new Set\(\["\/upgrade", "\/verify-receipt"\]\)/);
+assert.match(staticRouteShells, /noindex,nofollow/);
 
 console.log(`Search quality gates passed for ${publicSitelinks.length} priority routes and ${sitemapUrls.length} sitemap URLs.`);

--- a/frontend/src/ProfileResponsiveSafety.css
+++ b/frontend/src/ProfileResponsiveSafety.css
@@ -1,0 +1,128 @@
+/*
+ * Shared responsive safety contract for every public Proof Portfolio theme.
+ * Themes may change presentation, but they may not change these layout invariants.
+ */
+
+.proof-portfolio,
+.proof-portfolio .proof-profile-inner,
+.proof-portfolio .portfolio-topbar,
+.proof-portfolio .portfolio-topbar-actions,
+.proof-portfolio .portfolio-hero,
+.proof-portfolio .portfolio-identity,
+.proof-portfolio .portfolio-proof-passport,
+.proof-portfolio .portfolio-section,
+.proof-portfolio .portfolio-section-heading,
+.proof-portfolio .portfolio-section-heading > *,
+.proof-portfolio .portfolio-impact-grid,
+.proof-portfolio .portfolio-impact-card,
+.proof-portfolio .portfolio-impact-copy,
+.proof-portfolio .portfolio-impact-copy > *,
+.proof-portfolio .portfolio-work-grid,
+.proof-portfolio .portfolio-work-card,
+.proof-portfolio .portfolio-work-card-head,
+.proof-portfolio .portfolio-work-card-head > *,
+.proof-portfolio .portfolio-career-grid,
+.proof-portfolio .portfolio-career-column,
+.proof-portfolio .portfolio-career-item,
+.proof-portfolio .portfolio-skill-cloud,
+.proof-portfolio .portfolio-skill-cloud > span,
+.proof-portfolio .portfolio-evidence-list,
+.proof-portfolio .portfolio-passport-grid,
+.proof-portfolio .portfolio-passport-grid > * {
+  min-width: 0;
+  max-width: 100%;
+}
+
+/* User-controlled text must wrap by words where possible and never force width. */
+.proof-portfolio .portfolio-identity h1,
+.proof-portfolio .proof-headline,
+.proof-portfolio .proof-bio,
+.proof-portfolio .proof-location,
+.proof-portfolio .portfolio-impact-card h3,
+.proof-portfolio .portfolio-impact-card p,
+.proof-portfolio .portfolio-work-card h3,
+.proof-portfolio .portfolio-work-card p,
+.proof-portfolio .portfolio-career-item h3,
+.proof-portfolio .portfolio-career-item p,
+.proof-portfolio .portfolio-section-heading h2,
+.proof-portfolio .portfolio-section-heading p,
+.proof-portfolio .portfolio-skill-cloud strong,
+.proof-portfolio .portfolio-skill-cloud small,
+.proof-portfolio .portfolio-passport-grid span,
+.proof-portfolio .portfolio-passport-note,
+.proof-portfolio .portfolio-evidence-list a,
+.proof-portfolio .portfolio-evidence-list > span,
+.proof-portfolio .proof-pagination-summary {
+  overflow-wrap: anywhere;
+  word-break: normal;
+}
+
+.proof-portfolio a,
+.proof-portfolio button,
+.proof-portfolio input {
+  max-width: 100%;
+}
+
+.proof-portfolio .portfolio-topbar-actions,
+.proof-portfolio .portfolio-actions,
+.proof-portfolio .proof-pagination-controls {
+  flex-wrap: wrap;
+}
+
+/* Interactive controls remain reachable by touch without hiding content. */
+.proof-portfolio .portfolio-share,
+.proof-portfolio .proof-action,
+.proof-portfolio .proof-filter-row button,
+.proof-portfolio .proof-pagination-controls button,
+.proof-portfolio .portfolio-footer button {
+  min-height: 44px;
+}
+
+@media (max-width: 640px) {
+  .proof-portfolio .portfolio-hero,
+  .proof-portfolio .portfolio-impact-grid,
+  .proof-portfolio .portfolio-impact-card.featured,
+  .proof-portfolio .portfolio-impact-copy,
+  .proof-portfolio .portfolio-work-grid,
+  .proof-portfolio .portfolio-career-grid,
+  .proof-portfolio .portfolio-skill-cloud {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .proof-portfolio .portfolio-section-heading {
+    min-width: 0;
+  }
+
+  .proof-portfolio .portfolio-passport-grid {
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 140px), 1fr));
+  }
+}
+
+@media (max-width: 430px) {
+  .proof-portfolio .proof-profile-inner {
+    width: min(100% - 20px, 1180px);
+  }
+
+  .proof-portfolio .portfolio-topbar {
+    align-items: flex-start;
+    gap: 10px;
+  }
+
+  .proof-portfolio .portfolio-topbar-actions {
+    justify-content: flex-end;
+  }
+
+  .proof-portfolio .portfolio-hero,
+  .proof-portfolio .portfolio-section {
+    padding-left: 16px;
+    padding-right: 16px;
+  }
+
+  .proof-portfolio .portfolio-work-card-head {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .proof-portfolio .portfolio-work-index {
+    width: 39px;
+  }
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -12,6 +12,7 @@ import "./ProfileAppearancePreview.css";
 import "./UiUxFoundation.css";
 import "./ProfileTemplateRegressionFixes.css";
 import "./ProfileDesktopBalance.css";
+import "./ProfileResponsiveSafety.css";
 import NDAInformationGate from "./NDAInformationGate.jsx";
 import PublicAuthHeader from "./PublicAuthHeader.jsx";
 import RootContent from "./RootContent.jsx";

--- a/frontend/src/profileResponsiveSafetySource.test.js
+++ b/frontend/src/profileResponsiveSafetySource.test.js
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const safety = readFileSync(new URL("./ProfileResponsiveSafety.css", import.meta.url), "utf8");
+const main = readFileSync(new URL("./main.jsx", import.meta.url), "utf8");
+
+test("public profile safety contract loads after theme-specific profile styles", () => {
+  const themeFixes = main.indexOf('import "./ProfileTemplateRegressionFixes.css";');
+  const desktopBalance = main.indexOf('import "./ProfileDesktopBalance.css";');
+  const safetyIndex = main.indexOf('import "./ProfileResponsiveSafety.css";');
+
+  assert.ok(themeFixes >= 0, "profile theme regression fixes must remain loaded");
+  assert.ok(desktopBalance > themeFixes, "desktop balance must remain after theme fixes");
+  assert.ok(safetyIndex > desktopBalance, "responsive safety contract must load last among profile overrides");
+});
+
+test("user-controlled profile text cannot force character or container overflow", () => {
+  assert.match(safety, /min-width:\s*0/);
+  assert.match(safety, /max-width:\s*100%/);
+  assert.match(safety, /overflow-wrap:\s*anywhere/);
+  assert.match(safety, /word-break:\s*normal/);
+  assert.match(safety, /\.portfolio-identity h1/);
+  assert.match(safety, /\.portfolio-impact-card h3/);
+  assert.match(safety, /\.portfolio-work-card h3/);
+  assert.match(safety, /\.portfolio-skill-cloud strong/);
+  assert.match(safety, /\.portfolio-evidence-list a/);
+});
+
+test("phone layouts collapse meaningful profile grids instead of hiding content", () => {
+  assert.match(safety, /@media \(max-width:\s*640px\)/);
+  assert.match(safety, /grid-template-columns:\s*minmax\(0,\s*1fr\)/);
+  assert.match(safety, /repeat\(auto-fit,\s*minmax\(min\(100%,\s*140px\),\s*1fr\)\)/);
+  assert.doesNotMatch(safety, /display:\s*none/);
+});
+
+test("narrow mobile layouts preserve touch access and bounded cards", () => {
+  assert.match(safety, /@media \(max-width:\s*430px\)/);
+  assert.match(safety, /min-height:\s*44px/);
+  assert.match(safety, /\.proof-filter-row button/);
+  assert.match(safety, /\.proof-pagination-controls button/);
+  assert.match(safety, /\.portfolio-footer button/);
+});


### PR DESCRIPTION
## Why

This is the first P0 implementation pass from the founding-team audit. It targets two trust/indexability failures without redesigning working product flows.

### 1) Route-specific static crawl shells
The production build previously copied the homepage `index.html` unchanged into every public route directory. Before JavaScript executed, crawlers could therefore see the homepage canonical on sitemap routes such as `/resume-accomplishments` and `/impact-receipts`.

This PR:
- generates a route-specific canonical URL in every static public route shell;
- generates a matching route-specific `og:url`;
- makes `/upgrade` and `/verify-receipt` server-visible `noindex,nofollow` rather than waiting for React;
- extends the existing SEO verification gate so the build cannot quietly regress to copied homepage shells.

### 2) Shared Proof Profile responsive safety contract
Public Proof Profiles are acquisition surfaces and currently have reported narrow-container/wrapping regressions across themes.

This PR adds a final shared responsive contract that all themes inherit:
- `min-width: 0` / bounded containers on nested flex/grid content;
- `overflow-wrap: anywhere` + `word-break: normal` for user-controlled names, titles, skills, descriptions, and evidence links;
- one-column phone collapse without hiding meaningful content;
- resilient passport grid sizing;
- 44px minimum touch targets for profile actions, filters, pagination, and sharing controls;
- source-level regression tests and import-order protection.

## Scope deliberately not included
- no theme redesign;
- no framework/hosting migration;
- no paid SEO tooling;
- no changes to authentication, billing, or user data;
- no claim that the existing browser layout audit covers every requested public-profile breakpoint yet. That should be the next small P0 PR.

## Suggested checks
- `cd frontend && npm run test:seo`
- `cd frontend && npm run test:settings`
- `cd frontend && npm run build`
- `cd frontend && npm run test:layout`

## Acceptance criteria
- generated sitemap-route HTML does not canonicalize to `/` before JS;
- non-indexable utility routes expose `noindex` in their static shell;
- public profile user-controlled text cannot create horizontal overflow solely because of long unbroken content;
- phone layouts retain all meaningful proof content and interactive controls.