### PR TITLE
Improve Boasted branded Google search appearance

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,19 +8,20 @@
     <meta name="apple-mobile-web-app-title" content="Boasted" />
     <meta name="color-scheme" content="dark light" />
 
-    <link rel="icon" type="image/png" sizes="48x48" href="/favicon-48x48.png?v=4" />
     <link rel="icon" type="image/png" sizes="192x192" href="/boasted-logo-192.png?v=4" />
+    <link rel="icon" type="image/png" sizes="48x48" href="/favicon-48x48.png?v=4" />
     <link rel="icon" type="image/svg+xml" sizes="any" href="/favicon.svg?v=4" />
-    <link rel="shortcut icon" type="image/png" href="/favicon-48x48.png?v=4" />
+    <link rel="shortcut icon" type="image/png" href="/boasted-logo-192.png?v=4" />
     <link rel="apple-touch-icon" sizes="192x192" href="/boasted-logo-192.png?v=4" />
     <link rel="manifest" href="/site.webmanifest?v=4" />
     <link rel="stylesheet" href="/bragstack-polish.css" />
 
-    <title>Boasted | Career Proof for Work Across Industries</title>
-    <meta name="description" content="Boasted helps people across industries capture meaningful work, preserve evidence, and build reusable career proof for resumes, portfolios, interviews, reviews, promotions, certifications, and career transitions." />
+    <title>Boasted: Save It. Prove It. Use It.</title>
+    <meta name="description" content="Boasted helps you save your work, wins, projects, skills, and proof in one place, then reuse them for jobs, reviews, promotions, interviews, scholarships, and more." />
     <meta name="keywords" content="career proof, work accomplishments, resume builder, resume accomplishments, career portfolio, professional portfolio, job search, interview preparation, performance review, promotion packet, certification evidence, achievement tracker, brag document, career evidence, hiring, portfolio" />
     <meta name="author" content="Boasted" />
     <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1" />
+    <meta name="googlebot" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1" />
     <link rel="canonical" href="https://boasted.io/" />
 
     <meta property="og:type" content="website" />
@@ -59,9 +60,10 @@
             "@type": "Organization",
             "@id": "https://boasted.io/#organization",
             "name": "Boasted",
-            "alternateName": "Boasted Career Proof",
+            "alternateName": ["Boasted.io", "Boasted Career Proof"],
             "url": "https://boasted.io/",
             "email": "mailto:Tobias.scott@boasted.io",
