### PR TITLE
P0: add 108-case public Proof Profile browser QA

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,7 @@
     "test:seo": "node --test src/proofPortfolioSource.test.js src/marketingClaritySource.test.js && node scripts/verify-search-appearance.mjs",
     "test:settings": "node --test src/settingsAccountClosureSource.test.js src/settingsBackNavigationSource.test.js src/packetsPageSource.test.js src/appearanceUiAuditSource.test.js src/wholeAppUiAuditSource.test.js src/profileTemplateRegressionSource.test.js src/profileResponsiveSafetySource.test.js",
     "test:clicks": "node scripts/run-click-audit.mjs",
-    "test:layout": "node scripts/audit-responsive-layout.mjs",
+    "test:layout": "node scripts/audit-responsive-layout.mjs && node scripts/audit-public-profile-layout.mjs",
     "test:bundle": "node scripts/verify-bundle-budget.mjs",
     "preview": "vite preview"
   },

--- a/frontend/scripts/audit-public-profile-layout.mjs
+++ b/frontend/scripts/audit-public-profile-layout.mjs
@@ -1,0 +1,499 @@
+import assert from "node:assert/strict";
+import { spawn, spawnSync } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { createServer } from "vite";
+
+const HOST = "127.0.0.1";
+const APP_PORT = 41742;
+const DEBUG_PORT = 9225;
+const BASE_URL = `http://${HOST}:${APP_PORT}`;
+const SCREENSHOT_DIR = path.join(process.cwd(), "artifacts", "public-profile-layout");
+
+const VIEWPORTS = [
+  { name: "phone-320", width: 320, height: 740 },
+  { name: "phone-375", width: 375, height: 812 },
+  { name: "phone-390", width: 390, height: 844 },
+  { name: "phone-430", width: 430, height: 932 },
+  { name: "tablet-768", width: 768, height: 1024 },
+  { name: "desktop-1024", width: 1024, height: 768 },
+  { name: "desktop-1280", width: 1280, height: 800 },
+  { name: "desktop-1440", width: 1440, height: 900 },
+  { name: "desktop-1920", width: 1920, height: 1080 },
+];
+
+const LAYOUTS = [
+  "editorial",
+  "executive-sidebar",
+  "career-timeline",
+  "studio-split",
+  "minimal-column",
+  "portfolio-grid",
+  "case-study",
+  "modern-resume",
+  "command-center",
+  "academic",
+  "founder",
+  "compact",
+];
+
+const LONG_TOKEN = "incident-response-evidence-reference-without-natural-breakpoints-1234567890";
+const LONG_TITLE = "Reduced escalations across a high-volume production support workflow while preserving customer trust and cross-team incident ownership";
+const LONG_ROLE = "Senior Production Support and Cloud Reliability Escalation Engineer for Enterprise Platform Operations";
+
+const profileFor = (layout) => ({
+  name: "Alexandria-Montgomery-Support-Engineer-Long",
+  headline: `${LONG_ROLE} · ${LONG_TOKEN}`,
+  bio: "Production support engineer documenting customer-impacting incident leadership, automation, reliability improvements, mentoring, and durable operational changes across a complex enterprise environment without losing the context behind the work.",
+  location: "Atlanta Metropolitan Area, Georgia, United States",
+  github_url: "https://github.com/example-user-with-an-intentionally-long-profile-name",
+  portfolio_url: `https://example.com/${LONG_TOKEN}/${LONG_TOKEN}`,
+  resume_url: `https://example.com/resume/${LONG_TOKEN}.pdf`,
+  profile_layout: layout,
+  profile_theme: "default",
+  profile_primary_color: "#38bdf8",
+  profile_secondary_color: "#a78bfa",
+  profile_background_color: "#050816",
+  work_history: [
+    {
+      role: LONG_ROLE,
+      company: "Example Enterprise Infrastructure and Customer Reliability Organization With A Long Name",
+      location: "Remote · United States",
+      start_date: "2023-01",
+      end_date: "Present",
+      summary: "Owned difficult escalations, improved incident workflows, and translated recurring support pain into maintainable engineering fixes while coordinating with product, platform, and customer-facing teams.",
+    },
+    {
+      role: "Technical Support Engineer",
+      company: "Previous Platform Company",
+      location: "Atlanta, GA",
+      start_date: "2020-04",
+      end_date: "2022-12",
+      summary: "Resolved complex production issues and created reusable troubleshooting paths for the wider support organization.",
+    },
+  ],
+  profile_projects: [
+    {
+      name: `Incident Automation Toolkit ${LONG_TOKEN}`,
+      role: "Maintainer and workflow designer",
+      summary: "Converted repeated triage steps into a safer automation path with explicit escalation boundaries and measurable time savings.",
+      skills: ["Python", "Docker", "Incident Response", LONG_TOKEN],
+      url: `https://example.com/projects/${LONG_TOKEN}`,
+    },
+  ],
+});
+
+const skills = [
+  "Incident Response",
+  "Production Support",
+  "Docker",
+  "Kubernetes",
+  "Python",
+  "Linux",
+  "Cloud Operations",
+  "Customer Escalations",
+  "Root Cause Analysis",
+  "Observability",
+  "Automation",
+  "Reliability Engineering",
+  "Technical Communication",
+  "Cross-functional Leadership",
+  "Troubleshooting",
+  "Runbook Design",
+  "Knowledge Management",
+  "Change Management",
+  "Post-incident Review",
+  "Service Ownership",
+  "Mentoring",
+  "API Debugging",
+  "Distributed Systems",
+  "Performance Analysis",
+  LONG_TOKEN,
+];
+
+const entries = Array.from({ length: 6 }, (_, index) => ({
+  id: `entry-${index + 1}`,
+  title: index === 0 ? LONG_TITLE : `Production support accomplishment ${index + 1}: improved reliability and reduced repeat escalation effort`,
+  category: index % 2 === 0 ? "Reliability and Incident Response" : "Customer Outcomes and Automation",
+  entry_date: `2026-0${Math.min(index + 2, 8)}-15`,
+  entry_type: index % 2 === 0 ? "Current Job" : "Personal Development",
+  situation: "A recurring production issue created slow escalations and duplicated investigation effort across several teams.",
+  action: `Built a repeatable diagnostic and escalation workflow, documented ownership boundaries, and automated safe checks. Reference: ${LONG_TOKEN}`,
+  impact: "Reduced avoidable handoffs and gave responders a faster, clearer path to isolate the issue while preserving escalation quality and customer communication.",
+  lesson: "Operational improvements are strongest when the troubleshooting path, ownership model, and evidence stay connected.",
+  resume_bullet: "Improved production support response quality by standardizing evidence-backed triage and escalation workflows.",
+  tags: skills.slice(index, index + 7),
+  is_public: true,
+}));
+
+const receipts = [
+  {
+    id: "receipt-1",
+    accomplishment: LONG_TITLE,
+    contribution: `Designed the diagnostic workflow, coordinated responders, documented decision points, and created reusable automation. ${LONG_TOKEN}`,
+    result: "Reduced repeated investigation and improved escalation clarity across a customer-impacting workflow without overstating confidential internal metrics.",
+    skills: skills.slice(0, 7),
+    metrics: [{ value: "42%", label: "faster triage", context: "Measured across the approved comparison window before public generalization." }],
+    evidence: [
+      { title: `Public incident workflow evidence ${LONG_TOKEN}`, reference: `https://example.com/evidence/${LONG_TOKEN}` },
+      { title: "Public reliability write-up", reference: "https://example.com/reliability/write-up" },
+    ],
+    confirmed_count: 3,
+    is_public: true,
+  },
+  {
+    id: "receipt-2",
+    accomplishment: "Converted recurring troubleshooting knowledge into a durable team workflow",
+    contribution: "Mapped the repeated investigation path, removed ambiguous handoffs, and turned the stable pieces into reusable support guidance.",
+    result: "Made complex cases easier to hand off and reduced dependence on individual memory during high-pressure escalations.",
+    skills: skills.slice(7, 14),
+    metrics: [{ value: "18", label: "repeat cases reviewed", context: "Publicly safe aggregate used to validate the recurring pattern." }],
+    evidence: [{ title: "Workflow architecture overview", reference: "https://example.com/workflow-architecture" }],
+    confirmed_count: 1,
+    is_public: true,
+  },
+  {
+    id: "receipt-3",
+    accomplishment: "Mentored teammates through difficult production investigations",
+    contribution: "Created structured debugging prompts and paired with responders on evidence-first escalation decisions.",
+    result: "Improved confidence and consistency for cases that crossed application, container, and infrastructure boundaries.",
+    skills: skills.slice(14, 21),
+    metrics: [],
+    evidence: [],
+    confirmed_count: 0,
+    is_public: true,
+  },
+];
+
+const tagCounts = Object.fromEntries(skills.map((skill, index) => [skill, (index % 4) + 1]));
+
+function json(res, body, status = 200) {
+  res.statusCode = status;
+  res.setHeader("Content-Type", "application/json");
+  res.end(JSON.stringify(body));
+}
+
+function parsePublicRequest(rawUrl) {
+  const url = new URL(rawUrl, "http://mock.local");
+  const pathname = url.pathname.replace(/^\/__profile_api/, "");
+  const match = pathname.match(/^\/public\/brag\/([^/]+)(.*)$/);
+  if (!match) return { pathname, slug: "", suffix: "" };
+  return { pathname, slug: decodeURIComponent(match[1]), suffix: match[2] || "" };
+}
+
+function mockApiResponse(method, rawUrl) {
+  const { pathname, slug, suffix } = parsePublicRequest(rawUrl);
+  if (!pathname.startsWith("/public/brag/")) return {};
+
+  const layout = slug.startsWith("qa-") ? slug.slice(3) : "editorial";
+  if (method === "POST" && suffix === "/analytics") return { ok: true };
+  if (suffix === "/profile") return { profile: profileFor(layout) };
+  if (suffix === "/impact-receipts") return { receipts, total: receipts.length };
+  if (suffix === "/tags/summary") return { total_unique_tags: skills.length, tags: tagCounts };
+  if (suffix === "/connection") {
+    return {
+      open_to_talk: false,
+      calendly_enabled: false,
+      open_to_talk_types: [],
+      open_to_talk_note: "",
+    };
+  }
+  if (suffix === "") {
+    return {
+      entries,
+      total_entries: entries.length,
+      activity_last_6_months: [],
+    };
+  }
+  return {};
+}
+
+function mockApiPlugin() {
+  return {
+    name: "boasted-public-profile-layout-api",
+    configureServer(server) {
+      server.middlewares.use((req, res, next) => {
+        if (!req.url?.startsWith("/__profile_api")) return next();
+        req.on("data", () => {});
+        req.on("end", () => json(res, mockApiResponse(req.method || "GET", req.url || "/")));
+      });
+    },
+  };
+}
+
+function findChrome() {
+  return ["google-chrome", "chromium", "chromium-browser"]
+    .find((name) => spawnSync("which", [name], { encoding: "utf8" }).status === 0);
+}
+
+async function waitFor(fn, timeoutMs = 10000) {
+  const started = Date.now();
+  let lastError;
+  while (Date.now() - started < timeoutMs) {
+    try {
+      const result = await fn();
+      if (result) return result;
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 80));
+  }
+  throw lastError || new Error(`Timed out after ${timeoutMs}ms`);
+}
+
+async function findPageTarget() {
+  return waitFor(async () => {
+    const response = await fetch(`http://${HOST}:${DEBUG_PORT}/json/list`);
+    if (!response.ok) return null;
+    const targets = await response.json();
+    return targets.find((target) => target.type === "page" && target.webSocketDebuggerUrl) || null;
+  }, 5000);
+}
+
+class CDP {
+  constructor(wsUrl) {
+    this.ws = new WebSocket(wsUrl);
+    this.nextId = 1;
+    this.pending = new Map();
+  }
+
+  async open() {
+    await new Promise((resolve, reject) => {
+      this.ws.addEventListener("open", resolve, { once: true });
+      this.ws.addEventListener("error", reject, { once: true });
+    });
+    this.ws.addEventListener("message", (event) => {
+      const message = JSON.parse(event.data);
+      if (!message.id || !this.pending.has(message.id)) return;
+      const { resolve, reject } = this.pending.get(message.id);
+      this.pending.delete(message.id);
+      if (message.error) reject(new Error(message.error.message));
+      else resolve(message.result);
+    });
+  }
+
+  send(method, params = {}) {
+    const id = this.nextId++;
+    return new Promise((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+      this.ws.send(JSON.stringify({ id, method, params }));
+    });
+  }
+
+  close() {
+    try { this.ws.close(); } catch { /* best effort */ }
+  }
+}
+
+async function evaluate(cdp, expression) {
+  const result = await cdp.send("Runtime.evaluate", {
+    expression,
+    awaitPromise: true,
+    returnByValue: true,
+  });
+  if (result.exceptionDetails) throw new Error(result.exceptionDetails.text || "Browser evaluation failed");
+  return result.result?.value;
+}
+
+async function setViewport(cdp, viewport) {
+  await cdp.send("Emulation.setDeviceMetricsOverride", {
+    width: viewport.width,
+    height: viewport.height,
+    deviceScaleFactor: 1,
+    mobile: viewport.width <= 430,
+  });
+}
+
+async function openProfile(cdp, layout) {
+  await cdp.send("Page.navigate", { url: `${BASE_URL}/brag/qa-${layout}` });
+  await waitFor(async () => {
+    const ready = await evaluate(cdp, `(() => ({
+      state: document.readyState,
+      layout: document.querySelector(".proof-portfolio")?.dataset.layout || "",
+      name: document.querySelector(".portfolio-identity h1")?.textContent || "",
+      error: Boolean(document.querySelector(".proof-error"))
+    }))()`);
+    return ready.state !== "loading" && ready.layout === ${JSON.stringify(layout)} && ready.name.length > 0 && !ready.error;
+  }, 12000);
+  await new Promise((resolve) => setTimeout(resolve, 120));
+}
+
+async function measureLayout(cdp) {
+  return evaluate(cdp, `(() => {
+    const viewportWidth = window.innerWidth;
+    const documentWidth = Math.max(document.documentElement.scrollWidth, document.body.scrollWidth);
+    const root = document.querySelector(".proof-portfolio");
+    const visible = (element) => {
+      if (!element) return false;
+      const style = getComputedStyle(element);
+      const rect = element.getBoundingClientRect();
+      return style.display !== "none" && style.visibility !== "hidden" && rect.width > 0 && rect.height > 0;
+    };
+    const rectFor = (selector) => {
+      const element = document.querySelector(selector);
+      if (!visible(element)) return null;
+      const rect = element.getBoundingClientRect();
+      return { left: rect.left, right: rect.right, width: rect.width, height: rect.height, top: rect.top, bottom: rect.bottom };
+    };
+    const hasHorizontalScrollAncestor = (element) => {
+      let current = element.parentElement;
+      while (current && current !== root) {
+        const style = getComputedStyle(current);
+        if (["auto", "scroll"].includes(style.overflowX)) return true;
+        current = current.parentElement;
+      }
+      return false;
+    };
+    const offenders = [...document.querySelectorAll(".proof-portfolio *")]
+      .filter((element) => {
+        if (!visible(element)) return false;
+        const style = getComputedStyle(element);
+        if (["fixed", "absolute"].includes(style.position)) return false;
+        if (hasHorizontalScrollAncestor(element)) return false;
+        const rect = element.getBoundingClientRect();
+        return rect.left < -1 || rect.right > viewportWidth + 1 || rect.width > viewportWidth + 1;
+      })
+      .slice(0, 16)
+      .map((element) => {
+        const rect = element.getBoundingClientRect();
+        return {
+          tag: element.tagName.toLowerCase(),
+          className: typeof element.className === "string" ? element.className.slice(0, 140) : "",
+          text: (element.textContent || "").trim().slice(0, 100),
+          left: Math.round(rect.left * 10) / 10,
+          right: Math.round(rect.right * 10) / 10,
+          width: Math.round(rect.width * 10) / 10,
+        };
+      });
+    const touchTargets = [...document.querySelectorAll(
+      ".portfolio-share, .proof-action, .proof-filter-row button, .proof-pagination-controls button, .portfolio-footer button"
+    )].filter(visible).map((element) => {
+      const rect = element.getBoundingClientRect();
+      return { label: (element.textContent || element.getAttribute("aria-label") || element.tagName).trim().slice(0, 70), width: rect.width, height: rect.height };
+    });
+    const sections = [
+      ".portfolio-hero",
+      ".portfolio-proof-passport",
+      ".portfolio-featured-impact",
+      ".portfolio-career-section",
+      ".portfolio-skills-section",
+      ".portfolio-work-section",
+    ].map((selector) => ({ selector, visible: visible(document.querySelector(selector)), rect: rectFor(selector) }));
+    return {
+      viewportWidth,
+      documentWidth,
+      layout: root?.dataset.layout || "",
+      inner: rectFor(".proof-profile-inner"),
+      hero: rectFor(".portfolio-hero"),
+      controls: rectFor(".portfolio-controls"),
+      sections,
+      touchTargets,
+      offenders,
+    };
+  })()`);
+}
+
+function assertWithinViewport(rect, viewportWidth, label) {
+  assert.ok(rect, `${label} is not visible`);
+  assert.ok(rect.left >= -1, `${label} starts outside viewport: left=${rect.left}`);
+  assert.ok(rect.right <= viewportWidth + 1, `${label} is cut off on right: right=${rect.right}, viewport=${viewportWidth}`);
+  assert.ok(rect.width <= viewportWidth + 1, `${label} is wider than viewport: width=${rect.width}, viewport=${viewportWidth}`);
+}
+
+async function captureFailure(cdp, layout, viewport) {
+  await fs.mkdir(SCREENSHOT_DIR, { recursive: true });
+  const result = await cdp.send("Page.captureScreenshot", { format: "png", fromSurface: true, captureBeyondViewport: false });
+  const filename = `${layout}-${viewport.name}.png`;
+  await fs.writeFile(path.join(SCREENSHOT_DIR, filename), Buffer.from(result.data, "base64"));
+  return filename;
+}
+
+const chrome = findChrome();
+assert.ok(chrome, "Chrome/Chromium is required for public profile layout CI");
+process.env.VITE_API_BASE_URL = "/__profile_api";
+
+const server = await createServer({
+  root: process.cwd(),
+  logLevel: "error",
+  plugins: [mockApiPlugin()],
+  server: { host: HOST, port: APP_PORT, strictPort: true },
+});
+const userDataDir = await fs.mkdtemp(path.join(os.tmpdir(), "boasted-public-profile-layout-"));
+let browser;
+let cdp;
+const failures = [];
+
+try {
+  await fs.rm(SCREENSHOT_DIR, { recursive: true, force: true });
+  await server.listen();
+  browser = spawn(chrome, [
+    "--headless=new",
+    "--no-sandbox",
+    "--disable-gpu",
+    "--disable-dev-shm-usage",
+    `--remote-debugging-port=${DEBUG_PORT}`,
+    `--user-data-dir=${userDataDir}`,
+    "about:blank",
+  ], { stdio: ["ignore", "ignore", "pipe"] });
+
+  const target = await findPageTarget();
+  cdp = new CDP(target.webSocketDebuggerUrl);
+  await cdp.open();
+  await Promise.all([cdp.send("Page.enable"), cdp.send("Runtime.enable")]);
+
+  for (const viewport of VIEWPORTS) {
+    await setViewport(cdp, viewport);
+    for (const layout of LAYOUTS) {
+      const label = `${layout} @ ${viewport.width}x${viewport.height}`;
+      try {
+        await openProfile(cdp, layout);
+        const result = await measureLayout(cdp);
+
+        assert.equal(result.layout, layout, `${label} rendered the wrong profile layout`);
+        assert.ok(
+          result.documentWidth <= result.viewportWidth + 1,
+          `${label} has horizontal document overflow: document=${result.documentWidth}, viewport=${result.viewportWidth}`,
+        );
+        assertWithinViewport(result.inner, result.viewportWidth, `${label} profile inner`);
+        assertWithinViewport(result.hero, result.viewportWidth, `${label} hero`);
+        assertWithinViewport(result.controls, result.viewportWidth, `${label} controls`);
+        assert.equal(
+          result.offenders.length,
+          0,
+          `${label} contains clipped content: ${JSON.stringify(result.offenders)}`,
+        );
+        assert.ok(result.touchTargets.length >= 10, `${label} did not render the expected interactive profile controls`);
+        for (const targetInfo of result.touchTargets) {
+          assert.ok(
+            targetInfo.height >= 43,
+            `${label} touch target is too short: ${targetInfo.label} (${Math.round(targetInfo.height)}px)`,
+          );
+        }
+        for (const section of result.sections) {
+          assert.ok(section.visible, `${label} hides meaningful section ${section.selector}`);
+          assertWithinViewport(section.rect, result.viewportWidth, `${label} ${section.selector}`);
+        }
+
+        console.log(`PUBLIC PROFILE PASS ${label}`);
+      } catch (error) {
+        let screenshot = "";
+        try { screenshot = await captureFailure(cdp, layout, viewport); } catch { /* best effort */ }
+        failures.push(`${label}: ${error.message}${screenshot ? ` [screenshot: ${screenshot}]` : ""}`);
+      }
+    }
+  }
+
+  if (failures.length) {
+    console.error("\nPUBLIC PROFILE LAYOUT FAILURES");
+    failures.forEach((failure) => console.error(`- ${failure}`));
+    process.exitCode = 1;
+  } else {
+    console.log(`\nPublic Proof Profile guard passed ${LAYOUTS.length} layouts × ${VIEWPORTS.length} viewports = ${LAYOUTS.length * VIEWPORTS.length} rendered cases.`);
+  }
+} finally {
+  cdp?.close();
+  if (browser && browser.exitCode === null && browser.signalCode === null) browser.kill("SIGKILL");
+  await server.close();
+  await fs.rm(userDataDir, { recursive: true, force: true, maxRetries: 8, retryDelay: 150 });
+}

