### PR TITLE
Reframe homepage for 30-second product understanding

### DIFF
--- a/frontend/src/LandingPage.jsx
+++ b/frontend/src/LandingPage.jsx
@@ -20,37 +20,50 @@ import "./LandingPageMonetization.css";
 import "./LandingPageSimple.css";
 
 const simpleSteps = [
-  { number: "01", title: "Save it", description: "Write down what you accomplished before the details disappear." },
-  { number: "02", title: "Prove it", description: "Add the result, skills, evidence, and shared credit that belong with the work." },
-  { number: "03", title: "Use it", description: "Turn the same saved work into a résumé, review, promotion case, or interview story." },
+  {
+    number: "01",
+    title: "Save it",
+    description: "Capture a win, project, result, lesson, or piece of work while you still remember the details.",
+  },
+  {
+    number: "02",
+    title: "Prove it",
+    description: "Keep the result, evidence, skills, and shared credit connected to the work instead of scattered everywhere.",
+  },
+  {
+    number: "03",
+    title: "Use it",
+    description: "Reuse the same saved record when you need a résumé, review, promotion case, interview story, profile, or application.",
+  },
 ];
 
-const outputs = [
-  { id: "product-resume", icon: FileText, title: "ATS-friendly résumés", description: "Build from your saved work or import an existing résumé and clean it up." },
-  { id: "product-review", icon: TrendingUp, title: "Performance reviews", description: "Pull together the wins and results that show what changed because of your work." },
-  { id: "product-promotion", icon: Target, title: "Promotion packets", description: "Organize proof of scope, ownership, growth, and impact for advancement conversations." },
-  { id: "product-interview", icon: MessageSquare, title: "Interview practice", description: "Turn real accomplishments into stories you can explain clearly under pressure." },
-  { id: "product-profile", icon: Sparkles, title: "Proof Profiles", description: "Share only the work you choose while the rest of your private record stays private." },
+const outcomes = [
+  { icon: FileText, title: "Résumé", description: "Build from work you already saved." },
+  { icon: TrendingUp, title: "Performance review", description: "Bring back the wins and results that matter." },
+  { icon: Target, title: "Promotion", description: "Show scope, ownership, growth, and impact." },
+  { icon: MessageSquare, title: "Interview", description: "Turn real work into stories you can explain clearly." },
+  { icon: Sparkles, title: "Proof Profile", description: "Share only the proof you choose to make public." },
+  { icon: GraduationCap, title: "School & opportunity", description: "Reuse projects and achievements for internships, scholarships, and programs." },
 ];
 
 const plans = [
   {
     name: "Free",
     price: "$0",
-    tagline: "A simple place to start saving your work",
-    badge: "Base plan",
+    tagline: "Start building your record",
+    badge: "Start here",
     features: ["5 proof entries", "1 Impact Receipt", "Basic reports", "Basic Proof Profile", "Skill tracking"],
-    cta: "Create account — Pro gift included",
+    cta: "Start free",
     href: "/register",
   },
   {
     name: "Pro",
     price: "$0",
     suffix: " for now",
-    tagline: "Temporary complimentary early-access gift",
+    tagline: "Complimentary early access",
     featured: true,
-    badge: "Complimentary Pro gift",
-    features: ["Unlimited proof + Impact Receipts", "Career Intelligence", "Resume Builder", "Performance Review Builder", "Promotion Packet", "PDF and career exports"],
+    badge: "Early access gift",
+    features: ["Unlimited proof + Impact Receipts", "Career Intelligence", "Résumé Builder", "Performance Review Builder", "Promotion Packet", "PDF and career exports"],
     cta: "Get Pro free for now",
     href: "/register",
   },
@@ -58,7 +71,7 @@ const plans = [
     name: "Team",
     price: "$15",
     suffix: "/user / month",
-    tagline: "Better reviews and growth conversations without surveillance",
+    tagline: "Shared review workflows without surveillance",
     badge: "Coming soon",
     features: ["Everything in Pro", "Team review dashboard", "Shared review templates", "Optional manager confirmation", "Review-cycle packets", "Bounded team analytics", "Centralized billing"],
     cta: "Talk about Team",
@@ -67,7 +80,7 @@ const plans = [
   {
     name: "Enterprise",
     price: "Custom",
-    tagline: "Governance and deeper controls for larger organizations",
+    tagline: "Governance and controls for larger organizations",
     features: ["Everything in Team", "Enterprise admin dashboard", "Identity and SSO roadmap", "Audit and governance controls", "Retention and policy controls", "Custom integrations and support"],
     cta: "Talk about Enterprise",
     href: "mailto:hello@boasted.io?subject=Boasted%20Enterprise",
@@ -79,26 +92,18 @@ const organizationTabs = {
     label: "Teams",
     icon: Users,
     eyebrow: "FOR TEAMS",
-    title: "Make review season easier for managers and employees.",
-    description: "Team adds a shared company workspace around employee-owned proof. People keep their private career record, then intentionally bring selected evidence into reviews, promotions, and development conversations.",
-    features: [
-      "Review dashboard for packet readiness and workflow status",
+    title: "Make reviews and growth conversations easier.",
+    description: "Employees keep their own private record, then intentionally bring selected proof into reviews, promotions, and development conversations.",
+    bullets: [
       "Shared review and promotion templates",
       "Optional manager confirmation for selected accomplishments",
       "Review-cycle packets built from employee-approved proof",
-      "Bounded team trends instead of employee scores",
-      "Centralized seats, billing, and workspace administration",
+      "Bounded team trends instead of employee scoring",
     ],
-    stats: [
+    preview: [
       ["Review packets", "18 / 24", "ready"],
-      ["Confirmations", "Optional", "selected proof only"],
-      ["Private notes", "Hidden", "not a manager feed"],
-    ],
-    rows: [
-      ["Review cycle", "Q4 Growth Review", "In progress"],
-      ["Packet readiness", "18 of 24", "On track"],
-      ["Shared template", "Growth + Impact", "Active"],
-      ["Team trends", "Aggregate only", "Bounded"],
+      ["Confirmations", "Optional", "selected proof"],
+      ["Private notes", "Hidden", "employee-owned"],
     ],
     cta: "Talk about Team",
     href: "mailto:hello@boasted.io?subject=Boasted%20Team",
@@ -108,25 +113,17 @@ const organizationTabs = {
     icon: Building2,
     eyebrow: "FOR ENTERPRISE",
     title: "Add governance without turning career proof into surveillance.",
-    description: "Enterprise is for organizations that need stronger administration, identity, retention, policy, and integration controls while preserving the line between an employee's private record and company-facing workflows.",
-    features: [
-      "Enterprise admin dashboard for workspaces and review programs",
-      "Identity and SSO roadmap for larger deployments",
-      "Retention policies and administrative governance controls",
-      "Audit-oriented history for company-managed workflows",
+    description: "Larger organizations can add administration, policy, retention, identity, and integration controls while preserving the boundary around a person's private record.",
+    bullets: [
+      "Workspace and review-program administration",
+      "Identity and SSO roadmap",
+      "Retention and governance controls",
       "Custom integrations and implementation support",
-      "Bounded organization analytics designed for programs, not ranking people",
     ],
-    stats: [
+    preview: [
       ["Policies", "Managed", "workspace controls"],
       ["Retention", "Configurable", "company workflows"],
       ["Analytics", "Bounded", "no leaderboard"],
-    ],
-    rows: [
-      ["Identity", "SSO / directory", "Roadmap"],
-      ["Retention", "Policy controlled", "Managed"],
-      ["Review programs", "Multiple workspaces", "Centralized"],
-      ["Integrations", "Custom", "Supported"],
     ],
     cta: "Talk about Enterprise",
     href: "mailto:hello@boasted.io?subject=Boasted%20Enterprise",
@@ -134,27 +131,19 @@ const organizationTabs = {
   education: {
     label: "Education",
     icon: GraduationCap,
-    eyebrow: "FOR EDUCATION",
-    title: "Turn learning into proof students can actually reuse.",
-    description: "Education helps students and early-career users save coursework, projects, certifications, achievements, leadership, and practical experience, then reuse that evidence for résumés, interviews, scholarships, programs, internships, and career exploration.",
-    features: [
-      "Scholarship Finder with licensed source provenance, filters, query understanding, and provider submissions",
-      "Program Finder using U.S. Department of Education College Scorecard data",
-      "Federal Internship Finder using live USAJOBS public listings",
-      "Major Explorer, Skills from Education, and evidence-connected career directions",
+    eyebrow: "FOR STUDENTS",
+    title: "Give schoolwork, projects, and achievements somewhere to go.",
+    description: "Students can save what they have done, then reuse it for résumés, internships, scholarships, programs, portfolios, and early-career opportunities.",
+    bullets: [
       "Academic Portfolio and education-focused Impact Receipts",
-      "Public Education Data & Source Audit documenting approved and blocked sources",
+      "Scholarship, program, and federal internship discovery",
+      "Skills from education and evidence-connected career directions",
+      "Student proof stays private unless the student chooses to share it",
     ],
-    stats: [
-      ["Scholarships", "Licensed", "source-gated catalog"],
-      ["Programs", "Scorecard", "official public data"],
-      ["Internships", "USAJOBS", "live federal listings"],
-    ],
-    rows: [
-      ["Student evidence", "Private", "Shared by choice"],
-      ["Opportunity search", "Evidence-connected", "Editable"],
-      ["Source rights", "Audited", "Public log"],
-      ["Predictions", "None", "No fake fit score"],
+    preview: [
+      ["Student proof", "Private", "shared by choice"],
+      ["Programs", "Explore", "official data"],
+      ["Internships", "Discover", "live listings"],
     ],
     cta: "Explore Education",
     href: "/education",
@@ -171,9 +160,9 @@ function LandingPage() {
         <a className="landing-logo" href="/">Boasted</a>
         <nav className="landing-nav-links" aria-label="Main navigation">
           <a href="#how-it-works">How it works</a>
-          <a href="#product">What it makes</a>
-          <a href="#organizations">Organizations</a>
-          <a href="/education">Education</a>
+          <a href="#impact-receipt">Impact Receipt</a>
+          <a href="#outcomes">What it helps with</a>
+          <a href="#trust">Privacy</a>
           <a href="#pricing">Pricing</a>
         </nav>
         <div className="landing-nav-actions">
@@ -182,38 +171,55 @@ function LandingPage() {
         </div>
       </header>
 
-      <section className="landing-hero landing-simple-hero">
+      <section className="landing-hero landing-simple-hero landing-thirty-hero">
         <div className="landing-hero-copy">
-          <div className="landing-eyebrow"><ShieldCheck size={15} /> YOUR PRIVATE CAREER RECORD</div>
-          <h1>Remember what you did<span> at work.</span></h1>
+          <div className="landing-eyebrow"><Sparkles size={15} /> ONE PLACE FOR WHAT YOU HAVE DONE</div>
+          <h1>Never lose track of what you&apos;ve accomplished.</h1>
           <p className="landing-hero-description">
-            Save your wins, results, skills, and proof in one private place. Boasted turns them into résumés, performance reviews, promotion packets, and interview stories.
+            Save your work, wins, projects, skills, and proof in one place — so when a job, review, promotion, interview, scholarship, or other opportunity comes up, you are ready.
           </p>
           <div className="landing-hero-actions">
-            <a className="landing-btn" href="/register">Start free <ArrowRight size={18} /></a>
+            <a className="landing-btn" href="/register">Start building my record <ArrowRight size={18} /></a>
             <a className="landing-btn landing-btn-secondary" href="#how-it-works">See how it works</a>
           </div>
-          <p className="landing-trust-line">Private by default <span>•</span> You choose what to share <span>•</span> No made-up claims</p>
+          <p className="landing-trust-line">Free to start <span>•</span> Private by default <span>•</span> You decide what to share</p>
         </div>
 
-        <div className="landing-proof-preview">
-          <div className="preview-glow" />
-          <article className="proof-preview-card landing-simple-preview-card">
-            <div className="proof-preview-header"><div><p>Saved work</p><span>Private career proof</span></div><div className="proof-preview-avatar">B</div></div>
-            <div className="proof-preview-meta">One example you can reuse later</div>
-            <h2>Improved a recurring customer escalation workflow</h2>
-            <p>Documented the failure pattern, clarified the diagnostic path, and created a reusable troubleshooting guide.</p>
-            <div className="proof-preview-result"><span>Why save this?</span><strong>Later, this can become a résumé bullet, review example, promotion proof, or interview story.</strong></div>
-            <div className="proof-preview-tags"><span>Result</span><span>Skills</span><span>Evidence</span></div>
+        <div className="landing-product-shot" aria-label="Example Boasted Impact Receipt">
+          <div className="landing-product-shot-glow" />
+          <article className="impact-window">
+            <div className="impact-window-bar">
+              <div className="impact-window-dots" aria-hidden="true"><span /><span /><span /></div>
+              <div className="impact-window-location">Boasted / Impact Receipt</div>
+              <div className="impact-window-status"><ShieldCheck size={14} /> Private</div>
+            </div>
+            <div className="impact-window-body">
+              <div className="impact-shot-kicker">IMPACT RECEIPT</div>
+              <h2>Reduced repeat customer escalations by improving the troubleshooting path.</h2>
+              <div className="impact-shot-grid">
+                <div><span>Accomplishment</span><p>Created a reusable diagnostic guide for a recurring support failure.</p></div>
+                <div><span>Contribution</span><p>Mapped the failure pattern, clarified checks, and documented the recovery path.</p></div>
+                <div className="impact-shot-result"><span>Result</span><p>Faster triage and fewer repeat handoffs for the same issue pattern.</p></div>
+                <div><span>Evidence</span><p>Runbook · ticket examples · before/after workflow notes</p></div>
+                <div><span>Skills</span><p>Troubleshooting · documentation · systems thinking</p></div>
+                <div><span>Credit</span><p>Individual contribution with team review</p></div>
+              </div>
+            </div>
           </article>
+          <p className="landing-product-shot-caption">This is the idea: your work stops living in your memory, inbox, chat history, and random notes.</p>
         </div>
+      </section>
+
+      <section className="landing-thirty-thesis" aria-label="Boasted in one sentence">
+        <span>Boasted in one sentence</span>
+        <strong>It remembers what you have done, keeps the proof with it, and helps you use it later.</strong>
       </section>
 
       <section className="landing-workflow premium-workflow landing-simple-workflow" id="how-it-works">
         <div className="landing-section-heading">
-          <p>HOW BOASTED WORKS</p>
-          <h2>Save it → Prove it → Use it</h2>
-          <span>Boasted is a private notebook for the good things you do at work — except it can turn those notes into useful career tools later.</span>
+          <p>THE WHOLE MODEL</p>
+          <h2>Save it. Prove it. Use it.</h2>
+          <span>You do not need to become a career-planning expert. Just keep a record of the things you do while the details are still fresh.</span>
         </div>
         <div className="premium-workflow-grid landing-simple-step-grid">
           {simpleSteps.map((step) => (
@@ -224,34 +230,82 @@ function LandingPage() {
             </article>
           ))}
         </div>
-        <div className="landing-simple-receipt-note">
-          <Sparkles size={20} />
-          <div><strong>Impact Receipts keep an important win together.</strong><span>What you did, what happened, the evidence, skills, and credit stay connected so you can reuse the story without exaggerating it.</span></div>
+      </section>
+
+      <section className="landing-impact-section" id="impact-receipt">
+        <div className="landing-impact-copy">
+          <p className="landing-mini-label">THE PART THAT MAKES BOASTED DIFFERENT</p>
+          <h2>Do not just remember the win. Keep the receipt.</h2>
+          <p>An Impact Receipt keeps the story of an accomplishment together: what happened, what you contributed, what changed, what supports the claim, which skills were involved, and who deserves credit.</p>
+          <div className="landing-impact-points">
+            <div><Check size={18} /><span><strong>Context stays attached.</strong> You do not have to reconstruct the story months later.</span></div>
+            <div><Check size={18} /><span><strong>Proof stays attached.</strong> Results, evidence references, and skills stay connected to the work.</span></div>
+            <div><Check size={18} /><span><strong>Credit stays honest.</strong> Individual contribution and shared work can both be represented.</span></div>
+          </div>
+        </div>
+        <div className="landing-impact-anatomy" aria-label="Impact Receipt anatomy">
+          <div><span>01</span><strong>What happened?</strong><p>The accomplishment.</p></div>
+          <div><span>02</span><strong>What did you do?</strong><p>Your contribution.</p></div>
+          <div><span>03</span><strong>What changed?</strong><p>The result.</p></div>
+          <div><span>04</span><strong>What supports it?</strong><p>Evidence.</p></div>
+          <div><span>05</span><strong>What did it show?</strong><p>Skills.</p></div>
+          <div><span>06</span><strong>Who helped?</strong><p>Credit.</p></div>
         </div>
       </section>
 
-      <section className="landing-use-cases landing-simple-products" id="product">
+      <section className="landing-use-cases landing-simple-products" id="outcomes">
         <div className="landing-section-heading">
-          <p>WHAT BOASTED MAKES FOR YOU</p>
+          <p>ONE RECORD. MANY MOMENTS.</p>
           <h2>Use the work you already saved.</h2>
-          <span>You should not have to remember your whole career from scratch every time someone asks what you have done.</span>
+          <span>These are outcomes of the same record — not six different products you have to maintain.</span>
         </div>
-        <div className="use-case-grid landing-simple-output-grid">
-          {outputs.map(({ icon: Icon, ...item }) => (
-            <article className="use-case-card" id={item.id} key={item.id}>
-              <div className="use-case-icon"><Icon size={21} /></div>
-              <h3>{item.title}</h3>
-              <p>{item.description}</p>
-            </article>
-          ))}
+        <div className="landing-outcome-flow">
+          <div className="landing-outcome-source"><Sparkles size={21} /><span>Your saved work</span><strong>One record</strong></div>
+          <div className="landing-outcome-line" aria-hidden="true" />
+          <div className="use-case-grid landing-simple-output-grid">
+            {outcomes.map(({ icon: Icon, ...item }) => (
+              <article className="use-case-card" key={item.title}>
+                <div className="use-case-icon"><Icon size={21} /></div>
+                <h3>{item.title}</h3>
+                <p>{item.description}</p>
+              </article>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="landing-memory-problem">
+        <div className="landing-memory-number">6 months</div>
+        <div>
+          <p className="landing-mini-label">THE PROBLEM IS TIME</p>
+          <h2>Six months from now, will you remember everything you did this month?</h2>
+          <p>Projects blur together. Numbers disappear. Teams change. Managers leave. School semesters end. Useful links get buried. Boasted gives the important parts somewhere to live before that happens.</p>
+        </div>
+      </section>
+
+      <section className="landing-feature-section landing-simple-trust" id="trust">
+        <div className="landing-feature-copy">
+          <p className="landing-mini-label">YOUR INFORMATION IS YOURS</p>
+          <h2>Private first. Share only when you want to.</h2>
+          <p>Your record is for you. Boasted helps you organize what you save; it does not turn your day-to-day work into an employer activity feed or score.</p>
+          <div className="landing-feature-list">
+            <div><ShieldCheck size={17} /> Private proof stays behind your account.</div>
+            <div><ShieldCheck size={17} /> Public Proof Profiles show only what you choose to publish.</div>
+            <div><ShieldCheck size={17} /> Boasted does not invent results, credentials, or proof.</div>
+            <div><ShieldCheck size={17} /> You can keep confidential details out while still saving the career value of the work.</div>
+          </div>
+        </div>
+        <div className="feature-dashboard-preview landing-simple-trust-card">
+          <div className="feature-preview-header"><div><span>Default</span><strong>Private</strong></div><div><span>Sharing</span><strong>Your choice</strong></div></div>
+          <div className="feature-preview-entry"><div><span className="feature-preview-badge">Your record</span><small>You stay in control</small></div><h3>Save the useful part. Leave secrets out.</h3><p>Keep the result, skill, lesson, and credit you are allowed to keep. Do not upload employer secrets, customer secrets, or anything your agreements say you cannot store.</p></div>
         </div>
       </section>
 
       <section className="landing-org-section" id="organizations">
         <div className="landing-section-heading landing-org-heading">
-          <p>FOR ORGANIZATIONS & EDUCATION</p>
-          <h2>Different workspaces. Same proof-first idea.</h2>
-          <span>Choose a tab to see how Boasted can support a team, a larger organization, or students without making private proof a surveillance feed.</span>
+          <p>FOR MORE THAN ONE PERSON</p>
+          <h2>The same idea can work for teams, organizations, and students.</h2>
+          <span>The individual record stays the center. Organization features sit around it instead of replacing it.</span>
         </div>
 
         <div className="landing-org-tabs" role="tablist" aria-label="Organization solutions">
@@ -272,7 +326,7 @@ function LandingPage() {
             <h3>{organization.title}</h3>
             <p>{organization.description}</p>
             <div className="landing-org-feature-list">
-              {organization.features.map((feature) => <div key={feature}><Check size={17} /> <span>{feature}</span></div>)}
+              {organization.bullets.map((feature) => <div key={feature}><Check size={17} /> <span>{feature}</span></div>)}
             </div>
             <a className="landing-btn" href={organization.href}>{organization.cta} <ArrowRight size={17} /></a>
           </div>
@@ -280,43 +334,20 @@ function LandingPage() {
           <div className="landing-org-dashboard">
             <div className="landing-org-dashboard-title"><LayoutDashboard size={19} /><div><span>Workspace preview</span><strong>{organization.label}</strong></div></div>
             <div className="landing-org-stats">
-              {organization.stats.map(([label, value, detail]) => (
+              {organization.preview.map(([label, value, detail]) => (
                 <div key={label}><span>{label}</span><strong>{value}</strong><small>{detail}</small></div>
               ))}
             </div>
-            <div className="landing-org-table">
-              {organization.rows.map(([label, value, status]) => (
-                <div className="landing-org-row" key={label}><span>{label}</span><strong>{value}</strong><em>{status}</em></div>
-              ))}
-            </div>
-            <div className="landing-org-privacy"><ShieldCheck size={17} /><span>{organizationTab === "education" ? "Student proof stays private unless the user chooses to share it." : "Private employee notes are not exposed as a manager activity feed."}</span></div>
+            <div className="landing-org-privacy"><ShieldCheck size={17} /><span>{organizationTab === "education" ? "Student proof stays private unless the student chooses to share it." : "Private individual notes are not exposed as an employer activity feed."}</span></div>
           </div>
-        </div>
-      </section>
-
-      <section className="landing-feature-section landing-simple-trust" id="security">
-        <div className="landing-feature-copy">
-          <p className="landing-mini-label">YOUR WORK STAYS YOURS</p>
-          <h2>Private first. Share only when you want to.</h2>
-          <p>Your private work record is for you. Boasted helps organize what you save; it does not turn your day-to-day work into an employer score.</p>
-          <div className="landing-feature-list">
-            <div><ShieldCheck size={17} /> Private proof stays behind your account.</div>
-            <div><ShieldCheck size={17} /> Public profiles show only what you choose to publish.</div>
-            <div><ShieldCheck size={17} /> Boasted does not invent results, credentials, or proof.</div>
-            <div><ShieldCheck size={17} /> You can keep confidential details out while still saving the career value of the work.</div>
-          </div>
-        </div>
-        <div className="feature-dashboard-preview landing-simple-trust-card">
-          <div className="feature-preview-header"><div><span>Default</span><strong>Private</strong></div><div><span>Sharing</span><strong>Your choice</strong></div></div>
-          <div className="feature-preview-entry"><div><span className="feature-preview-badge">Simple rule</span><small>You stay in control</small></div><h3>Save the useful part. Leave secrets out.</h3><p>Keep the result, skill, lesson, and credit you are allowed to keep. Do not upload employer secrets, customer secrets, or anything your agreements say you cannot store.</p></div>
         </div>
       </section>
 
       <section className="landing-pricing" id="pricing">
         <div className="landing-section-heading">
-          <p>PRICING</p>
-          <h2>Start free. Grow into Team or Enterprise.</h2>
-          <span>All four plans stay visible. Pro is temporarily complimentary during early access; Team and Enterprise are available for company conversations.</span>
+          <p>SIMPLE PRICING</p>
+          <h2>Start free. Keep your record growing.</h2>
+          <span>Pro is temporarily complimentary during early access. Team and Enterprise are available for organization conversations.</span>
         </div>
         <div className="pricing-grid pricing-grid-four">
           {plans.map((plan) => (
@@ -333,17 +364,16 @@ function LandingPage() {
       </section>
 
       <section className="landing-final-cta landing-simple-final-cta">
-        <div><p>YOUR WORK IS ALREADY HAPPENING.</p><h2>Do not make your future self remember all of it.</h2><span>Save your best work now so it is ready when you need a résumé, review, promotion case, or interview story.</span></div>
-        <a className="landing-btn landing-final-button" href="/register">Start free <ArrowRight size={18} /></a>
+        <div><p>YOUR WORK SHOULD NOT DISAPPEAR JUST BECAUSE TIME PASSES.</p><h2>Start keeping the record your future self will wish you had.</h2><span>Save what you have done now. Use it whenever the next opportunity shows up.</span></div>
+        <a className="landing-btn landing-final-button" href="/register">Start building my record <ArrowRight size={18} /></a>
       </section>
 
       <footer className="mega-footer landing-simple-footer">
-        <div className="mega-footer-brand"><a className="landing-logo" href="/">Boasted</a><p>A private place to remember and reuse your best work.</p><a className="footer-cta" href="/register">Start free <ArrowRight size={15} /></a></div>
+        <div className="mega-footer-brand"><a className="landing-logo" href="/">Boasted</a><p>One place to remember what you have done and use it later.</p><a className="footer-cta" href="/register">Start free <ArrowRight size={15} /></a></div>
         <div className="mega-footer-columns landing-simple-footer-columns">
-          <div><h3>Product</h3><a href="#product">What Boasted makes</a><a href="#how-it-works">How it works</a><a href="#security">Privacy</a></div>
+          <div><h3>Product</h3><a href="#how-it-works">How it works</a><a href="#impact-receipt">Impact Receipts</a><a href="#outcomes">What it helps with</a></div>
           <div><h3>Organizations</h3><a href="#organizations" onClick={() => setOrganizationTab("team")}>Teams</a><a href="#organizations" onClick={() => setOrganizationTab("enterprise")}>Enterprise</a><a href="/education">Education</a></div>
-          <div><h3>Account</h3><a href="/login">Log in</a><a href="/register">Create account</a><a href="#pricing">Pricing</a></div>
-          <div><h3>Legal & trust</h3><a href="/privacy">Privacy</a><a href="/terms">Terms</a><a href="/legal/education-data">Education data audit</a></div>
+          <div><h3>Account & trust</h3><a href="/login">Log in</a><a href="/register">Create account</a><a href="/privacy">Privacy</a><a href="/terms">Terms</a></div>
         </div>
         <div className="mega-footer-bottom"><span>© 2026 Boasted</span><span>Private by default · Your proof stays yours.</span><div><a href="/privacy">Privacy</a><a href="/terms">Terms</a></div></div>
       </footer>

--- a/frontend/src/LandingPageSimple.css
+++ b/frontend/src/LandingPageSimple.css
@@ -1,7 +1,120 @@
-.landing-page-simple .landing-simple-hero{min-height:600px;padding-top:4.25rem;padding-bottom:3.25rem;gap:3rem}.landing-page-simple .landing-proof-preview{min-height:420px}.landing-page-simple .landing-hero-description{max-width:760px;font-size:1.08rem;line-height:1.58}.landing-simple-preview-card{transform:none}.landing-simple-workflow{padding-top:3.25rem!important;padding-bottom:3.25rem!important}.landing-simple-step-grid{grid-template-columns:repeat(3,minmax(0,1fr))!important;max-width:1100px;margin:0 auto}.landing-simple-step-grid .premium-workflow-card{min-height:230px}.landing-simple-step-grid .premium-workflow-card h3{margin-top:2.5rem}.landing-simple-receipt-note{display:flex;align-items:flex-start;gap:12px;max-width:920px;margin:18px auto 0;padding:14px 16px;border:1px solid rgba(129,140,248,.18);border-radius:16px;background:rgba(99,102,241,.08)}.landing-simple-receipt-note>svg{flex:0 0 auto;margin-top:2px;color:#a78bfa}.landing-simple-receipt-note strong,.landing-simple-receipt-note span{display:block}.landing-simple-receipt-note strong{margin-bottom:4px}.landing-simple-receipt-note span{color:var(--landing-muted,#a9b4c7);line-height:1.48}.landing-simple-products{padding-top:3.25rem!important;padding-bottom:3.25rem!important}.landing-simple-output-grid{grid-template-columns:repeat(5,minmax(0,1fr))}.landing-simple-output-grid .use-case-card{min-height:205px}.landing-simple-output-grid .use-case-card h3{margin-top:2.5rem}.landing-simple-trust{margin-top:2.25rem!important;margin-bottom:2.25rem!important}.landing-simple-trust-card{align-self:stretch}.landing-page-simple .landing-pricing{padding-top:3.25rem;padding-bottom:3.25rem}.landing-page-simple .pricing-card{min-height:100%}.landing-page-simple .pricing-card-pro{transform:none}.landing-simple-final-cta{margin-top:3rem!important}.landing-simple-footer{margin-top:3.5rem!important}.landing-simple-footer-columns{grid-template-columns:repeat(3,minmax(140px,1fr))!important}.landing-page-simple .landing-section-heading{margin-bottom:1.85rem}.landing-page-simple .landing-section-heading>span{max-width:780px;margin-top:.8rem;line-height:1.58}.landing-page-simple .landing-trust-line{margin-top:15px}.landing-page-simple .pricing-conversion-note span{line-height:1.45}
+.landing-page-simple .landing-thirty-hero{min-height:690px;padding-top:5rem;padding-bottom:4rem;gap:3.2rem;grid-template-columns:minmax(0,.9fr) minmax(500px,1.1fr)}
+.landing-page-simple .landing-thirty-hero .landing-hero-copy h1{font-size:clamp(3.55rem,6.4vw,6.3rem);line-height:.94;max-width:760px}
+.landing-page-simple .landing-hero-description{max-width:720px;font-size:1.1rem;line-height:1.65}
+.landing-page-simple .landing-hero-actions{margin-top:1.7rem}
+.landing-page-simple .landing-trust-line{margin-top:15px}
 
-.landing-org-section{width:min(1180px,calc(100% - 2rem));margin:0 auto;padding:3.25rem 0}.landing-org-heading{max-width:840px!important}.landing-org-tabs{display:flex;gap:.5rem;flex-wrap:wrap;margin:0 0 1rem}.landing-org-tabs button{min-height:42px;display:inline-flex;align-items:center;justify-content:center;gap:.5rem;padding:.62rem .95rem;border:1px solid var(--landing-border);border-radius:999px;color:var(--landing-muted);background:rgba(13,21,38,.65);font:inherit;font-size:.82rem;font-weight:850;cursor:pointer;transition:transform 160ms ease,border-color 160ms ease,color 160ms ease,background 160ms ease}.landing-org-tabs button:hover{transform:translateY(-1px);color:var(--landing-text);border-color:rgba(166,220,255,.34)}.landing-org-tabs button.active{color:#08101d;border-color:transparent;background:linear-gradient(120deg,var(--landing-blue),var(--landing-purple));box-shadow:0 10px 28px rgba(124,154,255,.18)}.landing-org-tabs button:focus-visible{outline:2px solid var(--landing-blue);outline-offset:2px}.landing-org-panel{display:grid;grid-template-columns:minmax(0,.9fr) minmax(420px,1.1fr);gap:1rem;padding:1.15rem;border:1px solid rgba(173,145,255,.24);border-radius:28px;background:radial-gradient(circle at 90% 10%,rgba(173,145,255,.12),transparent 24rem),rgba(11,18,33,.86)}.landing-org-copy{padding:1.2rem}.landing-org-copy h3{margin:.35rem 0 .8rem;font-size:clamp(2rem,4vw,3.35rem);line-height:1.04;letter-spacing:-.05em}.landing-org-copy>p{margin:0;color:var(--landing-muted);line-height:1.65}.landing-org-feature-list{display:grid;gap:.7rem;margin:1.3rem 0}.landing-org-feature-list>div{display:flex;align-items:flex-start;gap:.65rem;color:#dbe5f4;line-height:1.45}.landing-org-feature-list svg{flex:0 0 auto;margin-top:.15rem;color:#86efac}.landing-org-copy .landing-btn{margin-top:.2rem}.landing-org-dashboard{padding:1rem;border:1px solid rgba(166,220,255,.18);border-radius:22px;background:rgba(5,10,20,.78);box-shadow:0 24px 60px rgba(0,0,0,.26)}.landing-org-dashboard-title{display:flex;align-items:center;gap:.7rem;padding:.35rem .25rem .9rem;color:var(--landing-blue)}.landing-org-dashboard-title div{display:grid;gap:.12rem}.landing-org-dashboard-title span{color:var(--landing-muted);font-size:.68rem;font-weight:850;letter-spacing:.08em;text-transform:uppercase}.landing-org-dashboard-title strong{color:var(--landing-text);font-size:1rem}.landing-org-stats{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:.6rem}.landing-org-stats>div{padding:.8rem;border:1px solid var(--landing-border);border-radius:15px;background:rgba(19,30,51,.74)}.landing-org-stats span,.landing-org-stats small{display:block}.landing-org-stats span{color:var(--landing-muted);font-size:.66rem;font-weight:850;text-transform:uppercase}.landing-org-stats strong{display:block;margin:.38rem 0 .15rem;font-size:1.2rem}.landing-org-stats small{color:#8795aa;font-size:.68rem;line-height:1.35}.landing-org-table{display:grid;gap:.45rem;margin-top:.65rem}.landing-org-row{display:grid;grid-template-columns:1fr 1.25fr auto;align-items:center;gap:.65rem;padding:.72rem .8rem;border:1px solid rgba(148,163,184,.14);border-radius:13px;background:rgba(12,20,36,.58)}.landing-org-row span{color:var(--landing-muted);font-size:.75rem}.landing-org-row strong{font-size:.79rem}.landing-org-row em{padding:.3rem .5rem;border-radius:999px;color:#bdeccf;background:rgba(74,222,128,.09);font-size:.65rem;font-style:normal;font-weight:850;white-space:nowrap}.landing-org-privacy{display:flex;align-items:flex-start;gap:.55rem;margin-top:.65rem;padding:.72rem .8rem;border:1px solid rgba(105,228,246,.16);border-radius:13px;color:#b9c7db;background:rgba(39,117,158,.07);font-size:.75rem;line-height:1.45}.landing-org-privacy svg{flex:0 0 auto;color:var(--landing-blue)}
+.landing-product-shot{position:relative;min-width:0}
+.landing-product-shot-glow{position:absolute;inset:12% 5% 8%;border-radius:50%;background:rgba(129,140,248,.2);filter:blur(76px);pointer-events:none}
+.impact-window{position:relative;z-index:2;overflow:hidden;border:1px solid rgba(166,220,255,.2);border-radius:22px;background:rgba(7,12,23,.97);box-shadow:0 42px 100px rgba(0,0,0,.45)}
+.impact-window-bar{min-height:48px;display:grid;grid-template-columns:auto 1fr auto;align-items:center;gap:.8rem;padding:.65rem .85rem;border-bottom:1px solid rgba(148,163,184,.14);background:rgba(18,28,46,.9)}
+.impact-window-dots{display:flex;gap:5px}.impact-window-dots span{width:8px;height:8px;border-radius:50%;background:rgba(203,213,225,.35)}
+.impact-window-location{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:#93a2b8;font-size:.7rem;font-weight:750;text-align:center}
+.impact-window-status{display:inline-flex;align-items:center;gap:.35rem;color:#b8ebcd;font-size:.66rem;font-weight:850}
+.impact-window-body{padding:1.3rem}
+.impact-shot-kicker{color:var(--landing-blue);font-size:.66rem;font-weight:900;letter-spacing:.12em}
+.impact-window-body h2{max-width:620px;margin:.55rem 0 1rem;font-size:clamp(1.45rem,2.5vw,2.15rem);line-height:1.08;letter-spacing:-.035em}
+.impact-shot-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:.55rem}
+.impact-shot-grid>div{min-width:0;padding:.75rem;border:1px solid rgba(148,163,184,.14);border-radius:13px;background:rgba(18,29,49,.72)}
+.impact-shot-grid span{display:block;margin-bottom:.35rem;color:#8291a8;font-size:.61rem;font-weight:900;letter-spacing:.08em;text-transform:uppercase}
+.impact-shot-grid p{margin:0;color:#d7e0ed;font-size:.73rem;line-height:1.45}
+.impact-shot-grid .impact-shot-result{border-color:rgba(105,228,246,.24);background:rgba(38,105,134,.12)}
+.landing-product-shot-caption{position:relative;z-index:2;margin:.9rem auto 0;max-width:600px;color:#8795a9;font-size:.78rem;line-height:1.5;text-align:center}
 
-@media(max-width:1100px){.landing-simple-output-grid{grid-template-columns:repeat(3,minmax(0,1fr))}.pricing-grid-four{grid-template-columns:repeat(2,minmax(0,1fr))}.landing-org-panel{grid-template-columns:1fr}.landing-org-dashboard{max-width:none}}
-@media(max-width:850px){.landing-page-simple .landing-simple-hero{min-height:auto;padding-top:3.25rem;gap:1.5rem}.landing-page-simple .landing-proof-preview{min-height:380px}.landing-simple-step-grid{grid-template-columns:1fr!important}.landing-simple-output-grid{grid-template-columns:repeat(2,minmax(0,1fr))}.landing-simple-footer-columns{grid-template-columns:1fr!important}.landing-org-stats{grid-template-columns:1fr}.landing-org-row{grid-template-columns:1fr;gap:.3rem}.landing-org-row em{width:fit-content}}
-@media(max-width:620px){.landing-page-simple .landing-simple-hero{padding-top:2.5rem;padding-bottom:2.5rem}.landing-page-simple .landing-proof-preview{min-height:350px}.landing-simple-output-grid{grid-template-columns:1fr}.landing-simple-receipt-note{margin-left:0;margin-right:0}.landing-simple-workflow,.landing-simple-products,.landing-page-simple .landing-pricing,.landing-org-section{padding-top:2.5rem!important;padding-bottom:2.5rem!important}.landing-simple-trust{margin-top:1.5rem!important;margin-bottom:1.5rem!important}.landing-simple-final-cta{margin-top:2rem!important}.landing-simple-footer{margin-top:2.5rem!important}.landing-org-tabs{display:grid;grid-template-columns:1fr}.landing-org-tabs button{width:100%}.landing-org-panel{padding:.75rem}.landing-org-copy{padding:.55rem}.pricing-grid-four{grid-template-columns:1fr}}
+.landing-thirty-thesis{width:min(1080px,calc(100% - 2rem));margin:0 auto 1.25rem;padding:1rem 1.15rem;display:grid;grid-template-columns:auto 1fr;align-items:center;gap:1rem;border:1px solid rgba(166,220,255,.16);border-radius:18px;background:rgba(11,18,33,.68)}
+.landing-thirty-thesis span{padding:.42rem .62rem;border-radius:999px;color:var(--landing-blue);background:rgba(39,117,158,.1);font-size:.65rem;font-weight:900;letter-spacing:.08em;text-transform:uppercase;white-space:nowrap}
+.landing-thirty-thesis strong{font-size:1rem;line-height:1.5}
+
+.landing-simple-workflow{padding-top:4rem!important;padding-bottom:4rem!important}
+.landing-simple-step-grid{grid-template-columns:repeat(3,minmax(0,1fr))!important;max-width:1100px;margin:0 auto}
+.landing-simple-step-grid .premium-workflow-card{min-height:250px}
+.landing-simple-step-grid .premium-workflow-card h3{margin-top:2.5rem}
+.landing-page-simple .landing-section-heading{margin-bottom:1.85rem}
+.landing-page-simple .landing-section-heading>span{max-width:780px;margin-top:.8rem;line-height:1.58}
+
+.landing-impact-section{width:min(1180px,calc(100% - 2rem));margin:0 auto;padding:4rem 0;display:grid;grid-template-columns:minmax(0,.9fr) minmax(420px,1.1fr);gap:1.5rem;align-items:center}
+.landing-impact-copy{padding:1.2rem 1.2rem 1.2rem 0}
+.landing-impact-copy h2{margin:.4rem 0 .9rem;font-size:clamp(2.4rem,4.8vw,4.6rem);line-height:.98;letter-spacing:-.055em}
+.landing-impact-copy>p:not(.landing-mini-label){margin:0;color:var(--landing-muted);line-height:1.65}
+.landing-impact-points{display:grid;gap:.7rem;margin-top:1.3rem}
+.landing-impact-points>div{display:flex;gap:.65rem;align-items:flex-start;color:#cfdae8;line-height:1.5}
+.landing-impact-points svg{flex:0 0 auto;margin-top:.15rem;color:#86efac}
+.landing-impact-points strong{color:var(--landing-text)}
+.landing-impact-anatomy{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:.65rem;padding:1rem;border:1px solid rgba(173,145,255,.2);border-radius:24px;background:radial-gradient(circle at 85% 10%,rgba(173,145,255,.1),transparent 22rem),rgba(10,17,31,.88)}
+.landing-impact-anatomy>div{min-height:126px;padding:1rem;border:1px solid rgba(148,163,184,.14);border-radius:16px;background:rgba(18,29,49,.66)}
+.landing-impact-anatomy span{display:block;color:var(--landing-purple);font-size:.66rem;font-weight:900;letter-spacing:.1em}
+.landing-impact-anatomy strong{display:block;margin:.55rem 0 .25rem;font-size:1rem}
+.landing-impact-anatomy p{margin:0;color:var(--landing-muted);font-size:.82rem;line-height:1.4}
+
+.landing-simple-products{padding-top:4rem!important;padding-bottom:4rem!important}
+.landing-outcome-flow{max-width:1120px;margin:0 auto}
+.landing-outcome-source{width:220px;margin:0 auto 1.2rem;padding:1rem;display:grid;justify-items:center;gap:.25rem;border:1px solid rgba(105,228,246,.22);border-radius:18px;background:rgba(39,117,158,.09);text-align:center}
+.landing-outcome-source svg{color:var(--landing-blue)}
+.landing-outcome-source span{color:#8797ad;font-size:.68rem;font-weight:850;text-transform:uppercase;letter-spacing:.08em}.landing-outcome-source strong{font-size:1.05rem}
+.landing-outcome-line{width:1px;height:34px;margin:-1.2rem auto 0;background:linear-gradient(var(--landing-blue),rgba(166,220,255,0))}
+.landing-simple-output-grid{grid-template-columns:repeat(3,minmax(0,1fr));gap:.7rem}
+.landing-simple-output-grid .use-case-card{min-height:190px}
+.landing-simple-output-grid .use-case-card h3{margin-top:2.35rem}
+
+.landing-memory-problem{width:min(1100px,calc(100% - 2rem));margin:1.5rem auto 4rem;padding:1.5rem;display:grid;grid-template-columns:240px 1fr;gap:1.5rem;align-items:center;border:1px solid rgba(148,163,184,.16);border-radius:24px;background:rgba(11,18,33,.72)}
+.landing-memory-number{display:flex;min-height:160px;align-items:center;justify-content:center;border-radius:18px;color:var(--landing-blue);background:linear-gradient(145deg,rgba(39,117,158,.12),rgba(129,95,212,.09));font-size:clamp(2.2rem,5vw,4rem);font-weight:950;letter-spacing:-.06em}
+.landing-memory-problem h2{margin:.35rem 0 .6rem;font-size:clamp(1.8rem,3.5vw,3rem);line-height:1.04;letter-spacing:-.045em}.landing-memory-problem p:not(.landing-mini-label){margin:0;color:var(--landing-muted);line-height:1.6}
+
+.landing-simple-trust{margin-top:2.5rem!important;margin-bottom:3rem!important}.landing-simple-trust-card{align-self:stretch}
+
+.landing-org-section{width:min(1180px,calc(100% - 2rem));margin:0 auto;padding:4rem 0}
+.landing-org-heading{max-width:840px!important}
+.landing-org-tabs{display:flex;gap:.5rem;flex-wrap:wrap;margin:0 0 1rem}
+.landing-org-tabs button{min-height:42px;display:inline-flex;align-items:center;justify-content:center;gap:.5rem;padding:.62rem .95rem;border:1px solid var(--landing-border);border-radius:999px;color:var(--landing-muted);background:rgba(13,21,38,.65);font:inherit;font-size:.82rem;font-weight:850;cursor:pointer;transition:transform 160ms ease,border-color 160ms ease,color 160ms ease,background 160ms ease}
+.landing-org-tabs button:hover{transform:translateY(-1px);color:var(--landing-text);border-color:rgba(166,220,255,.34)}
+.landing-org-tabs button.active{color:#08101d;border-color:transparent;background:linear-gradient(120deg,var(--landing-blue),var(--landing-purple));box-shadow:0 10px 28px rgba(124,154,255,.18)}
+.landing-org-tabs button:focus-visible{outline:2px solid var(--landing-blue);outline-offset:2px}
+.landing-org-panel{display:grid;grid-template-columns:minmax(0,.95fr) minmax(400px,1.05fr);gap:1rem;padding:1.15rem;border:1px solid rgba(173,145,255,.24);border-radius:28px;background:radial-gradient(circle at 90% 10%,rgba(173,145,255,.12),transparent 24rem),rgba(11,18,33,.86)}
+.landing-org-copy{padding:1.2rem}.landing-org-copy h3{margin:.35rem 0 .8rem;font-size:clamp(2rem,4vw,3.35rem);line-height:1.04;letter-spacing:-.05em}.landing-org-copy>p{margin:0;color:var(--landing-muted);line-height:1.65}
+.landing-org-feature-list{display:grid;gap:.7rem;margin:1.3rem 0}.landing-org-feature-list>div{display:flex;align-items:flex-start;gap:.65rem;color:#dbe5f4;line-height:1.45}.landing-org-feature-list svg{flex:0 0 auto;margin-top:.15rem;color:#86efac}.landing-org-copy .landing-btn{margin-top:.2rem}
+.landing-org-dashboard{padding:1rem;border:1px solid rgba(166,220,255,.18);border-radius:22px;background:rgba(5,10,20,.78);box-shadow:0 24px 60px rgba(0,0,0,.26)}
+.landing-org-dashboard-title{display:flex;align-items:center;gap:.7rem;padding:.35rem .25rem .9rem;color:var(--landing-blue)}.landing-org-dashboard-title div{display:grid;gap:.12rem}.landing-org-dashboard-title span{color:var(--landing-muted);font-size:.68rem;font-weight:850;letter-spacing:.08em;text-transform:uppercase}.landing-org-dashboard-title strong{color:var(--landing-text);font-size:1rem}
+.landing-org-stats{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:.6rem}.landing-org-stats>div{padding:.85rem;border:1px solid var(--landing-border);border-radius:15px;background:rgba(19,30,51,.74)}.landing-org-stats span,.landing-org-stats small{display:block}.landing-org-stats span{color:var(--landing-muted);font-size:.66rem;font-weight:850;text-transform:uppercase}.landing-org-stats strong{display:block;margin:.38rem 0 .15rem;font-size:1.2rem}.landing-org-stats small{color:#8795aa;font-size:.68rem;line-height:1.35}
+.landing-org-privacy{display:flex;align-items:flex-start;gap:.55rem;margin-top:.65rem;padding:.72rem .8rem;border:1px solid rgba(105,228,246,.16);border-radius:13px;color:#b9c7db;background:rgba(39,117,158,.07);font-size:.75rem;line-height:1.45}.landing-org-privacy svg{flex:0 0 auto;color:var(--landing-blue)}
+
+.landing-page-simple .landing-pricing{padding-top:4rem;padding-bottom:4rem}.landing-page-simple .pricing-card{min-height:100%}.landing-page-simple .pricing-card-pro{transform:none}.landing-page-simple .pricing-conversion-note span{line-height:1.45}
+.landing-simple-final-cta{margin-top:3rem!important}.landing-simple-footer{margin-top:3.5rem!important}.landing-simple-footer-columns{grid-template-columns:repeat(3,minmax(140px,1fr))!important}
+
+@media(max-width:1100px){
+  .landing-page-simple .landing-thirty-hero{grid-template-columns:1fr;min-height:auto;gap:2rem}
+  .landing-product-shot{max-width:800px;width:100%;margin:0 auto}
+  .landing-simple-output-grid{grid-template-columns:repeat(3,minmax(0,1fr))}
+  .pricing-grid-four{grid-template-columns:repeat(2,minmax(0,1fr))}
+  .landing-impact-section,.landing-org-panel{grid-template-columns:1fr}
+  .landing-impact-copy{padding-right:0}
+  .landing-org-dashboard{max-width:none}
+}
+
+@media(max-width:850px){
+  .landing-page-simple .landing-thirty-hero{padding-top:3.25rem;padding-bottom:3.25rem}
+  .landing-page-simple .landing-thirty-hero .landing-hero-copy h1{font-size:clamp(3rem,12vw,5rem)}
+  .impact-shot-grid{grid-template-columns:1fr}
+  .landing-simple-step-grid{grid-template-columns:1fr!important}
+  .landing-simple-output-grid{grid-template-columns:repeat(2,minmax(0,1fr))}
+  .landing-simple-footer-columns{grid-template-columns:1fr!important}
+  .landing-impact-anatomy{grid-template-columns:1fr 1fr}
+  .landing-memory-problem{grid-template-columns:1fr}.landing-memory-number{min-height:110px}
+  .landing-org-stats{grid-template-columns:1fr}
+}
+
+@media(max-width:620px){
+  .landing-page-simple .landing-thirty-hero{padding-top:2.5rem;padding-bottom:2.75rem}
+  .landing-page-simple .landing-thirty-hero .landing-hero-copy h1{font-size:clamp(2.75rem,14vw,4.25rem)}
+  .landing-page-simple .landing-hero-description{font-size:1rem}
+  .landing-page-simple .landing-hero-actions{display:grid}.landing-page-simple .landing-hero-actions .landing-btn{width:100%}
+  .impact-window-bar{grid-template-columns:auto 1fr}.impact-window-status{display:none}.impact-window-body{padding:1rem}.impact-window-body h2{font-size:1.45rem}
+  .landing-thirty-thesis{grid-template-columns:1fr;gap:.7rem}.landing-thirty-thesis span{width:fit-content;white-space:normal}
+  .landing-impact-section,.landing-simple-workflow,.landing-simple-products,.landing-page-simple .landing-pricing,.landing-org-section{padding-top:2.75rem!important;padding-bottom:2.75rem!important}
+  .landing-impact-anatomy{grid-template-columns:1fr}.landing-impact-anatomy>div{min-height:auto}
+  .landing-simple-output-grid{grid-template-columns:1fr}
+  .landing-memory-problem{margin-bottom:2.75rem;padding:1rem}.landing-memory-number{min-height:88px;font-size:2.5rem}
+  .landing-simple-trust{margin-top:1.5rem!important;margin-bottom:2rem!important}
+  .landing-org-tabs{display:grid;grid-template-columns:1fr}.landing-org-tabs button{width:100%}.landing-org-panel{padding:.75rem}.landing-org-copy{padding:.55rem}
+  .pricing-grid-four{grid-template-columns:1fr}
+  .landing-simple-final-cta{margin-top:2rem!important}.landing-simple-footer{margin-top:2.5rem!important}
+}

--- a/frontend/src/marketingClaritySource.test.js
+++ b/frontend/src/marketingClaritySource.test.js
@@ -7,13 +7,15 @@ const read = (path) => readFileSync(new URL(path, import.meta.url), "utf8");
 test("landing page explains Boasted immediately in plain language", () => {
   const source = read("./LandingPage.jsx");
 
-  assert.match(source, /Remember what you did/);
-  assert.match(source, /Save your wins, results, skills, and proof in one private place/);
-  assert.match(source, /Save it → Prove it → Use it/);
-  assert.match(source, /ATS-friendly résumés/);
-  assert.match(source, /Performance reviews/);
-  assert.match(source, /Promotion packets/);
-  assert.match(source, /Interview practice/);
+  assert.match(source, /Never lose track of what you/);
+  assert.match(source, /Save your work, wins, projects, skills, and proof in one place/);
+  assert.match(source, /Save it\. Prove it\. Use it\./);
+  assert.match(source, /IMPACT RECEIPT/);
+  assert.match(source, /One record/);
+  assert.match(source, /title: "Résumé"/);
+  assert.match(source, /title: "Performance review"/);
+  assert.match(source, /title: "Promotion"/);
+  assert.match(source, /title: "Interview"/);
 
   assert.doesNotMatch(source, /Capture → Prove → Package → Share → Connect/);
   assert.doesNotMatch(source, /WHY IT EXISTS/);
@@ -30,7 +32,7 @@ test("pricing always shows Free Pro Team and Enterprise together", () => {
   assert.match(source, /name: "Team"/);
   assert.match(source, /name: "Enterprise"/);
   assert.match(source, /pricing-grid pricing-grid-four/);
-  assert.match(source, /All four plans stay visible/);
+  assert.match(source, /Pro is temporarily complimentary during early access/);
   assert.doesNotMatch(source, /const plans = isCompany/);
   assert.doesNotMatch(source, /landing-individual-pricing/);
   assert.doesNotMatch(source, /landing-business-pricing/);
@@ -46,11 +48,10 @@ test("organization section uses separate Team Enterprise and Education tabs", ()
   assert.match(source, /label: "Education"/);
   assert.match(source, /Team review dashboard/);
   assert.match(source, /Enterprise admin dashboard/);
-  assert.match(source, /Major Explorer/);
   assert.match(source, /Academic Portfolio/);
-  assert.match(source, /scholarships, programs, internships/);
-  assert.match(source, /private career record/);
-  assert.match(source, /not a manager feed/);
+  assert.match(source, /Scholarship, program, and federal internship discovery/);
+  assert.match(source, /Employees keep their own private record/);
+  assert.match(source, /Private individual notes are not exposed as an employer activity feed/);
   assert.match(css, /landing-org-tabs/);
   assert.match(css, /landing-org-dashboard/);
 });
@@ -74,8 +75,8 @@ test("Education marketing keeps Education in the header and gives students clear
 test("landing page stays compact instead of using oversized section gaps", () => {
   const css = read("./LandingPageSimple.css");
 
-  assert.match(css, /min-height:600px/);
-  assert.match(css, /padding-top:3\.25rem/);
+  assert.match(css, /landing-thirty-hero\{min-height:690px/);
+  assert.match(css, /landing-simple-workflow\{padding-top:4rem/);
   assert.match(css, /landing-org-section/);
   assert.doesNotMatch(css, /padding-top:84px/);
 });


### PR DESCRIPTION
## What changed
- Rewrites the hero around the universal problem: **Never lose track of what you've accomplished.**
- Shows a product-like Impact Receipt immediately so a first-time visitor can understand where their work goes.
- Makes **Save it → Prove it → Use it** the core mental model.
- Reframes resumes, reviews, promotions, interviews, Proof Profiles, and education as outcomes of one saved record instead of separate products.
- Gives Impact Receipts a dedicated moat/differentiation section.
- Adds the time/memory problem, privacy/ownership trust section, organization use cases, simplified pricing, and a final CTA that returns to the emotional core.
- Does not add fabricated testimonials; genuine customer proof can slot in later.

## Success criterion
A cold visitor should be able to say within ~30 seconds:
1. **I understand this.**
2. **This solves a problem I have.**
3. **I need this.**

## Scope
Only the marketing homepage component and its focused responsive styles are changed.