### PR TITLE
P0: emit route-specific static titles and descriptions

### DIFF
--- a/frontend/scripts/generate-static-route-shells.mjs
+++ b/frontend/scripts/generate-static-route-shells.mjs
@@ -15,6 +15,7 @@ const REQUIRED_CLIENT_ROUTES = [
   "/nda-safety",
   "/security",
   "/contact",
+  "/support",
   "/team",
   "/enterprise",
   "/use-cases",
@@ -30,6 +31,117 @@ const REQUIRED_CLIENT_ROUTES = [
 ];
 
 const NOINDEX_ROUTES = new Set(["/upgrade", "/verify-receipt"]);
+
+const ROUTE_META = Object.freeze({
+  "/privacy": {
+    title: "Privacy Policy | Boasted",
+    description: "Read the Boasted Privacy Policy, including information collection, career evidence, sharing, AI-assisted features, retention, security, and privacy choices.",
+  },
+  "/terms": {
+    title: "Terms and Conditions | Boasted",
+    description: "Read the terms governing Boasted accounts, user content, acceptable use, subscriptions, AI-assisted career content, confidentiality, and service use.",
+  },
+  "/nda-safety": {
+    title: "NDA & Confidential Work Guidance | Boasted",
+    description: "Learn how to document professional accomplishments in Boasted without overriding NDAs, employer policies, client agreements, or confidentiality obligations.",
+  },
+  "/security": {
+    title: "Boasted Security | Private-by-Default Career Evidence",
+    description: "Read Boasted's security approach, private-by-default model, confidential-work guidance, payment handling, and instructions for reporting a security concern.",
+  },
+  "/contact": {
+    title: "Contact Boasted | Support, Privacy, Security & Billing",
+    description: "Contact Boasted for product support, general questions, privacy requests, security concerns, billing questions, or legal correspondence.",
+  },
+  "/support": {
+    title: "Boasted Support Hub | Product Help, Beta Access & Security",
+    description: "Get Boasted product and account help, troubleshoot issues, understand complimentary beta access, review NDA guidance, and reach support, billing, privacy, or security contacts.",
+  },
+  "/team": {
+    title: "Boasted for Teams | Coming Soon",
+    description: "Learn about the planned Boasted Team direction for evidence-backed reviews, employee-controlled sharing, bounded analytics, and organization workflows without surveillance.",
+  },
+  "/enterprise": {
+    title: "Boasted Enterprise | Governance Roadmap for Career Evidence",
+    description: "Learn about Boasted's early enterprise direction for identity, governance, retention, admin policy controls, integrations, and employee-controlled evidence boundaries.",
+  },
+  "/use-cases": {
+    title: "Boasted Use Cases | Reviews, Promotions, Resumes & Interviews",
+    description: "Explore Boasted use cases across professions for reviews, promotions, resumes, interviews, certifications, career changes, freelancers, founders, students, and education-to-career proof.",
+  },
+  "/how-it-works": {
+    title: "How Boasted Works | Capture, Prove & Reuse Career Evidence",
+    description: "See how Boasted helps people in any profession capture accomplishments, create Impact Receipts, reuse evidence for career moments, share selectively, and keep private work private.",
+  },
+  "/login": {
+    title: "Sign In to Boasted | Career Proof",
+    description: "Sign in to Boasted to access your career proof, Impact Receipts, Resume Builder, and Practice Interviewer.",
+  },
+  "/register": {
+    title: "Sign up for Boasted | Start Free",
+    description: "Create a free Boasted account and start turning your accomplishments into career proof for resumes, interviews, reviews, promotions, portfolios, and career transitions.",
+  },
+  "/upgrade": {
+    title: "Boasted Pro | Upgrade",
+    description: "Review Boasted Pro upgrade options from inside your account.",
+  },
+  "/verify-receipt": {
+    title: "Verify an Impact Receipt | Boasted",
+    description: "Open a Boasted Impact Receipt verification flow using a direct verification link.",
+  },
+  "/education": {
+    title: "Boasted Education | Turn Learning into Career Proof",
+    description: "Boasted Education helps college, university, trade, technical, certification, bootcamp, and continuing-education learners turn real coursework, projects, training, research, and achievements into reusable career proof.",
+  },
+  "/docs": {
+    title: "Boasted Docs | How to Use Career Proof",
+    description: "Learn how people across professions can use Boasted, Impact Receipts, Resume Builder, Practice Interviewer, privacy controls, and career proof workflows.",
+  },
+  "/docs/education": {
+    title: "Boasted Education Guide | Learning & Career Proof",
+    description: "Learn how to use Boasted Education to capture coursework, projects, certifications, achievements, and contributions, then reuse that evidence for applications, resumes, interviews, portfolios, and career planning.",
+  },
+  "/legal/education-data": {
+    title: "Education Data Guidance | Boasted",
+    description: "Review how Boasted handles education-related records, user-provided learning evidence, privacy boundaries, and responsible use of education data.",
+  },
+  "/resume-accomplishments": {
+    title: "Resume Accomplishments & Achievement Tracker | Boasted",
+    description: "Track work accomplishments, measurable impact, and evidence so you can build stronger resume bullets from real career proof.",
+  },
+  "/interview-preparation": {
+    title: "Interview Preparation From Real Work Accomplishments | Boasted",
+    description: "Prepare behavioral and technical interview stories from documented situations, actions, results, metrics, and skills.",
+  },
+  "/pricing": {
+    title: "Boasted Pricing | Free & Pro Career Proof Plans",
+    description: "Compare Boasted Free and Pro plans for capturing accomplishments, building Impact Receipts, generating career outputs, and reusing professional proof.",
+  },
+  "/impact-receipts": {
+    title: "Impact Receipts | Evidence-Backed Work Accomplishments | Boasted",
+    description: "Create structured proof of your contribution, result, evidence, skills, shared credit, and measurable career impact.",
+  },
+  "/performance-reviews": {
+    title: "Performance Review Accomplishment Tracker | Boasted",
+    description: "Capture wins throughout the year and turn documented impact into performance-review material without rebuilding months of work from memory.",
+  },
+  "/career-portfolio": {
+    title: "Career Portfolio & Professional Proof Profile | Boasted",
+    description: "Build a professional career portfolio from selected accomplishments, skills, evidence, and measurable impact while keeping your account private by default.",
+  },
+  "/promotion-packet": {
+    title: "Promotion Packet & Career Impact Evidence | Boasted",
+    description: "Organize scope, ownership, leadership, growth, and measurable results into evidence-backed promotion material.",
+  },
+  "/career-analytics": {
+    title: "Career Analytics for Skills, Accomplishments & Impact | Boasted",
+    description: "See patterns across your skills, work accomplishments, evidence coverage, ownership, and career impact over time.",
+  },
+  "/public-proof-profiles": {
+    title: "Public Career Proof Profiles for Hiring & Portfolios | Boasted",
+    description: "Share selected accomplishments and Impact Receipts with recruiters, hiring managers, clients, and your network without exposing private work history.",
+  },
+});
 
 function normalizeRoute(route) {
   const pathname = route.split(/[?#]/, 1)[0] || "/";
@@ -51,16 +163,50 @@ function sitemapRoutes(xml) {
   return routes;
 }
 
+function escapeHtmlAttribute(value) {
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}
+
 function routeShell(indexHtml, route) {
   const canonicalUrl = `${SITE_ORIGIN}${route}`;
+  const meta = ROUTE_META[route];
+  if (!meta) throw new Error(`Missing static metadata for public route: ${route}`);
+
+  const title = escapeHtmlAttribute(meta.title);
+  const description = escapeHtmlAttribute(meta.description);
   let html = indexHtml
+    .replace(/<title>[^<]*<\/title>/, `<title>${title}</title>`)
+    .replace(
+      /<meta name="description" content="[^"]*"\s*\/>/,
+      `<meta name="description" content="${description}" />`,
+    )
     .replace(
       /<link rel="canonical" href="[^"]*"\s*\/>/,
       `<link rel="canonical" href="${canonicalUrl}" />`,
     )
     .replace(
+      /<meta property="og:title" content="[^"]*"\s*\/>/,
+      `<meta property="og:title" content="${title}" />`,
+    )
+    .replace(
+      /<meta property="og:description" content="[^"]*"\s*\/>/,
+      `<meta property="og:description" content="${description}" />`,
+    )
+    .replace(
       /<meta property="og:url" content="[^"]*"\s*\/>/,
       `<meta property="og:url" content="${canonicalUrl}" />`,
+    )
+    .replace(
+      /<meta name="twitter:title" content="[^"]*"\s*\/>/,
+      `<meta name="twitter:title" content="${title}" />`,
+    )
+    .replace(
+      /<meta name="twitter:description" content="[^"]*"\s*\/>/,
+      `<meta name="twitter:description" content="${description}" />`,
     );
 
   if (NOINDEX_ROUTES.has(route)) {
@@ -90,8 +236,8 @@ for (const route of [...routes].sort()) {
 }
 
 // Render serves a static site, so unknown client-side routes need an SPA shell too.
-// Keep the generic 404 shell canonicalized to the homepage; dynamic public profile
-// metadata is applied client-side after the requested slug loads.
+// Keep the generic 404 shell canonicalized to the homepage. Dynamic public profile
+// metadata is handled separately through the public share representation.
 await writeFile(path.join(DIST_DIR, "404.html"), indexHtml, "utf8");
 
 console.log(`Generated route-specific SPA shells for ${routes.size} public/client routes.`);

--- a/frontend/scripts/verify-search-appearance.mjs
+++ b/frontend/scripts/verify-search-appearance.mjs
@@ -21,6 +21,9 @@ const publicSitelinks = [
 ];
 
 const sitemapUrls = [...sitemap.matchAll(/<loc>(.*?)<\/loc>/g)].map((match) => match[1]);
+const sitemapPaths = sitemapUrls
+  .map((url) => new URL(url).pathname.replace(/\/$/, "") || "/")
+  .filter((path) => path !== "/");
 const duplicates = sitemapUrls.filter((url, index) => sitemapUrls.indexOf(url) !== index);
 
 assert.equal(duplicates.length, 0, `sitemap.xml contains duplicate URLs: ${duplicates.join(", ")}`);
@@ -55,14 +58,27 @@ assert.match(searchMeta, /SiteNavigationElement/);
 assert.match(searchMeta, /max-image-preview:large/);
 assert.match(searchMeta, /https:\/\/boasted\.io/);
 
-// Static HTML must not tell crawlers every sitemap route is the homepage.
+// Static HTML must expose route-specific crawl metadata before React executes.
 assert.match(staticRouteShells, /function routeShell\(indexHtml, route\)/);
+assert.match(staticRouteShells, /ROUTE_META = Object\.freeze/);
 assert.match(staticRouteShells, /canonicalUrl = `\$\{SITE_ORIGIN\}\$\{route\}`/);
+assert.match(staticRouteShells, /<title>/);
+assert.match(staticRouteShells, /<meta name="description"/);
 assert.match(staticRouteShells, /<link rel="canonical"/);
+assert.match(staticRouteShells, /<meta property="og:title"/);
+assert.match(staticRouteShells, /<meta property="og:description"/);
 assert.match(staticRouteShells, /<meta property="og:url"/);
+assert.match(staticRouteShells, /<meta name="twitter:title"/);
+assert.match(staticRouteShells, /<meta name="twitter:description"/);
+assert.match(staticRouteShells, /Missing static metadata for public route/);
 assert.match(staticRouteShells, /writeFile\(path\.join\(routeDir, "index\.html"\), routeShell\(indexHtml, route\)/);
 assert.doesNotMatch(staticRouteShells, /copyFile\(INDEX_FILE, path\.join\(routeDir, "index\.html"\)\)/);
 assert.match(staticRouteShells, /NOINDEX_ROUTES = new Set\(\["\/upgrade", "\/verify-receipt"\]\)/);
 assert.match(staticRouteShells, /noindex,nofollow/);
+assert.ok(staticRouteShells.includes('"/support"'), "the public Support Hub needs a generated static shell");
+
+for (const path of sitemapPaths) {
+  assert.ok(staticRouteShells.includes(`"${path}"`), `${path} must have explicit static title/description metadata`);
+}
 
 console.log(`Search quality gates passed for ${publicSitelinks.length} priority routes and ${sitemapUrls.length} sitemap URLs.`);


### PR DESCRIPTION
## Why

The founding-team audit calls out that public static shells still expose homepage title/description metadata until React executes, even after canonical hardening. That weakens crawl delivery for sitemap routes.

## What changes

- adds explicit static title/description metadata for every sitemap route plus required public client routes;
- rewrites `<title>`, description, Open Graph title/description/url, Twitter title/description, and canonical before React runs;
- adds a generated shell for `/support`, which is linked from production navigation;
- keeps `/upgrade` and `/verify-receipt` statically `noindex,nofollow`;
- fails the shell generator when a public route has no explicit metadata instead of silently inheriting homepage SEO;
- extends the SEO verification gate so every non-homepage sitemap route must have explicit static metadata.

## Scope

No UI redesign, auth, billing, data-model, or API changes. Dynamic `/brag/:slug` metadata remains a separate P0 because it requires a crawlable per-profile representation rather than a generic static route table.