--- a/frontend/scripts/audit-public-profile-layout.mjs
+++ b/frontend/scripts/audit-public-profile-layout.mjs
@@ -12,16 +12,16 @@ const BASE_URL = `http://${HOST}:${APP_PORT}`;
 const SCREENSHOT_DIR = path.join(process.cwd(), "artifacts", "public-profile-layout");
 
 const VIEWPORTS = [
-  { name: "phone-320", width: 320, height: 740 },
-  { name: "phone-375", width: 375, height: 812 },
-  { name: "phone-390", width: 390, height: 844 },
-  { name: "phone-430", width: 430, height: 932 },
-  { name: "tablet-768", width: 768, height: 1024 },
-  { name: "desktop-1024", width: 1024, height: 768 },
-  { name: "desktop-1280", width: 1280, height: 800 },
-  { name: "desktop-1440", width: 1440, height: 900 },
-  { name: "desktop-1920", width: 1920, height: 1080 },
-];
+  ["phone-320", 320, 740],
+  ["phone-375", 375, 812],
+  ["phone-390", 390, 844],
+  ["phone-430", 430, 932],
+  ["tablet-768", 768, 1024],
+  ["desktop-1024", 1024, 768],
+  ["desktop-1280", 1280, 800],
+  ["desktop-1440", 1440, 900],
+  ["desktop-1920", 1920, 1080],
+].map(([name, width, height]) => ({ name, width, height }));
 
 const LAYOUTS = [
   "editorial",
@@ -39,80 +39,62 @@ const LAYOUTS = [
 ];
 
 const LONG_TOKEN = "incident-response-evidence-reference-without-natural-breakpoints-1234567890";
-const LONG_TITLE = "Reduced escalations across a high-volume production support workflow while preserving customer trust and cross-team incident ownership";
 const LONG_ROLE = "Senior Production Support and Cloud Reliability Escalation Engineer for Enterprise Platform Operations";
-
-const profileFor = (layout) => ({
-  name: "Alexandria-Montgomery-Support-Engineer-Long",
-  headline: `${LONG_ROLE} · ${LONG_TOKEN}`,
-  bio: "Production support engineer documenting customer-impacting incident leadership, automation, reliability improvements, mentoring, and durable operational changes across a complex enterprise environment without losing the context behind the work.",
-  location: "Atlanta Metropolitan Area, Georgia, United States",
-  github_url: "https://github.com/example-user-with-an-intentionally-long-profile-name",
-  portfolio_url: `https://example.com/${LONG_TOKEN}/${LONG_TOKEN}`,
-  resume_url: `https://example.com/resume/${LONG_TOKEN}.pdf`,
-  profile_layout: layout,
-  profile_theme: "default",
-  profile_primary_color: "#38bdf8",
-  profile_secondary_color: "#a78bfa",
-  profile_background_color: "#050816",
-  work_history: [
-    {
-      role: LONG_ROLE,
-      company: "Example Enterprise Infrastructure and Customer Reliability Organization With A Long Name",
-      location: "Remote · United States",
-      start_date: "2023-01",
-      end_date: "Present",
-      summary: "Owned difficult escalations, improved incident workflows, and translated recurring support pain into maintainable engineering fixes while coordinating with product, platform, and customer-facing teams.",
-    },
-    {
-      role: "Technical Support Engineer",
-      company: "Previous Platform Company",
-      location: "Atlanta, GA",
-      start_date: "2020-04",
-      end_date: "2022-12",
-      summary: "Resolved complex production issues and created reusable troubleshooting paths for the wider support organization.",
-    },
-  ],
-  profile_projects: [
-    {
-      name: `Incident Automation Toolkit ${LONG_TOKEN}`,
-      role: "Maintainer and workflow designer",
-      summary: "Converted repeated triage steps into a safer automation path with explicit escalation boundaries and measurable time savings.",
-      skills: ["Python", "Docker", "Incident Response", LONG_TOKEN],
-      url: `https://example.com/projects/${LONG_TOKEN}`,
-    },
-  ],
-});
-
-const skills = [
-  "Incident Response",
-  "Production Support",
-  "Docker",
-  "Kubernetes",
-  "Python",
-  "Linux",
-  "Cloud Operations",
-  "Customer Escalations",
-  "Root Cause Analysis",
-  "Observability",
-  "Automation",
-  "Reliability Engineering",
-  "Technical Communication",
-  "Cross-functional Leadership",
-  "Troubleshooting",
-  "Runbook Design",
-  "Knowledge Management",
-  "Change Management",
-  "Post-incident Review",
-  "Service Ownership",
-  "Mentoring",
-  "API Debugging",
-  "Distributed Systems",
-  "Performance Analysis",
-  LONG_TOKEN,
+const LONG_TITLE = "Reduced escalations across a high-volume production support workflow while preserving customer trust and cross-team incident ownership";
+const SKILLS = [
+  "Incident Response", "Production Support", "Docker", "Kubernetes", "Python",
+  "Linux", "Cloud Operations", "Customer Escalations", "Root Cause Analysis",
+  "Observability", "Automation", "Reliability Engineering", "Technical Communication",
+  "Cross-functional Leadership", "Troubleshooting", "Runbook Design", "Knowledge Management",
+  "Change Management", "Post-incident Review", "Service Ownership", "Mentoring",
+  "API Debugging", "Distributed Systems", "Performance Analysis", LONG_TOKEN,
 ];
 
-const entries = Array.from({ length: 6 }, (_, index) => ({
+function profileFor(layout) {
+  return {
+    name: "Alexandria-Montgomery-Support-Engineer-Long",
+    headline: `${LONG_ROLE} · ${LONG_TOKEN}`,
+    bio: "Production support engineer documenting customer-impacting incident leadership, automation, reliability improvements, mentoring, and durable operational changes across a complex enterprise environment without losing the context behind the work.",
+    location: "Atlanta Metropolitan Area, Georgia, United States",
+    github_url: "https://github.com/example-user-with-an-intentionally-long-profile-name",
+    portfolio_url: `https://example.com/${LONG_TOKEN}/${LONG_TOKEN}`,
+    resume_url: `https://example.com/resume/${LONG_TOKEN}.pdf`,
+    profile_layout: layout,
+    profile_theme: "default",
+    profile_primary_color: "#38bdf8",
+    profile_secondary_color: "#a78bfa",
+    profile_background_color: "#050816",
+    work_history: [
+      {
+        role: LONG_ROLE,
+        company: "Example Enterprise Infrastructure and Customer Reliability Organization With A Long Name",
+        location: "Remote · United States",
+        start_date: "2023-01",
+        end_date: "Present",
+        summary: "Owned difficult escalations, improved incident workflows, and translated recurring support pain into maintainable engineering fixes while coordinating with product, platform, and customer-facing teams.",
+      },
+      {
+        role: "Technical Support Engineer",
+        company: "Previous Platform Company",
+        location: "Atlanta, GA",
+        start_date: "2020-04",
+        end_date: "2022-12",
+        summary: "Resolved complex production issues and created reusable troubleshooting paths for the wider support organization.",
+      },
+    ],
+    profile_projects: [
+      {
+        name: `Incident Automation Toolkit ${LONG_TOKEN}`,
+        role: "Maintainer and workflow designer",
+        summary: "Converted repeated triage steps into a safer automation path with explicit escalation boundaries and measurable time savings.",
+        skills: ["Python", "Docker", "Incident Response", LONG_TOKEN],
+        url: `https://example.com/projects/${LONG_TOKEN}`,
+      },
+    ],
+  };
+}
+
+const ENTRIES = Array.from({ length: 6 }, (_, index) => ({
   id: `entry-${index + 1}`,
   title: index === 0 ? LONG_TITLE : `Production support accomplishment ${index + 1}: improved reliability and reduced repeat escalation effort`,
   category: index % 2 === 0 ? "Reliability and Incident Response" : "Customer Outcomes and Automation",
@@ -121,20 +103,20 @@ const entries = Array.from({ length: 6 }, (_, index) => ({
   situation: "A recurring production issue created slow escalations and duplicated investigation effort across several teams.",
   action: `Built a repeatable diagnostic and escalation workflow, documented ownership boundaries, and automated safe checks. Reference: ${LONG_TOKEN}`,
   impact: "Reduced avoidable handoffs and gave responders a faster, clearer path to isolate the issue while preserving escalation quality and customer communication.",
-  lesson: "Operational improvements are strongest when the troubleshooting path, ownership model, and evidence stay connected.",
+  lesson: "Operational improvements are strongest when troubleshooting, ownership, and evidence stay connected.",
   resume_bullet: "Improved production support response quality by standardizing evidence-backed triage and escalation workflows.",
-  tags: skills.slice(index, index + 7),
+  tags: SKILLS.slice(index, index + 7),
   is_public: true,
 }));
 
-const receipts = [
+const RECEIPTS = [
   {
     id: "receipt-1",
     accomplishment: LONG_TITLE,
     contribution: `Designed the diagnostic workflow, coordinated responders, documented decision points, and created reusable automation. ${LONG_TOKEN}`,
     result: "Reduced repeated investigation and improved escalation clarity across a customer-impacting workflow without overstating confidential internal metrics.",
-    skills: skills.slice(0, 7),
-    metrics: [{ value: "42%", label: "faster triage", context: "Measured across the approved comparison window before public generalization." }],
+    skills: SKILLS.slice(0, 7),
+    metrics: [{ value: "42%", label: "faster triage", context: "Measured across an approved comparison window." }],
     evidence: [
       { title: `Public incident workflow evidence ${LONG_TOKEN}`, reference: `https://example.com/evidence/${LONG_TOKEN}` },
       { title: "Public reliability write-up", reference: "https://example.com/reliability/write-up" },
@@ -145,10 +127,10 @@ const receipts = [
   {
     id: "receipt-2",
     accomplishment: "Converted recurring troubleshooting knowledge into a durable team workflow",
-    contribution: "Mapped the repeated investigation path, removed ambiguous handoffs, and turned the stable pieces into reusable support guidance.",
+    contribution: "Mapped the repeated investigation path, removed ambiguous handoffs, and turned stable steps into reusable support guidance.",
     result: "Made complex cases easier to hand off and reduced dependence on individual memory during high-pressure escalations.",
-    skills: skills.slice(7, 14),
-    metrics: [{ value: "18", label: "repeat cases reviewed", context: "Publicly safe aggregate used to validate the recurring pattern." }],
+    skills: SKILLS.slice(7, 14),
+    metrics: [{ value: "18", label: "repeat cases reviewed", context: "Publicly safe aggregate." }],
     evidence: [{ title: "Workflow architecture overview", reference: "https://example.com/workflow-architecture" }],
     confirmed_count: 1,
     is_public: true,
@@ -157,8 +139,8 @@ const receipts = [
     id: "receipt-3",
     accomplishment: "Mentored teammates through difficult production investigations",
     contribution: "Created structured debugging prompts and paired with responders on evidence-first escalation decisions.",
-    result: "Improved confidence and consistency for cases that crossed application, container, and infrastructure boundaries.",
-    skills: skills.slice(14, 21),
+    result: "Improved confidence and consistency for cases crossing application, container, and infrastructure boundaries.",
+    skills: SKILLS.slice(14, 21),
     metrics: [],
     evidence: [],
     confirmed_count: 0,
@@ -166,7 +148,7 @@ const receipts = [
   },
 ];
 
-const tagCounts = Object.fromEntries(skills.map((skill, index) => [skill, (index % 4) + 1]));
+const TAGS = Object.fromEntries(SKILLS.map((skill, index) => [skill, (index % 4) + 1]));
 
 function json(res, body, status = 200) {
   res.statusCode = status;
@@ -174,38 +156,21 @@ function json(res, body, status = 200) {
   res.end(JSON.stringify(body));
 }
 
-function parsePublicRequest(rawUrl) {
+function mockResponse(method, rawUrl) {
   const url = new URL(rawUrl, "http://mock.local");
   const pathname = url.pathname.replace(/^\/__profile_api/, "");
   const match = pathname.match(/^\/public\/brag\/([^/]+)(.*)$/);
-  if (!match) return { pathname, slug: "", suffix: "" };
-  return { pathname, slug: decodeURIComponent(match[1]), suffix: match[2] || "" };
-}
-
-function mockApiResponse(method, rawUrl) {
-  const { pathname, slug, suffix } = parsePublicRequest(rawUrl);
-  if (!pathname.startsWith("/public/brag/")) return {};
-
+  if (!match) return {};
+  const slug = decodeURIComponent(match[1]);
+  const suffix = match[2] || "";
   const layout = slug.startsWith("qa-") ? slug.slice(3) : "editorial";
-  if (method === "POST" && suffix === "/analytics") return { ok: true };
+
+  if (method === "POST" && suffix === "/analytics") return { recorded: true };
   if (suffix === "/profile") return { profile: profileFor(layout) };
-  if (suffix === "/impact-receipts") return { receipts, total: receipts.length };
-  if (suffix === "/tags/summary") return { total_unique_tags: skills.length, tags: tagCounts };
-  if (suffix === "/connection") {
-    return {
-      open_to_talk: false,
-      calendly_enabled: false,
-      open_to_talk_types: [],
-      open_to_talk_note: "",
-    };
-  }
-  if (suffix === "") {
-    return {
-      entries,
-      total_entries: entries.length,
-      activity_last_6_months: [],
-    };
-  }
+  if (suffix === "/impact-receipts") return { receipts: RECEIPTS, total: RECEIPTS.length };
+  if (suffix === "/tags/summary") return { total_unique_tags: SKILLS.length, tags: TAGS };
+  if (suffix === "/connection") return { open_to_talk: false, calendly_enabled: false, open_to_talk_types: [] };
+  if (suffix === "") return { entries: ENTRIES, total_entries: ENTRIES.length, activity_last_6_months: [] };
   return {};
 }
 
@@ -216,7 +181,7 @@ function mockApiPlugin() {
       server.middlewares.use((req, res, next) => {
         if (!req.url?.startsWith("/__profile_api")) return next();
         req.on("data", () => {});
-        req.on("end", () => json(res, mockApiResponse(req.method || "GET", req.url || "/")));
+        req.on("end", () => json(res, mockResponse(req.method || "GET", req.url || "/")));
       });
     },
   };
@@ -242,15 +207,6 @@ async function waitFor(fn, timeoutMs = 10000) {
   throw lastError || new Error(`Timed out after ${timeoutMs}ms`);
 }
 
-async function findPageTarget() {
-  return waitFor(async () => {
-    const response = await fetch(`http://${HOST}:${DEBUG_PORT}/json/list`);
-    if (!response.ok) return null;
-    const targets = await response.json();
-    return targets.find((target) => target.type === "page" && target.webSocketDebuggerUrl) || null;
-  }, 5000);
-}
-
 class CDP {
   constructor(wsUrl) {
     this.ws = new WebSocket(wsUrl);
@@ -266,10 +222,10 @@ class CDP {
     this.ws.addEventListener("message", (event) => {
       const message = JSON.parse(event.data);
       if (!message.id || !this.pending.has(message.id)) return;
-      const { resolve, reject } = this.pending.get(message.id);
+      const pending = this.pending.get(message.id);
       this.pending.delete(message.id);
-      if (message.error) reject(new Error(message.error.message));
-      else resolve(message.result);
+      if (message.error) pending.reject(new Error(message.error.message));
+      else pending.resolve(message.result);
     });
   }
 
@@ -286,12 +242,17 @@ class CDP {
   }
 }
 
+async function findPageTarget() {
+  return waitFor(async () => {
+    const response = await fetch(`http://${HOST}:${DEBUG_PORT}/json/list`);
+    if (!response.ok) return null;
+    const targets = await response.json();
+    return targets.find((target) => target.type === "page" && target.webSocketDebuggerUrl) || null;
+  }, 5000);
+}
+
 async function evaluate(cdp, expression) {
-  const result = await cdp.send("Runtime.evaluate", {
-    expression,
-    awaitPromise: true,
-    returnByValue: true,
-  });
+  const result = await cdp.send("Runtime.evaluate", { expression, awaitPromise: true, returnByValue: true });
   if (result.exceptionDetails) throw new Error(result.exceptionDetails.text || "Browser evaluation failed");
   return result.result?.value;
 }
@@ -314,15 +275,14 @@ async function openProfile(cdp, layout) {
       name: document.querySelector(".portfolio-identity h1")?.textContent || "",
       error: Boolean(document.querySelector(".proof-error"))
     }))()`);
-    return ready.state !== "loading" && ready.layout === ${JSON.stringify(layout)} && ready.name.length > 0 && !ready.error;
+    return ready.state !== "loading" && ready.layout === layout && ready.name.length > 0 && !ready.error;
   }, 12000);
   await new Promise((resolve) => setTimeout(resolve, 120));
 }
 
-async function measureLayout(cdp) {
+async function measure(cdp) {
   return evaluate(cdp, `(() => {
     const viewportWidth = window.innerWidth;
-    const documentWidth = Math.max(document.documentElement.scrollWidth, document.body.scrollWidth);
     const root = document.querySelector(".proof-portfolio");
     const visible = (element) => {
       if (!element) return false;
@@ -334,13 +294,12 @@ async function measureLayout(cdp) {
       const element = document.querySelector(selector);
       if (!visible(element)) return null;
       const rect = element.getBoundingClientRect();
-      return { left: rect.left, right: rect.right, width: rect.width, height: rect.height, top: rect.top, bottom: rect.bottom };
+      return { left: rect.left, right: rect.right, width: rect.width, height: rect.height };
     };
-    const hasHorizontalScrollAncestor = (element) => {
+    const scrollAncestor = (element) => {
       let current = element.parentElement;
       while (current && current !== root) {
-        const style = getComputedStyle(current);
-        if (["auto", "scroll"].includes(style.overflowX)) return true;
+        if (["auto", "scroll"].includes(getComputedStyle(current).overflowX)) return true;
         current = current.parentElement;
       }
       return false;
@@ -349,8 +308,7 @@ async function measureLayout(cdp) {
       .filter((element) => {
         if (!visible(element)) return false;
         const style = getComputedStyle(element);
-        if (["fixed", "absolute"].includes(style.position)) return false;
-        if (hasHorizontalScrollAncestor(element)) return false;
+        if (["fixed", "absolute"].includes(style.position) || scrollAncestor(element)) return false;
         const rect = element.getBoundingClientRect();
         return rect.left < -1 || rect.right > viewportWidth + 1 || rect.width > viewportWidth + 1;
       })
@@ -359,8 +317,8 @@ async function measureLayout(cdp) {
         const rect = element.getBoundingClientRect();
         return {
           tag: element.tagName.toLowerCase(),
-          className: typeof element.className === "string" ? element.className.slice(0, 140) : "",
-          text: (element.textContent || "").trim().slice(0, 100),
+          className: typeof element.className === "string" ? element.className.slice(0, 120) : "",
+          text: (element.textContent || "").trim().slice(0, 90),
           left: Math.round(rect.left * 10) / 10,
           right: Math.round(rect.right * 10) / 10,
           width: Math.round(rect.width * 10) / 10,
@@ -370,7 +328,7 @@ async function measureLayout(cdp) {
       ".portfolio-share, .proof-action, .proof-filter-row button, .proof-pagination-controls button, .portfolio-footer button"
     )].filter(visible).map((element) => {
       const rect = element.getBoundingClientRect();
-      return { label: (element.textContent || element.getAttribute("aria-label") || element.tagName).trim().slice(0, 70), width: rect.width, height: rect.height };
+      return { label: (element.textContent || "control").trim().slice(0, 60), height: rect.height };
     });
     const sections = [
       ".portfolio-hero",
@@ -382,7 +340,7 @@ async function measureLayout(cdp) {
     ].map((selector) => ({ selector, visible: visible(document.querySelector(selector)), rect: rectFor(selector) }));
     return {
       viewportWidth,
-      documentWidth,
+      documentWidth: Math.max(document.documentElement.scrollWidth, document.body.scrollWidth),
       layout: root?.dataset.layout || "",
       inner: rectFor(".proof-profile-inner"),
       hero: rectFor(".portfolio-hero"),
@@ -403,9 +361,9 @@ function assertWithinViewport(rect, viewportWidth, label) {
 
 async function captureFailure(cdp, layout, viewport) {
   await fs.mkdir(SCREENSHOT_DIR, { recursive: true });
-  const result = await cdp.send("Page.captureScreenshot", { format: "png", fromSurface: true, captureBeyondViewport: false });
+  const shot = await cdp.send("Page.captureScreenshot", { format: "png", fromSurface: true, captureBeyondViewport: false });
   const filename = `${layout}-${viewport.name}.png`;
-  await fs.writeFile(path.join(SCREENSHOT_DIR, filename), Buffer.from(result.data, "base64"));
+  await fs.writeFile(path.join(SCREENSHOT_DIR, filename), Buffer.from(shot.data, "base64"));
   return filename;
 }
 
@@ -448,33 +406,21 @@ try {
       const label = `${layout} @ ${viewport.width}x${viewport.height}`;
       try {
         await openProfile(cdp, layout);
-        const result = await measureLayout(cdp);
-
-        assert.equal(result.layout, layout, `${label} rendered the wrong profile layout`);
-        assert.ok(
-          result.documentWidth <= result.viewportWidth + 1,
-          `${label} has horizontal document overflow: document=${result.documentWidth}, viewport=${result.viewportWidth}`,
-        );
+        const result = await measure(cdp);
+        assert.equal(result.layout, layout, `${label} rendered the wrong layout`);
+        assert.ok(result.documentWidth <= result.viewportWidth + 1, `${label} document overflow: ${result.documentWidth}px > ${result.viewportWidth}px`);
         assertWithinViewport(result.inner, result.viewportWidth, `${label} profile inner`);
         assertWithinViewport(result.hero, result.viewportWidth, `${label} hero`);
         assertWithinViewport(result.controls, result.viewportWidth, `${label} controls`);
-        assert.equal(
-          result.offenders.length,
-          0,
-          `${label} contains clipped content: ${JSON.stringify(result.offenders)}`,
-        );
-        assert.ok(result.touchTargets.length >= 10, `${label} did not render the expected interactive profile controls`);
+        assert.equal(result.offenders.length, 0, `${label} clipped content: ${JSON.stringify(result.offenders)}`);
+        assert.ok(result.touchTargets.length >= 10, `${label} did not render expected controls`);
         for (const targetInfo of result.touchTargets) {
-          assert.ok(
-            targetInfo.height >= 43,
-            `${label} touch target is too short: ${targetInfo.label} (${Math.round(targetInfo.height)}px)`,
-          );
+          assert.ok(targetInfo.height >= 43, `${label} touch target too short: ${targetInfo.label} (${Math.round(targetInfo.height)}px)`);
         }
         for (const section of result.sections) {
           assert.ok(section.visible, `${label} hides meaningful section ${section.selector}`);
           assertWithinViewport(section.rect, result.viewportWidth, `${label} ${section.selector}`);
         }
-
         console.log(`PUBLIC PROFILE PASS ${label}`);
       } catch (error) {
         let screenshot = "";


### PR DESCRIPTION
## Why
Public Proof Profiles are acquisition surfaces, and the existing browser layout CI only exercises authenticated app routes. Source-level profile tests cannot catch real rendering overflow, clipping, or touch-target regressions across the twelve profile structures.

## What this adds
- a headless-Chrome public profile audit using the same Vite/CDP approach as the existing authenticated responsive CI;
- all 12 public profile layouts;
- 9 requested breakpoints: 320, 375, 390, 430, 768, 1024, 1280, 1440, and 1920;
- 108 rendered layout/viewport cases per CI run;
- adversarial content: long names, long role/company strings, long unbroken evidence URLs/tokens, 25 skills, work history, projects, metrics, confirmations, and multiple Impact Receipts;
- assertions for document/container overflow, clipped content, hidden meaningful sections, layout identity, and minimum touch-target height;
- failure screenshots under `artifacts/public-profile-layout`;
- inclusion in the existing `npm run test:layout` gate.

## Safety
This is test-only except for updating the test command. It does not change production UI, profile data, authentication, or API behavior.

## Acceptance
CI must pass the full frontend deterministic checks, lint, build, existing authenticated layout audit, and the new 108-case public profile matrix before merge.