### PR TITLE
Connect Boasted entity graph to founder profiles

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -64,7 +64,19 @@
             "url": "https://boasted.io/",
             "email": "mailto:Tobias.scott@boasted.io",
             "description": "Boasted is career evidence software for capturing accomplishments, outcomes, skills, and proof so people can reuse them when opportunities arrive.",
+            "founder": { "@id": "https://boasted.io/#founder" },
             "logo": { "@id": "https://boasted.io/#logo" }
+          },
+          {
+            "@type": "Person",
+            "@id": "https://boasted.io/#founder",
+            "name": "Tobias Scott",
+            "url": "https://tcs-portfolio.netlify.app/",
+            "jobTitle": "Founder",
+            "sameAs": [
+              "https://github.com/mergemaven11",
+              "https://www.linkedin.com/in/tobias-scott-he-him-b3572751/"
+            ]
           },
           {
             "@type": "WebSite",

--- a/frontend/src/useSearchAppearanceMeta.js
+++ b/frontend/src/useSearchAppearanceMeta.js
@@ -170,6 +170,7 @@ export default function useSearchAppearanceMeta(path) {
           alternateName: ["Boasted.io", "Boasted Career Proof"],
           url: "https://boasted.io/",
           description: "Boasted is career evidence software for capturing accomplishments, outcomes, skills, and proof so people can reuse them when opportunities arrive.",
+          founder: { "@id": "https://boasted.io/#founder" },
           logo: {
             "@type": "ImageObject",
             url: OFFICIAL_LOGO_URL,
@@ -177,6 +178,17 @@ export default function useSearchAppearanceMeta(path) {
             height: 192,
           },
           image: OFFICIAL_LOGO_URL,
+        },
+        {
+          "@type": "Person",
+          "@id": "https://boasted.io/#founder",
+          name: "Tobias Scott",
+          url: "https://tcs-portfolio.netlify.app/",
+          jobTitle: "Founder",
+          sameAs: [
+            "https://github.com/mergemaven11",
+            "https://www.linkedin.com/in/tobias-scott-he-him-b3572751/",
+          ],
         },
         {
           "@type": "ItemList",


### PR DESCRIPTION
## Why
Boasted now has public founder/brand references from Tobias's GitHub profile and engineering portfolio. The site's own structured data should express the same relationship so search engines can connect the brand, product, founder, and established public profiles consistently.

## What changes
- adds a `Person` entity for Tobias Scott to the static homepage JSON-LD;
- connects `Organization.founder` to that Person entity;
- links the founder entity to the public engineering portfolio, GitHub profile, and LinkedIn profile;
- mirrors the founder relationship in the runtime search-appearance schema so static and rendered structured data agree.

No visible UI or product behavior changes.