### PR TITLE
Fix required CI coverage for every pull request

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -1,16 +1,13 @@
 name: CI PR
 
-# Protected-branch contexts are intentionally defined here; changing this
-# workflow triggers the full backend, frontend, and dependency validation set.
+# Protected-branch contexts are intentionally defined here. Run this workflow
+# for every pull request so required checks never remain permanently "Expected"
+# just because a change falls outside backend/frontend paths. The `changes` job
+# below still gates the expensive backend/frontend/dependency work. This also
+# keeps docs-only and config-only PRs compatible with strict required checks.
 
 on:
   pull_request:
-    paths:
-      - "backend/**"
-      - "frontend/**"
-      - ".github/workflows/ci-*.yml"
-      - ".github/workflows/production-smoke.yml"
-      - "docs/CI_BUDGET_POLICY.md"
 
 concurrency:
   group: ci-pr-${{ github.event.pull_request.number }}
@@ -44,7 +41,6 @@ jobs:
           if printf '%s\n' "$changed_files" | grep -Eq '^(backend/requirements\.txt|frontend/package\.json|frontend/package-lock\.json|\.github/workflows/ci-)'; then echo "dependencies=true" >> "$GITHUB_OUTPUT"; else echo "dependencies=false" >> "$GITHUB_OUTPUT"; fi
 
   backend-medium:
-    # Preserve the protected-branch context while using the cheaper medium PR tier.
     name: Run backend tests
     needs: changes
     if: needs.changes.outputs.backend == 'true'
@@ -79,7 +75,6 @@ jobs:
         run: python -m pytest
 
   frontend-medium:
-    # Preserve the protected-branch context while using the cheaper medium PR tier.
     name: Test, lint and build frontend
     needs: changes
     if: needs.changes.outputs.frontend == 'true'


### PR DESCRIPTION
## Why

The protected branch requires three CI contexts, but `CI PR` currently has outer `pull_request.paths` filters. A docs-only PR such as #379 never starts the workflow, so required checks remain permanently **Expected** and the PR cannot merge even though the workflow already has internal change detection.

## Change

Run `CI PR` for every pull request and let the existing `changes` job decide whether backend/frontend/dependency work is necessary.

This fixes the structural merge deadlock for docs/config-only PRs without expanding product scope.

## Important separate blocker

This does **not** claim to fix the current GitHub-hosted runner provisioning failure (`runner_id: 0`, `steps: []`). That remains #386/account-side. This PR fixes the independent path-filter problem so required checks can exist once runners are available.

## Concurrency

Based on current `main` at `57c52bfa5e3ccd43b23522ef46cbd9273d52b2cd`; changes only `.github/workflows/ci-pr.yml`.