### PR TITLE
P0: wire successful reuse and profile-share analytics (current main)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vite build && node scripts/generate-static-route-shells.mjs",
     "lint": "eslint .",
-    "test:analytics": "node --test src/analytics.test.js",
+    "test:analytics": "node --test src/analytics.test.js src/behaviorAnalyticsSource.test.js",
     "test:education": "node --test src/applicationsHubSource.test.js src/accomplishmentsEducationSource.test.js src/educationToolkitSource.test.js src/educationOpportunitySource.test.js",
     "test:interview": "node --test src/interviewEngine*.test.js src/interviewTranscript.test.js src/interviewVoice.test.js",
     "test:resume": "node --test src/resumeStructured.test.js src/dashboardTags.test.js",

--- a/frontend/src/PerformancePacketPreview.jsx
+++ b/frontend/src/PerformancePacketPreview.jsx
@@ -11,6 +11,7 @@ import {
   Sparkles,
 } from "lucide-react";
 
+import { ANALYTICS_EVENTS, trackAnalyticsEvent } from "./analytics";
 import { downloadCareerPacket } from "./api";
 import CertificationPacketPages from "./CertificationPacketPages";
 import GenericPacketPages from "./GenericPacketPages.jsx";
@@ -71,6 +72,12 @@ function PerformancePacketPreview({ packet, onBack, backLabel = "Back to reports
       const { blob, filename } = await downloadCareerPacket(packet, format);
       if (!blob || Number(blob.size || 0) === 0) throw new Error("The generated file was empty.");
       const url = URL.createObjectURL(blob); const link = document.createElement("a"); link.href = url; link.download = filename; document.body.appendChild(link); link.click(); link.remove(); URL.revokeObjectURL(url);
+      const packetKind = packet?.kind || "performance-review";
+      const savedProofCount = Number(scorecard.accomplishments || 0) + Number(scorecard.impact_receipts || 0);
+      trackAnalyticsEvent(ANALYTICS_EVENTS.CAREER_PACKET_EXPORTED, { packet_kind: packetKind, format });
+      if (savedProofCount > 0) {
+        trackAnalyticsEvent(ANALYTICS_EVENTS.EXISTING_PROOF_REUSED, { reuse_type: "career_packet", packet_kind: packetKind, format });
+      }
     } catch (error) {
       console.error(error);
       if (error.response?.status === 401) { localStorage.removeItem("bragstack_token"); window.location.href = "/login"; return; }

--- a/frontend/src/PublicBragPage.jsx
+++ b/frontend/src/PublicBragPage.jsx
@@ -13,6 +13,7 @@ import {
   ShieldCheck,
 } from "lucide-react";
 import CalendlyEmbed from "./CalendlyEmbed.jsx";
+import { ANALYTICS_EVENTS, trackAnalyticsEvent } from "./analytics";
 import {
   getPublicEntries,
   getPublicImpactReceipts,
@@ -289,9 +290,11 @@ export default function PublicBragPage() {
     try {
       if (navigator.share) {
         await navigator.share(shareData);
+        trackAnalyticsEvent(ANALYTICS_EVENTS.PROFILE_SHARED, { share_method: "native" });
         setShareNotice("Shared");
       } else if (navigator.clipboard?.writeText) {
         await navigator.clipboard.writeText(url);
+        trackAnalyticsEvent(ANALYTICS_EVENTS.PROFILE_SHARED, { share_method: "clipboard" });
         setShareNotice("Rich link copied");
       } else {
         window.prompt("Copy this Proof Portfolio share link:", url);

--- a/frontend/src/behaviorAnalyticsSource.test.js
+++ b/frontend/src/behaviorAnalyticsSource.test.js
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const publicProfile = readFileSync(new URL("./PublicBragPage.jsx", import.meta.url), "utf8");
+const packetPreview = readFileSync(new URL("./PerformancePacketPreview.jsx", import.meta.url), "utf8");
+
+function position(source, needle) {
+  const index = source.indexOf(needle);
+  assert.ok(index >= 0, `Expected source to contain: ${needle}`);
+  return index;
+}
+
+test("public profile sharing is recorded only after a successful native share or clipboard copy", () => {
+  const nativeSuccess = position(publicProfile, "await navigator.share(shareData);");
+  const nativeEvent = position(publicProfile, 'trackAnalyticsEvent(ANALYTICS_EVENTS.PROFILE_SHARED, { share_method: "native" });');
+  const clipboardSuccess = position(publicProfile, "await navigator.clipboard.writeText(url);");
+  const clipboardEvent = position(publicProfile, 'trackAnalyticsEvent(ANALYTICS_EVENTS.PROFILE_SHARED, { share_method: "clipboard" });');
+  const promptFallback = position(publicProfile, 'window.prompt("Copy this Proof Portfolio share link:", url);');
+
+  assert.ok(nativeEvent > nativeSuccess, "native sharing must resolve before analytics is emitted");
+  assert.ok(clipboardEvent > clipboardSuccess, "clipboard writing must resolve before analytics is emitted");
+  assert.ok(promptFallback > clipboardEvent, "the unverified prompt fallback must not be counted as a successful share");
+  assert.match(publicProfile, /if \(error\?\.name !== "AbortError"\)/, "cancelled native shares must remain non-events");
+});
+
+test("career packet export and proof reuse are recorded only after a successful non-empty export", () => {
+  const download = position(packetPreview, "await downloadCareerPacket(packet, format);");
+  const nonEmptyGuard = position(packetPreview, 'if (!blob || Number(blob.size || 0) === 0) throw new Error("The generated file was empty.");');
+  const exportEvent = position(packetPreview, "ANALYTICS_EVENTS.CAREER_PACKET_EXPORTED");
+  const reuseGuard = position(packetPreview, "if (savedProofCount > 0)");
+  const reuseEvent = position(packetPreview, "ANALYTICS_EVENTS.EXISTING_PROOF_REUSED");
+
+  assert.ok(nonEmptyGuard > download, "empty packet responses must fail before analytics");
+  assert.ok(exportEvent > nonEmptyGuard, "packet export analytics must follow the non-empty response guard");
+  assert.ok(reuseGuard > exportEvent, "proof reuse must be evaluated after a successful export");
+  assert.ok(reuseEvent > reuseGuard, "reuse analytics must remain inside the saved-proof guard");
+});
+
+test("behavior analytics sends structural metadata rather than career content", () => {
+  assert.match(publicProfile, /PROFILE_SHARED, \{ share_method: "native" \}/);
+  assert.match(publicProfile, /PROFILE_SHARED, \{ share_method: "clipboard" \}/);
+  assert.match(packetPreview, /CAREER_PACKET_EXPORTED, \{ packet_kind: packetKind, format \}/);
+  assert.match(packetPreview, /EXISTING_PROOF_REUSED, \{ reuse_type: "career_packet", packet_kind: packetKind, format \}/);
+
+  const expectedEventCalls = [
+    '{ share_method: "native" }',
+    '{ share_method: "clipboard" }',
+    '{ packet_kind: packetKind, format }',
+    '{ reuse_type: "career_packet", packet_kind: packetKind, format }',
+  ];
+  for (const call of expectedEventCalls) {
+    assert.doesNotMatch(call, /(slug|url|filename|title|employer|organization|evidence|accomplishment|subject)/i);
+  }
+});


### PR DESCRIPTION
## Why
Refreshes #376 onto current main after #378 added recurring production canonical-vs-origin smoke checks. The telemetry change itself is unchanged; this PR exists so the required checks run against the latest base.

## What this wires
- `profile_shared` only after successful native Web Share or clipboard copy;
- no share event for aborted native share or unverifiable prompt fallback;
- `career_packet_exported` only after a successful non-empty packet export;
- `existing_proof_reused` only when that successful export contains saved accomplishments or Impact Receipts;
- regression tests for event ordering and structural-only metadata.

## Privacy
Only structural fields such as `share_method`, `packet_kind`, `format`, and `reuse_type` are sent. No slug, profile URL, filename, title, employer, organization, evidence, accomplishment text, or subject data is sent.

## Acceptance
Merge only after the full current PR gate—including the new production smoke checks, frontend deterministic tests, analytics tests, lint, build, and responsive/profile checks—is green.