### PR TITLE
P0: add privacy-safe activation milestone analytics

### DIFF
--- a/frontend/src/analytics.js
+++ b/frontend/src/analytics.js
@@ -15,11 +15,26 @@ const UTM_FIELDS = [
 const FIRST_TOUCH_UTM_KEY = "bragstack_first_touch_utm";
 const SESSION_UTM_KEY = "bragstack_session_utm";
 const MAX_ATTRIBUTION_VALUE_LENGTH = 100;
+const SENSITIVE_PRODUCT_PARAMETER_PATTERN = /(^|_)(accomplishment|employer|evidence|url|company|organization|title|description|body|text|content)($|_)/i;
 
 export const ANALYTICS_EVENTS = Object.freeze({
   SIGN_UP: "sign_up",
+  SIGNUP_STARTED: "signup_started",
+  SIGNUP_COMPLETED: "signup_completed",
+  ONBOARDING_COMPLETED: "onboarding_completed",
   ACCOMPLISHMENT_CREATED: "accomplishment_created",
+  FIRST_PROOF_CREATED: "first_proof_created",
+  SECOND_PROOF_CREATED: "second_proof_created",
+  FIFTH_PROOF_CREATED: "fifth_proof_created",
   IMPACT_RECEIPT_CREATED: "impact_receipt_created",
+  FIRST_IMPACT_RECEIPT_COMPLETED: "first_impact_receipt_completed",
+  FIRST_GENERATED_OUTPUT: "first_generated_output",
+  EXISTING_PROOF_REUSED: "existing_proof_reused",
+  PUBLIC_PROFILE_VIEWED: "public_profile_viewed",
+  PROFILE_SHARED: "profile_shared",
+  IMPACT_RECEIPT_SHARED: "impact_receipt_shared",
+  CAREER_PACKET_EXPORTED: "career_packet_exported",
+  RETURNED_WITHIN_7_DAYS: "returned_within_7_days",
 });
 
 function safeStorageRead(storage, key) {
@@ -108,10 +123,11 @@ export function initializeAnalytics() {
   document.head.appendChild(script);
 }
 
-function sanitizeEventParameters(parameters = {}) {
+function sanitizeEventParameters(parameters = {}, { productParameters = false } = {}) {
   return Object.fromEntries(
     Object.entries(parameters).filter(([key, value]) => {
       if (!GA_NAME_PATTERN.test(key)) return false;
+      if (productParameters && SENSITIVE_PRODUCT_PARAMETER_PATTERN.test(key)) return false;
       if (value === null || value === undefined || value === "") return false;
       return ["string", "number", "boolean"].includes(typeof value);
     }),
@@ -127,10 +143,10 @@ export function trackAnalyticsEvent(eventName, parameters = {}) {
   window.gtag(
     "event",
     eventName,
-    sanitizeEventParameters({
-      ...getCampaignEventParameters(),
-      ...parameters,
-    }),
+    {
+      ...sanitizeEventParameters(getCampaignEventParameters()),
+      ...sanitizeEventParameters(parameters, { productParameters: true }),
+    },
   );
   return true;
 }

--- a/frontend/src/analytics.js
+++ b/frontend/src/analytics.js
@@ -14,8 +14,16 @@ const UTM_FIELDS = [
 ];
 const FIRST_TOUCH_UTM_KEY = "bragstack_first_touch_utm";
 const SESSION_UTM_KEY = "bragstack_session_utm";
+const ACTIVATION_COHORT_KEY = "boasted_activation_cohort";
+const ACTIVATION_SIGNUP_AT_KEY = "boasted_activation_signup_at";
+const ACTIVATION_LAST_SEEN_AT_KEY = "boasted_activation_last_seen_at";
+const ACTIVATION_RETURN_TRACKED_KEY = "boasted_activation_d7_return_tracked";
+const ACTIVATION_PROOF_COUNT_KEY = "boasted_activation_proof_count";
+const ACTIVATION_RECEIPT_COUNT_KEY = "boasted_activation_receipt_count";
 const MAX_ATTRIBUTION_VALUE_LENGTH = 100;
 const SENSITIVE_PRODUCT_PARAMETER_PATTERN = /(^|_)(accomplishment|employer|evidence|url|company|organization|title|description|body|text|content)($|_)/i;
+const RETURN_SESSION_GAP_MS = 30 * 60 * 1000;
+const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
 
 export const ANALYTICS_EVENTS = Object.freeze({
   SIGN_UP: "sign_up",
@@ -40,9 +48,9 @@ export const ANALYTICS_EVENTS = Object.freeze({
 function safeStorageRead(storage, key) {
   try {
     const rawValue = storage?.getItem(key);
-    return rawValue ? JSON.parse(rawValue) : {};
+    return rawValue ? JSON.parse(rawValue) : null;
   } catch {
-    return {};
+    return null;
   }
 }
 
@@ -71,12 +79,12 @@ export function captureCampaignAttribution() {
 
   const incomingUtm = readUtmParametersFromUrl();
   if (!Object.keys(incomingUtm).length) {
-    return safeStorageRead(window.sessionStorage, SESSION_UTM_KEY);
+    return safeStorageRead(window.sessionStorage, SESSION_UTM_KEY) || {};
   }
 
   safeStorageWrite(window.sessionStorage, SESSION_UTM_KEY, incomingUtm);
 
-  const existingFirstTouch = safeStorageRead(window.localStorage, FIRST_TOUCH_UTM_KEY);
+  const existingFirstTouch = safeStorageRead(window.localStorage, FIRST_TOUCH_UTM_KEY) || {};
   if (!Object.keys(existingFirstTouch).length) {
     safeStorageWrite(window.localStorage, FIRST_TOUCH_UTM_KEY, incomingUtm);
   }
@@ -88,7 +96,7 @@ export function getCampaignEventParameters() {
   if (typeof window === "undefined") return {};
 
   const sessionUtm = captureCampaignAttribution();
-  const firstTouchUtm = safeStorageRead(window.localStorage, FIRST_TOUCH_UTM_KEY);
+  const firstTouchUtm = safeStorageRead(window.localStorage, FIRST_TOUCH_UTM_KEY) || {};
 
   return {
     ...sessionUtm,
@@ -99,6 +107,89 @@ export function getCampaignEventParameters() {
       ]),
     ),
   };
+}
+
+function sanitizeEventParameters(parameters = {}, { productParameters = false } = {}) {
+  return Object.fromEntries(
+    Object.entries(parameters).filter(([key, value]) => {
+      if (!GA_NAME_PATTERN.test(key)) return false;
+      if (productParameters && SENSITIVE_PRODUCT_PARAMETER_PATTERN.test(key)) return false;
+      if (value === null || value === undefined || value === "") return false;
+      return ["string", "number", "boolean"].includes(typeof value);
+    }),
+  );
+}
+
+function emitAnalyticsEvent(eventName, parameters = {}) {
+  if (typeof window?.gtag !== "function" || !GA_NAME_PATTERN.test(eventName)) return false;
+  window.gtag(
+    "event",
+    eventName,
+    {
+      ...sanitizeEventParameters(getCampaignEventParameters()),
+      ...sanitizeEventParameters(parameters, { productParameters: true }),
+    },
+  );
+  return true;
+}
+
+function trackReturnWithinSevenDays() {
+  if (typeof window === "undefined") return;
+  const signupAt = Number(safeStorageRead(window.localStorage, ACTIVATION_SIGNUP_AT_KEY));
+  const lastSeenAt = Number(safeStorageRead(window.localStorage, ACTIVATION_LAST_SEEN_AT_KEY));
+  const alreadyTracked = safeStorageRead(window.localStorage, ACTIVATION_RETURN_TRACKED_KEY) === true;
+  const now = Date.now();
+
+  if (
+    !alreadyTracked
+    && signupAt > 0
+    && lastSeenAt > 0
+    && now - lastSeenAt >= RETURN_SESSION_GAP_MS
+    && now - signupAt <= SEVEN_DAYS_MS
+  ) {
+    emitAnalyticsEvent(ANALYTICS_EVENTS.RETURNED_WITHIN_7_DAYS, {
+      days_since_signup: Math.max(0, Math.floor((now - signupAt) / (24 * 60 * 60 * 1000))),
+    });
+    safeStorageWrite(window.localStorage, ACTIVATION_RETURN_TRACKED_KEY, true);
+  }
+
+  if (signupAt > 0) safeStorageWrite(window.localStorage, ACTIVATION_LAST_SEEN_AT_KEY, now);
+}
+
+function trackActivationMilestones(eventName, parameters = {}) {
+  if (typeof window === "undefined") return;
+
+  if (eventName === ANALYTICS_EVENTS.SIGN_UP) {
+    const now = Date.now();
+    safeStorageWrite(window.localStorage, ACTIVATION_COHORT_KEY, true);
+    safeStorageWrite(window.localStorage, ACTIVATION_SIGNUP_AT_KEY, now);
+    safeStorageWrite(window.localStorage, ACTIVATION_LAST_SEEN_AT_KEY, now);
+    safeStorageWrite(window.localStorage, ACTIVATION_RETURN_TRACKED_KEY, false);
+    safeStorageWrite(window.localStorage, ACTIVATION_PROOF_COUNT_KEY, 0);
+    safeStorageWrite(window.localStorage, ACTIVATION_RECEIPT_COUNT_KEY, 0);
+    emitAnalyticsEvent(ANALYTICS_EVENTS.SIGNUP_COMPLETED, { method: parameters.method || "unknown" });
+    return;
+  }
+
+  if (safeStorageRead(window.localStorage, ACTIVATION_COHORT_KEY) !== true) return;
+
+  if (eventName === ANALYTICS_EVENTS.ACCOMPLISHMENT_CREATED) {
+    const nextCount = Number(safeStorageRead(window.localStorage, ACTIVATION_PROOF_COUNT_KEY) || 0) + 1;
+    safeStorageWrite(window.localStorage, ACTIVATION_PROOF_COUNT_KEY, nextCount);
+    if (nextCount === 1) emitAnalyticsEvent(ANALYTICS_EVENTS.FIRST_PROOF_CREATED, { proof_number: 1 });
+    if (nextCount === 2) emitAnalyticsEvent(ANALYTICS_EVENTS.SECOND_PROOF_CREATED, { proof_number: 2 });
+    if (nextCount === 5) emitAnalyticsEvent(ANALYTICS_EVENTS.FIFTH_PROOF_CREATED, { proof_number: 5 });
+  }
+
+  if (eventName === ANALYTICS_EVENTS.IMPACT_RECEIPT_CREATED) {
+    const nextCount = Number(safeStorageRead(window.localStorage, ACTIVATION_RECEIPT_COUNT_KEY) || 0) + 1;
+    safeStorageWrite(window.localStorage, ACTIVATION_RECEIPT_COUNT_KEY, nextCount);
+    if (nextCount === 1) {
+      emitAnalyticsEvent(ANALYTICS_EVENTS.FIRST_IMPACT_RECEIPT_COMPLETED, {
+        creation_source: parameters.creation_source || "unknown",
+      });
+    }
+  }
 }
 
 export function initializeAnalytics() {
@@ -121,33 +212,16 @@ export function initializeAnalytics() {
   script.src = `https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`;
   script.dataset.bragstackAnalytics = "true";
   document.head.appendChild(script);
-}
 
-function sanitizeEventParameters(parameters = {}, { productParameters = false } = {}) {
-  return Object.fromEntries(
-    Object.entries(parameters).filter(([key, value]) => {
-      if (!GA_NAME_PATTERN.test(key)) return false;
-      if (productParameters && SENSITIVE_PRODUCT_PARAMETER_PATTERN.test(key)) return false;
-      if (value === null || value === undefined || value === "") return false;
-      return ["string", "number", "boolean"].includes(typeof value);
-    }),
-  );
+  trackReturnWithinSevenDays();
 }
 
 export function trackAnalyticsEvent(eventName, parameters = {}) {
   if (typeof window === "undefined" || !GA_NAME_PATTERN.test(eventName)) return false;
 
   initializeAnalytics();
-  if (typeof window.gtag !== "function") return false;
-
-  window.gtag(
-    "event",
-    eventName,
-    {
-      ...sanitizeEventParameters(getCampaignEventParameters()),
-      ...sanitizeEventParameters(parameters, { productParameters: true }),
-    },
-  );
+  if (!emitAnalyticsEvent(eventName, parameters)) return false;
+  trackActivationMilestones(eventName, parameters);
   return true;
 }
 

--- a/frontend/src/analytics.test.js
+++ b/frontend/src/analytics.test.js
@@ -145,4 +145,27 @@ describe("Boasted analytics", () => {
     assert.equal(event[2].utm_campaign, "beta");
     assert.equal(event[2].first_utm_source, "linkedin");
   });
+
+  it("drops sensitive product content while preserving structural metadata", () => {
+    trackAnalyticsEvent(ANALYTICS_EVENTS.CAREER_PACKET_EXPORTED, {
+      packet_type: "performance-review",
+      format: "pdf",
+      accomplishment_text: "Saved a customer escalation",
+      employer: "Private Employer",
+      evidence_url: "https://private.example/evidence",
+      organization_name: "Private Org",
+    });
+
+    const event = window.dataLayer.find(
+      (entry) => entry[0] === "event" && entry[1] === ANALYTICS_EVENTS.CAREER_PACKET_EXPORTED,
+    );
+
+    assert.ok(event);
+    assert.equal(event[2].packet_type, "performance-review");
+    assert.equal(event[2].format, "pdf");
+    assert.equal(event[2].accomplishment_text, undefined);
+    assert.equal(event[2].employer, undefined);
+    assert.equal(event[2].evidence_url, undefined);
+    assert.equal(event[2].organization_name, undefined);
+  });
 });

--- a/frontend/src/analytics.test.js
+++ b/frontend/src/analytics.test.js
@@ -60,6 +60,10 @@ function installBrowserFakes() {
   };
 }
 
+function productEvents(name) {
+  return window.dataLayer.filter((entry) => entry[0] === "event" && entry[1] === name);
+}
+
 describe("Boasted analytics", () => {
   beforeEach(() => {
     installBrowserFakes();
@@ -135,9 +139,7 @@ describe("Boasted analytics", () => {
     });
 
     assert.equal(tracked, true);
-    const event = window.dataLayer.find(
-      (entry) => entry[0] === "event" && entry[1] === ANALYTICS_EVENTS.SIGN_UP,
-    );
+    const event = productEvents(ANALYTICS_EVENTS.SIGN_UP)[0];
     assert.ok(event);
     assert.equal(event[2].method, "email_password");
     assert.equal(event[2].utm_source, "linkedin");
@@ -156,9 +158,7 @@ describe("Boasted analytics", () => {
       organization_name: "Private Org",
     });
 
-    const event = window.dataLayer.find(
-      (entry) => entry[0] === "event" && entry[1] === ANALYTICS_EVENTS.CAREER_PACKET_EXPORTED,
-    );
+    const event = productEvents(ANALYTICS_EVENTS.CAREER_PACKET_EXPORTED)[0];
 
     assert.ok(event);
     assert.equal(event[2].packet_type, "performance-review");
@@ -167,5 +167,37 @@ describe("Boasted analytics", () => {
     assert.equal(event[2].employer, undefined);
     assert.equal(event[2].evidence_url, undefined);
     assert.equal(event[2].organization_name, undefined);
+  });
+
+  it("derives signup and proof milestones only for a newly tracked signup cohort", () => {
+    trackAnalyticsEvent(ANALYTICS_EVENTS.SIGN_UP, { method: "email_password" });
+    for (let index = 0; index < 5; index += 1) {
+      trackAnalyticsEvent(ANALYTICS_EVENTS.ACCOMPLISHMENT_CREATED);
+    }
+
+    assert.equal(productEvents(ANALYTICS_EVENTS.SIGNUP_COMPLETED).length, 1);
+    assert.equal(productEvents(ANALYTICS_EVENTS.FIRST_PROOF_CREATED).length, 1);
+    assert.equal(productEvents(ANALYTICS_EVENTS.SECOND_PROOF_CREATED).length, 1);
+    assert.equal(productEvents(ANALYTICS_EVENTS.FIFTH_PROOF_CREATED).length, 1);
+    assert.equal(productEvents(ANALYTICS_EVENTS.FIRST_PROOF_CREATED)[0][2].proof_number, 1);
+    assert.equal(productEvents(ANALYTICS_EVENTS.FIFTH_PROOF_CREATED)[0][2].proof_number, 5);
+  });
+
+  it("derives the first completed Impact Receipt once for the new-user cohort", () => {
+    trackAnalyticsEvent(ANALYTICS_EVENTS.SIGN_UP, { method: "email_password" });
+    trackAnalyticsEvent(ANALYTICS_EVENTS.IMPACT_RECEIPT_CREATED, { creation_source: "accomplishment" });
+    trackAnalyticsEvent(ANALYTICS_EVENTS.IMPACT_RECEIPT_CREATED, { creation_source: "manual" });
+
+    const events = productEvents(ANALYTICS_EVENTS.FIRST_IMPACT_RECEIPT_COMPLETED);
+    assert.equal(events.length, 1);
+    assert.equal(events[0][2].creation_source, "accomplishment");
+  });
+
+  it("does not invent proof milestones for existing users outside the signup cohort", () => {
+    trackAnalyticsEvent(ANALYTICS_EVENTS.ACCOMPLISHMENT_CREATED);
+    trackAnalyticsEvent(ANALYTICS_EVENTS.IMPACT_RECEIPT_CREATED, { creation_source: "manual" });
+
+    assert.equal(productEvents(ANALYTICS_EVENTS.FIRST_PROOF_CREATED).length, 0);
+    assert.equal(productEvents(ANALYTICS_EVENTS.FIRST_IMPACT_RECEIPT_COMPLETED).length, 0);
   });
 });


### PR DESCRIPTION
## Why

The product audit says the next roadmap should be driven by behavior: signup completion, first/second/fifth proof creation, first completed Impact Receipt, reuse/sharing, exports, and D7 return. It also explicitly requires that accomplishment text, employer information, evidence content, and URLs never be sent to GA.

## What this first instrumentation slice does

- expands the canonical event vocabulary for the audit metrics;
- keeps the existing `sign_up`, `accomplishment_created`, and `impact_receipt_created` events for continuity;
- derives `signup_completed` from the already-successful registration event;
- for newly tracked signup cohorts only, derives `first_proof_created`, `second_proof_created`, and `fifth_proof_created` from successful accomplishment creation;
- derives `first_impact_receipt_completed` once for a new signup cohort;
- records `returned_within_7_days` only after a >=30 minute return gap and only once within seven days of signup;
- adds a product-event privacy boundary that drops content-shaped fields such as accomplishment/employer/evidence/URL/company/organization/title/description/text before GA dispatch;
- adds regression tests for the privacy boundary and milestone logic.

## Deliberate scope

This PR does **not** pretend events are wired where behavior is ambiguous. `first_generated_output`, `existing_proof_reused`, `public_profile_viewed`, `profile_shared`, `impact_receipt_shared`, and `career_packet_exported` are defined here but should be wired at the exact successful UI/API actions in follow-up commits rather than inferred from page visits or button impressions.

## Measurement caveat

Proof/receipt milestones are enabled only for users whose signup was observed by this instrumentation. Existing users are intentionally excluded so their next accomplishment is not mislabeled as their first proof.

Draft until CI validates the analytics tests and the wider frontend suite.