### PR TITLE
P0: operationalize five-user beta observation round

### DIFF
--- a/docs/FOUNDER_BETA_OBSERVATION_PROTOCOL.md
+++ b/docs/FOUNDER_BETA_OBSERVATION_PROTOCOL.md
@@ -1,0 +1,324 @@
+# Founder Beta Observation Protocol
+
+## Purpose
+
+Use five observed beta sessions to answer one product question before expanding the roadmap:
+
+> Can a technical or support engineer turn one real accomplishment into structured proof, complete an Impact Receipt, and produce one immediately useful career output without founder coaching?
+
+This is an observation exercise, not a feature demo. Do not sell the participant on the workflow while they are using it. Watch where the product makes sense, where confidence drops, and where the participant needs help.
+
+## Initial participant profile
+
+Recruit **five technical/support engineers** who have at least one real recent accomplishment they can safely discuss. Prefer a mix of:
+
+- production support / technical support;
+- cloud, platform, DevOps, or SRE-adjacent work;
+- customer-facing troubleshooting;
+- incident, automation, reliability, documentation, or process-improvement work;
+- different seniority levels when possible.
+
+Do not require participants to share confidential employer, customer, patient, student, credential, or client information. A sanitized real accomplishment is enough.
+
+## Recruitment sprint
+
+The research round is not considered recruited until **five qualifying participants have agreed to a session time**. A list of interested people or sent messages is not the exit condition.
+
+### Recruiting target
+
+Start with a small, high-fit outreach batch rather than broad promotion. Aim to contact enough people to schedule five sessions while preserving the ability to personally observe each one.
+
+Prioritize, in order:
+
+1. first-degree technical/support engineering contacts who can give candid feedback;
+2. former coworkers or trusted professional peers in support, cloud, platform, DevOps, SRE, or production operations;
+3. second-degree referrals from those people;
+4. relevant professional communities where research participation requests are permitted.
+
+Do not buy a lead list, mass-DM strangers, or optimize for raw signup count. This round is about observed behavior from the initial ICP.
+
+### Recruitment message
+
+Use a problem-first invitation instead of asking someone to “test my SaaS”:
+
+> I’m studying why support and technical engineers lose track of their strongest work after incidents, customer saves, automation, and troubleshooting disappear into tickets and chat. I’m looking for a few engineers who can bring one real, safely sanitized accomplishment. I’ll watch you try a short Boasted workflow that turns it into evidence you could reuse in a review, resume, interview, or proof profile. I’m testing the workflow, not you, and I don’t need any confidential employer or customer information. Would you be open to a short observed session?
+
+If they ask what Boasted is before agreeing, use one sentence:
+
+> Boasted helps you keep the proof behind your professional accomplishments so the same evidence can be reused later instead of reconstructed from memory.
+
+Do not send a feature list in the recruiting message. The first-impression test in the session is only useful if the participant has not already been taught the entire product model.
+
+### Lightweight screener
+
+Before scheduling, confirm only what is needed:
+
+- Are you currently or recently working in technical support, production support, cloud/platform operations, SRE/DevOps, software support, or a closely related role?
+- Can you think of one real accomplishment, incident, customer win, automation, reliability improvement, documentation improvement, or process improvement you can discuss without exposing confidential information?
+- Are you comfortable using an early beta while the founder observes where the workflow is confusing?
+- Are you comfortable creating a test account and keeping the record private unless you explicitly choose otherwise?
+
+Do not ask for employer-confidential details in the screener.
+
+### Outreach tracker
+
+Use participant IDs in research notes. Personal contact information should remain in the normal communication tool used to schedule the session, not in the research notes or analytics payloads.
+
+| Participant | Fit confirmed | Invited | Replied | Scheduled | Session complete | D7 follow-up | Notes |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| P01 | | | | | | | |
+| P02 | | | | | | | |
+| P03 | | | | | | | |
+| P04 | | | | | | | |
+| P05 | | | | | | | |
+
+If a participant declines or does not qualify, recycle that participant ID only before any research notes are created for them.
+
+### Follow-up cadence
+
+For a person who has not responded, send at most one concise follow-up. Do not create a drip campaign for a five-person research round.
+
+Suggested follow-up:
+
+> Just following up in case this got buried. I’m still looking for a few technical/support engineers to try one real accomplishment → proof → Impact Receipt → useful output flow. No confidential work details are needed. If you’re not interested, no worries at all.
+
+Once five qualifying sessions are scheduled, stop recruiting for Round 1. Do not keep collecting signups just because outreach is working.
+
+### Scheduling note
+
+Reserve enough time to observe the full flow without rushing the participant. The founder should have the protocol open, a blank P01–P05 note ready, and no prewritten accomplishment content. If a scheduling link is used, describe the session as product research or beta observation rather than a sales demo.
+
+## Session rule
+
+Ask the participant to bring **one real accomplishment from memory**. The founder should not pre-format it into STAR, resume language, or an Impact Receipt.
+
+The target sequence is:
+
+1. real accomplishment;
+2. structured proof/accomplishment record;
+3. completed Impact Receipt;
+4. one useful output from that same saved proof.
+
+For the first round, use one of these outputs:
+
+- resume bullet;
+- STAR interview answer;
+- performance-review statement;
+- shareable public proof, if the participant is comfortable publishing it.
+
+The participant should understand the core reuse idea: **capture it once, then turn the same proof into something useful later.**
+
+## Before the session
+
+Confirm:
+
+- the participant understands this is an early beta observation;
+- screen recording is off unless they explicitly consent;
+- no confidential information should be entered;
+- the founder will mostly observe rather than teach;
+- the participant can stop or make any record private at any time.
+
+Create a blank note with this participant ID only: `P01` through `P05`. Do not put employer names or sensitive accomplishment text in analytics or research filenames.
+
+## Observation script
+
+### 1. First impression
+
+Open the marketing page and say only:
+
+> Take a look at this as if someone sent you the link. Tell me what you think this product is for.
+
+Record:
+
+- whether the participant can explain the problem in their own words;
+- whether they understand that Boasted preserves career proof, not just resumes;
+- what they believe the first action should be;
+- any terminology they pause on.
+
+Do not correct them until they have finished explaining their understanding.
+
+### 2. Sign up and orient
+
+Ask:
+
+> Create an account and get to the point where you think you are ready to save your accomplishment.
+
+Observe:
+
+- signup friction;
+- onboarding friction;
+- whether the dashboard provides an obvious next step;
+- whether extra product surfaces distract from the core loop;
+- whether privacy/private-by-default behavior is understandable.
+
+### 3. Create the first proof
+
+Ask:
+
+> Think of one real thing you did at work that mattered. Put it into Boasted in the way that feels natural to you.
+
+Do not tell them what to type unless they are completely blocked.
+
+Observe:
+
+- time to begin typing;
+- fields that require explanation;
+- whether contribution versus result is clear;
+- whether they naturally include measurable impact;
+- whether evidence feels useful or intimidating;
+- whether they understand public versus private state;
+- where they abandon, backtrack, or ask a question.
+
+### 4. Complete an Impact Receipt
+
+Ask:
+
+> Now turn that accomplishment into an Impact Receipt. Tell me what you think an Impact Receipt is while you do it.
+
+Observe whether the participant understands that the receipt should connect:
+
+- accomplishment;
+- personal contribution;
+- result / impact;
+- evidence;
+- skills;
+- credit / confirmation where appropriate.
+
+Record the first moment they express an “aha,” if one happens. Do not manufacture one by explaining the feature.
+
+### 5. Reuse the same proof
+
+Ask:
+
+> Imagine you need this accomplishment for something real this week. Pick one: a resume, an interview, a performance review, or something you can share. Use Boasted to make that from the proof you already saved.
+
+Observe:
+
+- whether they look for a new blank generator instead of reusing saved proof;
+- whether the relationship between the saved accomplishment, Impact Receipt, and output is obvious;
+- how many navigation decisions it takes to get from receipt to output;
+- whether they trust the generated output because its source proof remains visible;
+- whether they want to edit the output or the underlying proof;
+- whether they can explain why saving the original proof was valuable.
+
+This step is the core activation test.
+
+### 6. Sharing and trust
+
+If the participant is comfortable, show the public/private controls and ask:
+
+> What would you be willing to share publicly, and what would you definitely keep private?
+
+Observe:
+
+- whether public profile language is clear;
+- whether selective sharing feels safe;
+- whether verification increases trust;
+- whether the participant expects public profile visitors to see anything they did not explicitly publish.
+
+Do not ask them to publish employer-confidential information for the sake of the test.
+
+## Do not coach these moments
+
+Unless the participant is completely blocked, do not explain:
+
+- what an Impact Receipt means;
+- where the next button is;
+- which output they should choose;
+- what a field “really wants”;
+- why reuse is valuable;
+- why a feature exists.
+
+Confusion is data. A founder explanation can hide the exact product problem the session is meant to reveal.
+
+## Session measurements
+
+Record these for each participant:
+
+| Measure | P01 | P02 | P03 | P04 | P05 |
+| --- | --- | --- | --- | --- | --- |
+| Understands product from marketing page without coaching | | | | | |
+| Completes signup | | | | | |
+| Creates first proof | | | | | |
+| Completes first Impact Receipt | | | | | |
+| Produces one output from existing proof | | | | | |
+| Understands private/public state | | | | | |
+| Can explain “capture once, reuse later” afterward | | | | | |
+| Would use it again for another accomplishment | | | | | |
+
+Also capture:
+
+- time from account creation to first saved proof;
+- time from first saved proof to completed Impact Receipt;
+- time from completed receipt to useful output;
+- number of times the participant asks what to do next;
+- number of times the founder must intervene;
+- exact step of any abandonment;
+- output chosen;
+- whether the participant independently wants to save a second accomplishment.
+
+These are research notes, not GA event payloads. Do not send accomplishment text, employer information, evidence content, or URLs to GA.
+
+## Post-session questions
+
+Ask after the participant has finished the flow:
+
+1. What do you think Boasted is for now?
+2. What part felt most valuable?
+3. What part felt like work without enough payoff?
+4. At any point, were you unsure whether something was private or public?
+5. Did the Impact Receipt make the accomplishment feel more useful, or just more structured?
+6. Was turning the saved proof into the output easier than starting from scratch?
+7. What would make you come back next week?
+8. What would stop you from saving a second accomplishment?
+9. If Boasted disappeared tomorrow, what would you miss, if anything?
+
+Do not ask whether every existing feature is useful. The goal is to validate the core loop, not collect votes for the roadmap.
+
+## Seven-day follow-up
+
+Contact the same participant about seven days later. Do not start by reminding them of features. Ask:
+
+> Since our session, did anything happen at work that made you think about saving another accomplishment or reusing the one you captured?
+
+Then ask:
+
+- Did you return to Boasted on your own?
+- Did you create a second proof?
+- Did you reuse the original proof?
+- Did you share or export anything?
+- What stopped you if you intended to return but did not?
+
+The product should eventually make this return behavior measurable, but the first five sessions need qualitative context behind the numbers.
+
+## Synthesis after five sessions
+
+Do not prioritize based on the loudest participant. Look for repeated friction.
+
+Create a short table:
+
+| Repeated observation | Participants affected | Core-loop impact | Fix / test |
+| --- | ---: | --- | --- |
+| Example | 3/5 | Blocks receipt completion | Simplify field / copy / flow |
+
+Prioritize findings in this order:
+
+1. blocks signup or first proof;
+2. blocks Impact Receipt completion;
+3. hides or weakens immediate reuse/output;
+4. creates privacy or trust confusion;
+5. prevents a second proof or later reuse;
+6. everything else.
+
+Do not add a new major product surface based on these sessions unless it directly fixes a repeated core-loop problem.
+
+## Founder exit criteria
+
+This first research round is complete when:
+
+- five target participants have been observed end-to-end;
+- each participant attempted proof -> Impact Receipt -> one output;
+- the founder has recorded intervention points and abandonment points;
+- seven-day follow-up is completed or explicitly marked unavailable;
+- repeated friction is separated from one-off preferences;
+- the next product changes can be tied to observed behavior rather than feature enthusiasm.


### PR DESCRIPTION
## Why

The founding-team audit says the most valuable manual work this week is observing five technical/support engineers complete the real sequence: accomplishment -> structured proof -> Impact Receipt -> one useful output, then following up a week later.

## What this adds

A founder-run beta observation protocol that defines:

- the initial technical/support engineer participant profile;
- the exact end-to-end task without pre-formatting the accomplishment;
- where the founder must not coach so confusion remains observable;
- activation, privacy, reuse, and intervention measurements;
- post-session questions focused on the core loop rather than feature voting;
- a seven-day follow-up;
- synthesis rules that prioritize repeated core-loop friction over one-off requests;
- explicit privacy guidance for employer/customer/confidential information.

## Product principle

This protocol is intentionally centered on proof -> Impact Receipt -> output. It should generate evidence for roadmap decisions before expanding major product surfaces.