### PR TITLE
P1: preserve selected Impact Receipt provenance in evidence outputs

### DIFF
--- a/backend/app/core_output_routes.py
+++ b/backend/app/core_output_routes.py
@@ -6,7 +6,8 @@ from collections import Counter
 from datetime import date, datetime, timezone
 from typing import Any
 
-from fastapi import APIRouter, Depends, Query
+from bson import ObjectId
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field
 
 from app.auth import get_current_user
@@ -21,6 +22,7 @@ class ResumeTargetRequest(BaseModel):
     target_role: str = Field(..., min_length=2, max_length=200)
     target_description: str = Field(default="", max_length=12000)
     max_bullets: int = Field(default=8, ge=1, le=20)
+    source_receipt_ids: list[str] = Field(default_factory=list, max_length=20)
 
 
 def _clean(value: Any) -> str:
@@ -58,16 +60,7 @@ def _receipt_date(receipt: dict) -> date | None:
 
 
 def _receipts_for_user(user_id: str, start_date: date | None = None, end_date: date | None = None) -> list[dict]:
-    """Handle receipts for user.
-
-    Args:
-        user_id: Function argument.
-        start_date: Function argument.
-        end_date: Function argument.
-
-    Returns:
-        Function result.
-    """
+    """Return owned receipts, newest first, optionally constrained by date."""
     receipts = list(impact_receipts_collection.find({"user_id": user_id}).sort("created_at", -1))
     if start_date is None and end_date is None:
         return receipts
@@ -83,15 +76,76 @@ def _receipts_for_user(user_id: str, start_date: date | None = None, end_date: d
     return selected
 
 
+def _normalize_receipt_ids(receipt_ids: list[str] | None) -> list[str]:
+    """Validate and de-duplicate explicit receipt selectors while preserving order."""
+    normalized = []
+    seen = set()
+    for value in receipt_ids or []:
+        receipt_id = _clean(value)
+        if not receipt_id or not ObjectId.is_valid(receipt_id):
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="Invalid Impact Receipt selection.",
+            )
+        if receipt_id not in seen:
+            normalized.append(receipt_id)
+            seen.add(receipt_id)
+    return normalized
+
+
+def _selected_receipts_for_user(
+    user_id: str,
+    receipt_ids: list[str] | None,
+    start_date: date | None = None,
+    end_date: date | None = None,
+) -> list[dict]:
+    """Return exactly the requested owned receipts, or the normal owned set when unselected."""
+    normalized_ids = _normalize_receipt_ids(receipt_ids)
+    if not normalized_ids:
+        return _receipts_for_user(user_id, start_date, end_date)
+
+    object_ids = [ObjectId(receipt_id) for receipt_id in normalized_ids]
+    found = list(
+        impact_receipts_collection.find(
+            {
+                "user_id": user_id,
+                "_id": {"$in": object_ids},
+            }
+        )
+    )
+    by_id = {str(receipt["_id"]): receipt for receipt in found}
+
+    # One generic response avoids revealing which requested ID was missing or
+    # belonged to another user.
+    if len(by_id) != len(normalized_ids):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="One or more selected Impact Receipts are unavailable.",
+        )
+
+    selected = [by_id[receipt_id] for receipt_id in normalized_ids]
+    if start_date is None and end_date is None:
+        return selected
+
+    date_filtered = []
+    for receipt in selected:
+        created = _receipt_date(receipt)
+        if start_date is not None and (created is None or created < start_date):
+            continue
+        if end_date is not None and (created is None or created > end_date):
+            continue
+        date_filtered.append(receipt)
+
+    if len(date_filtered) != len(selected):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="One or more selected Impact Receipts are unavailable for this output period.",
+        )
+    return date_filtered
+
+
 def _metric_text(receipt: dict) -> list[str]:
-    """Handle metric text.
-
-    Args:
-        receipt: Function argument.
-
-    Returns:
-        Function result.
-    """
+    """Handle metric text."""
     values = []
     for metric in receipt.get("metrics", []) or []:
         label = _clean(metric.get("label"))