+            "description": "Boasted is career evidence software for capturing accomplishments, outcomes, skills, and proof so people can reuse them when opportunities arrive.",
             "logo": { "@id": "https://boasted.io/#logo" }
           },
           {
@@ -69,15 +71,16 @@
             "@id": "https://boasted.io/#website",
             "url": "https://boasted.io/",
             "name": "Boasted",
-            "alternateName": "Boasted Career Proof",
+            "alternateName": ["Boasted.io", "Boasted Career Proof"],
             "publisher": { "@id": "https://boasted.io/#organization" },
-            "description": "Career evidence software for people across professions to preserve accomplishments, outcomes, evidence, skills, and recognition for resumes, portfolios, interviews, reviews, promotions, certifications, and career transitions.",
+            "description": "Boasted helps people save meaningful work and turn it into reusable career proof for resumes, portfolios, interviews, reviews, promotions, certifications, scholarships, and career transitions.",
             "inLanguage": "en-US"
           },
           {
             "@type": "SoftwareApplication",
             "@id": "https://boasted.io/#app",
             "name": "Boasted",
+            "alternateName": "Boasted.io",
             "applicationCategory": "BusinessApplication",
             "operatingSystem": "Web",
             "url": "https://boasted.io/",

--- a/frontend/public/sitemap.xml
+++ b/frontend/public/sitemap.xml
@@ -14,8 +14,6 @@
   <url><loc>https://boasted.io/contact</loc><changefreq>monthly</changefreq><priority>0.55</priority></url>
   <url><loc>https://boasted.io/team</loc><changefreq>monthly</changefreq><priority>0.6</priority></url>
   <url><loc>https://boasted.io/enterprise</loc><changefreq>monthly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://boasted.io/login</loc><changefreq>monthly</changefreq><priority>0.85</priority></url>
-  <url><loc>https://boasted.io/register</loc><changefreq>monthly</changefreq><priority>0.85</priority></url>
   <url><loc>https://boasted.io/impact-receipts</loc><changefreq>weekly</changefreq><priority>0.9</priority></url>
   <url><loc>https://boasted.io/performance-reviews</loc><changefreq>weekly</changefreq><priority>0.9</priority></url>
   <url><loc>https://boasted.io/career-portfolio</loc><changefreq>weekly</changefreq><priority>0.9</priority></url>

--- a/frontend/scripts/generate-static-route-shells.mjs
+++ b/frontend/scripts/generate-static-route-shells.mjs
@@ -30,7 +30,7 @@ const REQUIRED_CLIENT_ROUTES = [
   "/legal/education-data",
 ];
 
-const NOINDEX_ROUTES = new Set(["/upgrade", "/verify-receipt"]);
+const NOINDEX_ROUTES = new Set(["/login", "/register", "/upgrade", "/verify-receipt"]);
 
 const ROUTE_META = Object.freeze({
   "/privacy": {

--- a/frontend/scripts/verify-search-appearance.mjs
+++ b/frontend/scripts/verify-search-appearance.mjs
@@ -15,9 +15,9 @@ const publicSitelinks = [
   "/resume-accomplishments",
   "/interview-preparation",
   "/impact-receipts",
+  "/career-portfolio",
   "/how-it-works",
   "/pricing",
-  "/login",
 ];
 
 const sitemapUrls = [...sitemap.matchAll(/<loc>(.*?)<\/loc>/g)].map((match) => match[1]);
@@ -29,6 +29,8 @@ const duplicates = sitemapUrls.filter((url, index) => sitemapUrls.indexOf(url) !
 assert.equal(duplicates.length, 0, `sitemap.xml contains duplicate URLs: ${duplicates.join(", ")}`);
 assert.ok(sitemapUrls.every((url) => url.startsWith("https://boasted.io/")), "sitemap URLs must use the canonical HTTPS origin");
 assert.ok(sitemapUrls.every((url) => !url.includes("#") && !url.includes("?")), "sitemap URLs must not contain fragments or query strings");
+assert.ok(!sitemap.includes("https://boasted.io/login"), "login should not compete with product pages in the public sitemap");
+assert.ok(!sitemap.includes("https://boasted.io/register"), "register should not compete with product pages in the public sitemap");
 
 assert.match(robots, /Sitemap:\s+https:\/\/boasted\.io\/sitemap\.xml/);
 assert.match(robots, /Disallow:\s+\/app\//);
@@ -52,11 +54,14 @@ assert.match(seoLandingPages, /meta\[property="og:url"\]/);
 assert.match(seoLandingPages, /meta\[name="twitter:title"\]/);
 assert.match(seoLandingPages, /meta\[name="twitter:description"\]/);
 assert.match(searchMeta, /NOINDEX_PREFIXES\s*=\s*\["\/app"\]/);
+assert.match(searchMeta, /"\/login"/);
+assert.match(searchMeta, /"\/register"/);
 assert.match(searchMeta, /"\/upgrade"/);
 assert.match(searchMeta, /"\/verify-receipt"/);
 assert.match(searchMeta, /SiteNavigationElement/);
 assert.match(searchMeta, /max-image-preview:large/);
 assert.match(searchMeta, /https:\/\/boasted\.io/);
+assert.match(searchMeta, /Boasted\.io/);
 
 // Static HTML must expose route-specific crawl metadata before React executes.
 assert.match(staticRouteShells, /function routeShell\(indexHtml, route\)/);

--- a/frontend/scripts/verify-search-appearance.mjs
+++ b/frontend/scripts/verify-search-appearance.mjs
@@ -78,7 +78,7 @@ assert.match(staticRouteShells, /<meta name="twitter:description"/);
 assert.match(staticRouteShells, /Missing static metadata for public route/);
 assert.match(staticRouteShells, /writeFile\(path\.join\(routeDir, "index\.html"\), routeShell\(indexHtml, route\)/);
 assert.doesNotMatch(staticRouteShells, /copyFile\(INDEX_FILE, path\.join\(routeDir, "index\.html"\)\)/);
-assert.match(staticRouteShells, /NOINDEX_ROUTES = new Set\(\["\/upgrade", "\/verify-receipt"\]\)/);
+assert.match(staticRouteShells, /NOINDEX_ROUTES = new Set\(\["\/login", "\/register", "\/upgrade", "\/verify-receipt"\]\)/);
 assert.match(staticRouteShells, /noindex,nofollow/);
 assert.ok(staticRouteShells.includes('"/support"'), "the public Support Hub needs a generated static shell");
 

--- a/frontend/src/primarySitelinks.js
+++ b/frontend/src/primarySitelinks.js
@@ -4,8 +4,7 @@ export const PRIMARY_SITELINKS = [
   ["Resume Builder", "/resume-accomplishments", "Build evidence-backed resume material"],
   ["Interview Preparation", "/interview-preparation", "Practice role-specific interview stories"],
   ["Impact Receipts", "/impact-receipts", "Turn accomplishments into reusable proof"],
-  ["Education", "/education", "Track student wins, growth, and opportunity-ready stories"],
+  ["Career Portfolio", "/career-portfolio", "Build a professional proof portfolio from selected accomplishments"],
   ["How It Works", "/how-it-works", "See how Boasted turns wins into career proof"],
-  ["Support Hub", "/support", "Get product help, beta access guidance, and support contacts"],
-  ["Sign In", "/login", "Open your Boasted account"],
+  ["Pricing", "/pricing", "Compare Boasted Free and Pro plans"],
 ];

--- a/frontend/src/seoSitelinks.js
+++ b/frontend/src/seoSitelinks.js
@@ -2,7 +2,7 @@ export const PRIMARY_SITELINKS = [
   { label: "Resume Builder", href: "/resume-accomplishments" },
   { label: "Interview Preparation", href: "/interview-preparation" },
   { label: "Impact Receipts", href: "/impact-receipts" },
+  { label: "Career Portfolio", href: "/career-portfolio" },
   { label: "How It Works", href: "/how-it-works" },
   { label: "Pricing", href: "/pricing" },
-  { label: "Sign In", href: "/login" },
 ];

--- a/frontend/src/useSearchAppearanceMeta.js
+++ b/frontend/src/useSearchAppearanceMeta.js
@@ -3,8 +3,8 @@ import { PRIMARY_SITELINKS } from "./primarySitelinks.js";
 
 const PUBLIC_META = {
   "/": {
-    title: "Boasted | Career Proof, Resume Builder & Interview Practice",
-    description: "Boasted helps people across industries turn everyday wins into reusable career proof for resumes, interviews, reviews, promotions, portfolios, certifications, and their next opportunity.",
+    title: "Boasted: Save It. Prove It. Use It.",
+    description: "Boasted helps you save your work, wins, projects, skills, and proof in one place, then reuse them for jobs, reviews, promotions, interviews, scholarships, and more.",
   },
   "/login": {
     title: "Sign In to Boasted | Career Proof",
@@ -69,7 +69,7 @@ const PUBLIC_META = {
 };
 
 const NOINDEX_PREFIXES = ["/app"];
-const NOINDEX_PATHS = new Set(["/upgrade", "/verify-receipt"]);
+const NOINDEX_PATHS = new Set(["/login", "/register", "/upgrade", "/verify-receipt"]);
 const OFFICIAL_LOGO_URL = "https://boasted.io/boasted-logo-192.png";
 
 function ensureMeta(selector, attributes) {
@@ -159,14 +159,17 @@ export default function useSearchAppearanceMeta(path) {
           "@id": "https://boasted.io/#website",
           url: "https://boasted.io/",
           name: "Boasted",
-          alternateName: ["Boasted", "boasted.io"],
+          alternateName: ["Boasted.io", "Boasted Career Proof"],
+          description: "Boasted helps people save meaningful work and turn it into reusable career proof.",
           publisher: { "@id": "https://boasted.io/#organization" },
         },
         {
           "@type": "Organization",
           "@id": "https://boasted.io/#organization",
           name: "Boasted",
+          alternateName: ["Boasted.io", "Boasted Career Proof"],
           url: "https://boasted.io/",
+          description: "Boasted is career evidence software for capturing accomplishments, outcomes, skills, and proof so people can reuse them when opportunities arrive.",
           logo: {
             "@type": "ImageObject",
             url: OFFICIAL_LOGO_URL,


### PR DESCRIPTION
## Why
Google has indexed `https://boasted.io/`, but the bare branded query **boasted** is still dominated by dictionary results and the site does not yet surface with a strong branded result. This PR tightens the signals Google uses for site name, favicon, title/snippet, and automated sitelinks.

## What changes
- makes the homepage title explicitly brand-led: **Boasted: Save It. Prove It. Use It.**
- makes the homepage description start with and clearly define Boasted
- strengthens static `WebSite` and `Organization` structured data with `Boasted.io` as an alternate brand name
- keeps the approved 192×192 Boasted logo as the primary raster favicon/search icon candidate, with 48×48 and SVG fallbacks
- adds an explicit static `googlebot` index directive on the homepage
- focuses the six primary sitelink candidates on real product pages:
  - Resume Builder
  - Interview Preparation
  - Impact Receipts
  - Career Portfolio
  - How It Works
  - Pricing
- removes `/login` and `/register` from the public sitemap
- marks login/register noindex at runtime and in generated static route shells so auth pages do not compete with product pages
- updates the search-quality regression gate to enforce the new branded-search contract

## Important expectation
Google controls whether and when a favicon, site name, and sitelinks are shown. These changes make Boasted eligible and provide stronger signals, but they cannot force the Docker-style result immediately. Google still needs to recrawl/reprocess the site and build confidence in the new brand/domain.

## Concurrency safety
Created from current `main` after the favicon/social-card work and isolated on `fix/branded-search-appearance`. Scope is limited to search metadata, sitemap/sitelink configuration, and the static route SEO generator/test.