### PR TITLE
P1: make the Impact Receipt the next-use aha moment

### DIFF
--- a/frontend/src/ImpactReceiptsPage.jsx
+++ b/frontend/src/ImpactReceiptsPage.jsx
@@ -138,6 +138,7 @@ function ImpactReceiptsPage() {
   const [updatingId, setUpdatingId] = useState(null);
   const [isCreating, setIsCreating] = useState(false);
   const [showCreate, setShowCreate] = useState(false);
+  const [showNextUses, setShowNextUses] = useState(false);
   const [form, setForm] = useState(EMPTY_FORM);
   const [editingId, setEditingId] = useState(null);
   const [editForm, setEditForm] = useState(null);
@@ -186,13 +187,13 @@ function ImpactReceiptsPage() {
 
   async function submitReceipt(event) {
     event.preventDefault();
-    setIsCreating(true); setError(""); setSuccess("");
+    setIsCreating(true); setError(""); setSuccess(""); setShowNextUses(false);
     const skills = form.skills.split(",").map((skill) => skill.trim()).filter(Boolean);
     const metrics = form.metricLabel.trim() && form.metricValue.trim() ? [{ label: form.metricLabel.trim(), value: form.metricValue.trim(), context: form.metricContext.trim() || null }] : [];
     const evidence = normalizeEvidence(form.evidence).map((item) => ({ ...item, reference: item.reference.trim() || null, description: item.description.trim() || null, title: item.title.trim() }));
     try {
       await createImpactReceipt({ accomplishment: form.accomplishment.trim(), contribution: form.contribution.trim(), result: form.result.trim(), metrics, evidence, skills, credit: [], is_public: form.isPublic });
-      setForm(EMPTY_FORM); setShowCreate(false); setPage(1); setSuccess("Impact Receipt saved with evidence."); await loadReceipts();
+      setForm(EMPTY_FORM); setShowCreate(false); setPage(1); setSuccess("Impact Receipt saved with evidence."); setShowNextUses(true); await loadReceipts();
     } catch (err) {
       const detail = err.response?.data?.detail;
       setError(typeof detail === "string" ? detail : "Impact Receipt could not be saved. Check the required fields.");
@@ -274,6 +275,21 @@ function ImpactReceiptsPage() {
     {stats.confirmedCount > 0 && <div className="product-alert success"><CheckCircle2 size={17} /> Your proof has earned {stats.confirmedCount} third-party confirmation{stats.confirmedCount === 1 ? "" : "s"} across {stats.verifiedReceiptCount} verified Impact Receipt{stats.verifiedReceiptCount === 1 ? "" : "s"}.</div>}
     {error && <div className="product-alert error">{error}</div>}
     {success && <div className="product-alert success">{success}</div>}
+
+    {showNextUses && <section className="receipt-next-use-card" aria-labelledby="receipt-next-use-title">
+      <div className="receipt-next-use-copy">
+        <p className="mini-label">You captured this once</p>
+        <h2 id="receipt-next-use-title">Here are four things it can become.</h2>
+        <p>Your proof is saved. Keep the same evidence and move into the career moment you need next—without starting from a blank page.</p>
+      </div>
+      <div className="receipt-next-use-grid">
+        <a href="/app/resume-builder"><strong>Resume bullet</strong><span>Turn recorded proof into resume-ready material.</span><ExternalLink size={16} /></a>
+        <a href="/app/interview-practice"><strong>STAR answer</strong><span>Practice telling the same impact as an interview story.</span><ExternalLink size={16} /></a>
+        <a href="/app/reports?packets=1"><strong>Review statement</strong><span>Use your evidence in a review or career packet.</span><ExternalLink size={16} /></a>
+        <a href="/app/profile"><strong>Shareable proof</strong><span>Choose what belongs on your Public Proof Profile.</span><ExternalLink size={16} /></a>
+      </div>
+      <button type="button" className="receipt-next-use-dismiss" onClick={() => setShowNextUses(false)}>Not now</button>
+    </section>}
 
     {isLoading ? <BragStackLoader compact message="Loading your Impact Receipts…" detail="Gathering evidence-backed outcomes, proof, and confirmation signals." /> : receipts.length === 0 ? (
       <section className="product-empty"><h2>No receipts yet.</h2><p>Create your first evidence-backed receipt, or turn an existing accomplishment into one.</p><a href="/app/accomplishments">Create from an accomplishment <ExternalLink size={16} /></a></section>

--- a/frontend/src/ImpactReceiptsPolish.css
+++ b/frontend/src/ImpactReceiptsPolish.css
@@ -20,6 +20,97 @@
   flex: 0 0 auto;
 }
 
+.receipt-next-use-card {
+  margin: 18px 0 22px;
+  padding: clamp(18px, 3vw, 28px);
+  border: 1px solid rgba(125, 211, 252, .28);
+  border-radius: 20px;
+  background: linear-gradient(145deg, rgba(14, 116, 144, .2), rgba(15, 23, 42, .92) 58%);
+  box-shadow: 0 18px 48px rgba(2, 6, 23, .26);
+}
+
+.receipt-next-use-copy {
+  max-width: 760px;
+}
+
+.receipt-next-use-copy h2 {
+  margin: 4px 0 8px;
+  font-size: clamp(1.35rem, 2.4vw, 1.8rem);
+}
+
+.receipt-next-use-copy > p:last-child {
+  margin: 0;
+  color: #cbd5e1;
+  line-height: 1.65;
+}
+
+.receipt-next-use-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+  margin-top: 20px;
+}
+
+.receipt-next-use-grid a {
+  min-width: 0;
+  min-height: 116px;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-content: start;
+  gap: 7px 10px;
+  padding: 16px;
+  border: 1px solid rgba(148, 163, 184, .2);
+  border-radius: 16px;
+  background: rgba(15, 23, 42, .72);
+  color: #f8fafc;
+  text-decoration: none;
+  overflow-wrap: anywhere;
+}
+
+.receipt-next-use-grid a strong,
+.receipt-next-use-grid a span {
+  grid-column: 1;
+}
+
+.receipt-next-use-grid a strong {
+  font-size: .98rem;
+}
+
+.receipt-next-use-grid a span {
+  color: #cbd5e1;
+  font-size: .84rem;
+  line-height: 1.45;
+}
+
+.receipt-next-use-grid a svg {
+  grid-column: 2;
+  grid-row: 1;
+  color: #7dd3fc;
+}
+
+.receipt-next-use-grid a:hover {
+  border-color: rgba(125, 211, 252, .5);
+  background: rgba(14, 116, 144, .22);
+}
+
+.receipt-next-use-grid a:focus-visible,
+.receipt-next-use-dismiss:focus-visible {
+  outline: 2px solid #7dd3fc;
+  outline-offset: 3px;
+}
+
+.receipt-next-use-dismiss {
+  min-height: 44px;
+  margin-top: 14px;
+  padding: 8px 12px;
+  border: 0;
+  background: transparent;
+  color: #94a3b8;
+  font: inherit;
+  font-weight: 800;
+  cursor: pointer;
+}
+
 .receipt-library-pagination {
   margin-top: 22px;
 }
@@ -61,7 +152,21 @@
   outline-offset: 2px;
 }
 
+@media (max-width: 900px) {
+  .receipt-next-use-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
 @media (max-width: 620px) {
+  .receipt-next-use-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .receipt-next-use-grid a {
+    min-height: 96px;
+  }
+
   .receipt-library-pagination .pagination-controls {
     width: 100%;
   }

--- a/frontend/src/wholeAppUiAuditSource.test.js
+++ b/frontend/src/wholeAppUiAuditSource.test.js
@@ -173,3 +173,37 @@ test("Impact Receipts prioritize verified proof, paginate the full library, and 
   assert.ok(impactReceiptsApiSource.includes("limit: API_PAGE_LIMIT, skip"), "receipt loader must request API pages explicitly");
   assert.ok(impactReceiptsApiSource.includes("data.has_more"), "receipt loader must continue until the full library is loaded");
 });
+
+test("a newly saved Impact Receipt immediately teaches the next four existing uses", () => {
+  assert.match(
+    impactReceiptsSource,
+    /setSuccess\("Impact Receipt saved with evidence\."\); setShowNextUses\(true\)/,
+    "the next-use panel must appear only after a successful receipt save",
+  );
+
+  for (const token of [
+    "You captured this once",
+    "Here are four things it can become.",
+    "Resume bullet",
+    "STAR answer",
+    "Review statement",
+    "Shareable proof",
+    'href="/app/resume-builder"',
+    'href="/app/interview-practice"',
+    'href="/app/reports?packets=1"',
+    'href="/app/profile"',
+  ]) {
+    assert.ok(impactReceiptsSource.includes(token), `receipt next-use guidance is missing: ${token}`);
+  }
+
+  for (const token of [
+    ".receipt-next-use-card",
+    ".receipt-next-use-grid",
+    "grid-template-columns: repeat(4, minmax(0, 1fr))",
+    "min-height: 44px",
+    "@media (max-width: 900px)",
+    "@media (max-width: 620px)",
+  ]) {
+    assert.ok(impactReceiptsStyles.includes(token), `receipt next-use responsive contract is missing: ${token}`);
+  }
+});


### PR DESCRIPTION
## Why

The founding-team audit defines activation as more than saving proof: a user should complete an Impact Receipt and understand how that same proof becomes something useful. Today the receipt-creation flow ends at a success message and reloads the library.

## What this changes

- after a **successful new Impact Receipt save**, show: “You captured this once. Here are four things it can become.”
- provide four clear existing-product destinations:
  - Resume bullet → Resume Builder
  - STAR answer → Practice Interview
  - Review statement → Career Packets
  - Shareable proof → Profile / Public Proof Profile controls
- keep the panel dismissible and accessible;
- add a 4-column → 2-column → 1-column responsive layout with ≥44px dismiss target and focus-visible treatment;
- add regression assertions to the existing whole-app UI source gate.

## Deliberate boundary

This PR teaches the correct product mental model but does **not** claim receipt-specific reuse is implemented. The destination links do not carry an unused receipt ID or invent integration semantics. True “reopen this receipt → use this for X” behavior remains the Week 3 reuse slice.

## Concurrency safety

This branch is intentionally isolated from the other active work. It does not touch `frontend/package.json`, analytics plumbing, `PublicBragPage`, packet preview code, or transactional email code.

## CI status

Keep this draft until the repository-wide GitHub Actions issue is resolved. Multiple independent PRs currently fail `Detect PR changes` before any runner steps execute, so this branch must not be merged based on absent checks.