@@ -107,14 +161,7 @@ def _metric_text(receipt: dict) -> list[str]:
 
 
 def _evidence_summary(receipt: dict) -> list[dict]:
-    """Handle evidence summary.
-
-    Args:
-        receipt: Function argument.
-
-    Returns:
-        Function result.
-    """
+    """Handle evidence summary."""
     return [
         {
             "title": _clean(item.get("title")),
@@ -129,14 +176,7 @@ def _evidence_summary(receipt: dict) -> list[dict]:
 
 
 def _proof_strength(receipt: dict) -> int:
-    """Handle proof strength.
-
-    Args:
-        receipt: Function argument.
-
-    Returns:
-        Function result.
-    """
+    """Handle proof strength."""
     score = min(len(receipt.get("evidence", []) or []), 3)
     score += min(len(receipt.get("metrics", []) or []), 2)
     score += 1 if any(
@@ -147,14 +187,7 @@ def _proof_strength(receipt: dict) -> int:
 
 
 def _receipt_record(receipt: dict) -> dict:
-    """Handle receipt record.
-
-    Args:
-        receipt: Function argument.
-
-    Returns:
-        Function result.
-    """
+    """Handle receipt record."""
     created = _receipt_date(receipt)
     return {
         "receipt_id": str(receipt["_id"]),
@@ -171,14 +204,7 @@ def _receipt_record(receipt: dict) -> dict:
 
 
 def _tokenize(value: str) -> set[str]:
-    """Handle tokenize.
-
-    Args:
-        value: Function argument.
-
-    Returns:
-        Function result.
-    """
+    """Handle tokenize."""
     stop_words = {
         "and", "the", "with", "for", "from", "that", "this", "your", "you", "our", "are",
         "will", "have", "has", "into", "using", "use", "job", "role", "work", "team", "their",
@@ -191,15 +217,7 @@ def _tokenize(value: str) -> set[str]:
 
 
 def _resume_score(receipt: dict, target_tokens: set[str]) -> tuple[int, int]:
-    """Handle resume score.
-
-    Args:
-        receipt: Function argument.
-        target_tokens: Function argument.
-
-    Returns:
-        Function result.
-    """
+    """Handle resume score."""
     searchable = " ".join(
         [
             _clean(receipt.get("accomplishment")),
@@ -213,14 +231,7 @@ def _resume_score(receipt: dict, target_tokens: set[str]) -> tuple[int, int]:
 
 
 def _resume_bullet(receipt: dict) -> str:
-    """Handle resume bullet.
-
-    Args:
-        receipt: Function argument.
-
-    Returns:
-        Function result.
-    """
+    """Handle resume bullet."""
     contribution = _clean(receipt.get("contribution"))
     result = _clean(receipt.get("result"))
     accomplishment = _clean(receipt.get("accomplishment"))
@@ -236,12 +247,13 @@ def _resume_bullet(receipt: dict) -> str:
 def evidence_only_performance_review(
     start_date: date | None = Query(default=None),
     end_date: date | None = Query(default=None),
+    receipt_id: list[str] | None = Query(default=None),
     current_user: dict = Depends(get_current_user),
 ):
     """Build a performance-review packet exclusively from owned Impact Receipts."""
 
     user_id = str(current_user["_id"])
-    receipts = _receipts_for_user(user_id, start_date, end_date)
+    receipts = _selected_receipts_for_user(user_id, receipt_id, start_date, end_date)
     records = [_receipt_record(receipt) for receipt in receipts]
 
     skill_counts = Counter(skill for record in records for skill in record["skills"])
@@ -287,10 +299,11 @@ def evidence_only_resume_material(
     """Rank and format evidence-backed resume material for a target job."""
 
     user_id = str(current_user["_id"])
-    receipts = _receipts_for_user(user_id)
+    explicit_selection = bool(payload.source_receipt_ids)
+    receipts = _selected_receipts_for_user(user_id, payload.source_receipt_ids)
     target_tokens = _tokenize(f"{payload.target_role} {payload.target_description}")
 
-    ranked = sorted(
+    ranked = receipts if explicit_selection else sorted(
         receipts,
         key=lambda receipt: _resume_score(receipt, target_tokens),
         reverse=True,

--- a/backend/tests/test_core_outputs_and_beta.py
+++ b/backend/tests/test_core_outputs_and_beta.py
@@ -111,6 +111,49 @@ def test_performance_review_uses_only_receipts(output_context):
     assert data["review_highlights"][0]["evidence"][0]["reference"] == "INC-1042"
 
 
+def test_performance_review_can_use_one_selected_owned_receipt(output_context):
+    user, receipts, _ = output_context
+    ignored_id = insert_receipt(
+        receipts,
+        user,
+        accomplishment="Improved unrelated documentation",
+        result="Reduced onboarding questions by 10%",
+    )
+    selected_id = insert_receipt(
+        receipts,
+        user,
+        accomplishment="Stabilized production DNS",
+        contribution="Diagnosed and fixed production DNS failures",
+        result="Reduced DNS incident recurrence by 40%",
+    )
+
+    response = client.get(
+        "/outputs/performance-review",
+        params=[("receipt_id", str(selected_id))],
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["source_receipt_ids"] == [str(selected_id)]
+    assert str(ignored_id) not in data["source_receipt_ids"]
+    assert data["summary"]["receipt_count"] == 1
+    assert data["all_receipts"][0]["accomplishment"] == "Stabilized production DNS"
+
+
+def test_performance_review_preserves_explicit_receipt_order(output_context):
+    user, receipts, _ = output_context
+    first_id = insert_receipt(receipts, user, accomplishment="First selected proof")
+    second_id = insert_receipt(receipts, user, accomplishment="Second selected proof")
+
+    response = client.get(
+        "/outputs/performance-review",
+        params=[("receipt_id", str(second_id)), ("receipt_id", str(first_id))],
+    )
+
+    assert response.status_code == 200
+    assert response.json()["source_receipt_ids"] == [str(second_id), str(first_id)]
+
+
 def test_resume_target_can_rank_but_not_invent_claims(output_context):
     """Verify resume target can rank but not invent claims.
 
@@ -140,6 +183,97 @@ def test_resume_target_can_rank_but_not_invent_claims(output_context):
     assert "Terraform" not in bullet
     assert "AWS" not in bullet
     assert data["evidence_backed_skills"] == ["Docker", "Networking", "Troubleshooting"]
+
+
+def test_resume_material_does_not_broaden_an_explicit_selection(output_context):
+    user, receipts, _ = output_context
+    selected_id = insert_receipt(
+        receipts,
+        user,
+        accomplishment="Reduced Docker incidents",
+        contribution="Fixed container DNS failures",
+        result="Reduced recurring incidents by 25%",
+        skills=["Docker", "Networking"],
+    )
+    better_keyword_match_id = insert_receipt(
+        receipts,
+        user,
+        accomplishment="Migrated Kubernetes platform",
+        contribution="Migrated Kubernetes clusters",
+        result="Improved deployment reliability",
+        skills=["Kubernetes", "Terraform"],
+    )
+
+    response = client.post(
+        "/outputs/resume-material",
+        json={
+            "target_role": "Kubernetes Platform Engineer",
+            "target_description": "Kubernetes Terraform",
+            "source_receipt_ids": [str(selected_id)],
+        },
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["source_receipt_ids"] == [str(selected_id)]
+    assert str(better_keyword_match_id) not in data["source_receipt_ids"]
+    assert len(data["resume_bullets"]) == 1
+    assert "Kubernetes" not in data["resume_bullets"][0]["bullet"]
+
+
+def test_resume_material_preserves_selected_receipt_order(output_context):
+    user, receipts, _ = output_context
+    first_id = insert_receipt(receipts, user, accomplishment="First proof")
+    second_id = insert_receipt(receipts, user, accomplishment="Second proof")
+
+    response = client.post(
+        "/outputs/resume-material",
+        json={
+            "target_role": "Support Engineer",
+            "source_receipt_ids": [str(second_id), str(first_id)],
+            "max_bullets": 2,
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["source_receipt_ids"] == [str(second_id), str(first_id)]
+
+
+def test_selected_output_rejects_invalid_receipt_id(output_context):
+    user, receipts, _ = output_context
+    insert_receipt(receipts, user)
+
+    response = client.get(
+        "/outputs/performance-review",
+        params=[("receipt_id", "not-an-object-id")],
+    )
+
+    assert response.status_code == 422
+    assert response.json()["detail"] == "Invalid Impact Receipt selection."
+
+
+def test_selected_output_does_not_reveal_other_user_receipt(output_context):
+    user, receipts, _ = output_context
+    insert_receipt(receipts, user)
+    other_user = {"_id": ObjectId()}
+    other_receipt_id = insert_receipt(receipts, other_user)
+
+    performance_response = client.get(
+        "/outputs/performance-review",
+        params=[("receipt_id", str(other_receipt_id))],
+    )
+    resume_response = client.post(
+        "/outputs/resume-material",
+        json={
+            "target_role": "Support Engineer",
+            "source_receipt_ids": [str(other_receipt_id)],
+        },
+    )
+
+    assert performance_response.status_code == 404
+    assert resume_response.status_code == 404
+    assert performance_response.json()["detail"] == "One or more selected Impact Receipts are unavailable."
+    assert resume_response.json()["detail"] == "One or more selected Impact Receipts are unavailable."
 
 
 def test_resume_output_does_not_use_other_users_receipts(output_context):


### PR DESCRIPTION
## Why

Week 3 of the founding-team audit is about proving reuse: when a user chooses an existing Impact Receipt, the downstream output should use **that selected proof** rather than dropping the selection and starting from the whole library.

This implements the backend selection/provenance contract from #389 without adding another generator or touching any active frontend lane.

## What changes

### Performance review
`GET /outputs/performance-review` now accepts optional repeated `receipt_id` selectors.

- no selector → existing behavior unchanged: use the authenticated user's owned receipt set;
- explicit selector → use exactly those owned receipts, preserving selector order;
- date constraints still apply;
- a selected receipt outside the requested period fails instead of silently broadening to other receipts.

### Resume material
`POST /outputs/resume-material` adds optional bounded `source_receipt_ids`.

- no selector → existing target-role ranking behavior unchanged;
- explicit selector → preserve the user's receipt selection instead of replacing it with a higher keyword match from another receipt;
- `max_bullets` still limits the actual output;
- returned `source_receipt_ids` always reflects the proof actually used.

## Authorization / privacy

- receipt selectors are structurally validated;
- selected IDs are fetched only under the authenticated `user_id`;
- missing and cross-user selections share one generic 404 response;
- the backend never falls back to unrelated owned receipts after an explicit selection;
- no receipt content is added to URLs or analytics.

## Tests added

Coverage now includes:

- one selected owned receipt for performance review;
- deterministic selector order;
- explicit résumé selection cannot be overridden by a stronger target-keyword match;
- selected résumé order;
- invalid selector handling;
- cross-user selector isolation with the same generic unavailable response;
- existing no-selector tests remain in place for backward compatibility.

## Concurrency safety

This branch changes only:

- `backend/app/core_output_routes.py`
- `backend/tests/test_core_outputs_and_beta.py`

It does not overlap #380 OAuth/analytics, #381 frontend reuse/share telemetry, #382 transactional email, #383 Impact Receipt UI, #364 Accomplishments QA, or #387 dashboard activation focus.

## Deliberate scope

This PR does **not** add frontend `Use this for` links yet. The UI should only pass a receipt selector after the destination really consumes it. It also does not emit `existing_proof_reused` or `first_generated_output`; those remain success-boundary frontend/product events.

## CI status

Keep draft until #386 is resolved. GitHub-hosted runners are currently failing before step 1, so this must not be merged based on absent checks.

Closes no issue automatically; #389 remains the end-to-end reuse tracker until a real frontend selected-proof path is shipped.