### PR TITLE
Harden auth with server-managed idle sessions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,15 @@
 # Backend
 MONGO_URL=mongodb://mongo:27017
 JWT_SECRET=replace-with-a-long-random-secret
+# JWT signature lifetime. Server-managed session checks below can invalidate a
+# token earlier for inactivity, logout, password reset, or absolute expiry.
 ACCESS_TOKEN_EXPIRE_MINUTES=1440
+# Authenticated sessions expire after 60 minutes without a protected API request.
+AUTH_SESSION_IDLE_MINUTES=60
+# Sessions can never remain active beyond this absolute lifetime.
+AUTH_SESSION_ABSOLUTE_DAYS=7
+# Avoid writing last_seen_at on every request while keeping inactivity accurate.
+AUTH_SESSION_TOUCH_SECONDS=60
 FRONTEND_URL=http://localhost:5173
 
 # Education opportunity discovery

--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -10,6 +10,7 @@ from fastapi.security import OAuth2PasswordBearer
 from jose import JWTError, jwt
 from passlib.context import CryptContext
 
+from app.auth_sessions import validate_and_touch_auth_session
 from app.database import users_collection
 from app.plans import get_entitlements_for_user, get_plan_for_user
 
@@ -26,31 +27,12 @@ oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/login")
 
 
 def _password_fits_bcrypt(password: str) -> bool:
-    """Check whether a password fits bcrypt's 72-byte input limit.
-
-    Args:
-        password: Plain-text password to measure after UTF-8 encoding.
-
-    Returns:
-        True when the encoded password is at most 72 bytes.
-    """
+    """Check whether a password fits bcrypt's 72-byte input limit."""
     return len(password.encode("utf-8")) <= MAX_BCRYPT_PASSWORD_BYTES
 
 
 def hash_password(password: str) -> str:
-    """Hash a Boasted password with the configured bcrypt context.
-
-    Args:
-        password: Plain-text password supplied during account creation or
-            password reset.
-
-    Returns:
-        Encoded bcrypt password hash suitable for persistence.
-
-    Raises:
-        HTTPException: If the UTF-8 encoded password exceeds bcrypt's
-            supported 72-byte limit.
-    """
+    """Hash a Boasted password with the configured bcrypt context."""
     if not _password_fits_bcrypt(password):
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
@@ -60,32 +42,14 @@ def hash_password(password: str) -> str:
 
 
 def verify_password(plain_password: str, hashed_password: str) -> bool:
-    """Verify a candidate password against a stored bcrypt hash.
-
-    Args:
-        plain_password: Candidate plain-text password.
-        hashed_password: Persisted bcrypt password hash.
-
-    Returns:
-        True when the password matches; otherwise False. Passwords exceeding
-        bcrypt's byte limit are rejected without verification.
-    """
+    """Verify a candidate password against a stored bcrypt hash."""
     if not _password_fits_bcrypt(plain_password):
         return False
     return password_context.verify(plain_password, hashed_password)
 
 
 def create_access_token(data: dict) -> str:
-    """Create a signed Boasted access token with standard timing claims.
-
-    Args:
-        data: Claims to include in the token, typically including the user's
-            identifier as ``sub``.
-
-    Returns:
-        An HS256-signed JWT containing expiration, issue time, not-before time,
-        and a unique token identifier.
-    """
+    """Create a signed Boasted access token with standard timing claims."""
     payload = data.copy()
     now = datetime.now(timezone.utc)
     expire = now + timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
@@ -100,18 +64,35 @@ def create_access_token(data: dict) -> str:
     return jwt.encode(payload, SECRET_KEY, algorithm=ALGORITHM)
 
 
+def decode_access_token(token: str) -> dict:
+    """Decode a signed access token or raise a standard credentials error."""
+    credentials_error = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Could not validate credentials",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+    except JWTError as exc:
+        raise credentials_error from exc
+    return payload
+
+
+def get_current_session_id(token: str = Depends(oauth2_scheme)) -> str:
+    """Return the authenticated session identifier embedded in a JWT."""
+    payload = decode_access_token(token)
+    session_id = payload.get("sid")
+    if not session_id:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Session expired. Please sign in again.",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    return str(session_id)
+
+
 def serialize_user(user: dict) -> dict:
-    """Convert a MongoDB user document into the public API response shape.
-
-    Args:
-        user: MongoDB user document containing an ``_id`` and optional profile,
-            plan, entitlement, and internal-role fields.
-
-    Returns:
-        A JSON-friendly dictionary containing profile data, plan information,
-        effective entitlements, and allow-listed internal roles. Password hashes
-        and other authentication secrets are intentionally excluded.
-    """
+    """Convert a MongoDB user document into the public API response shape."""
     return {
         "id": str(user["_id"]),
         "name": user.get("name", ""),
@@ -150,16 +131,10 @@ def serialize_user(user: dict) -> dict:
 async def get_current_user(token: str = Depends(oauth2_scheme)) -> dict:
     """Resolve and return the authenticated user for a bearer token.
 
-    Args:
-        token: OAuth2 bearer token injected by FastAPI.
-
-    Returns:
-        The matching MongoDB user document.
-
-    Raises:
-        HTTPException: If the token is missing required claims, cannot be
-            decoded, contains an invalid MongoDB identifier, or references a
-            user that no longer exists.
+    A valid signature is necessary but not sufficient. Every access token must
+    also reference an active server-side session. This enables inactivity
+    expiry, logout revocation, and password-reset revocation without waiting for
+    the JWT's cryptographic expiration time.
     """
     credentials_error = HTTPException(
         status_code=status.HTTP_401_UNAUTHORIZED,
@@ -167,16 +142,23 @@ async def get_current_user(token: str = Depends(oauth2_scheme)) -> dict:
         headers={"WWW-Authenticate": "Bearer"},
     )
 
-    try:
-        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
-        user_id: str | None = payload.get("sub")
-        if user_id is None:
-            raise credentials_error
-    except JWTError:
+    payload = decode_access_token(token)
+    user_id = payload.get("sub")
+    session_id = payload.get("sid")
+    if not user_id or not session_id:
         raise credentials_error
+    user_id = str(user_id)
+    session_id = str(session_id)
 
     if not ObjectId.is_valid(user_id):
         raise credentials_error
+
+    if not validate_and_touch_auth_session(session_id, user_id):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Session expired. Please sign in again.",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
 
     user = users_collection.find_one({"_id": ObjectId(user_id)})
     if user is None:

--- a/backend/app/auth_routes.py
+++ b/backend/app/auth_routes.py
@@ -10,7 +10,19 @@ from fastapi import APIRouter, Depends, HTTPException
 from fastapi.security import OAuth2PasswordRequestForm
 from pydantic import BaseModel, EmailStr, Field, field_validator
 
-from app.auth import create_access_token, get_current_user, hash_password, serialize_user, verify_password
+from app.auth import (
+    create_access_token,
+    get_current_session_id,
+    get_current_user,
+    hash_password,
+    serialize_user,
+    verify_password,
+)
+from app.auth_sessions import (
+    create_auth_session,
+    revoke_all_auth_sessions,
+    revoke_auth_session,
+)
 from app.database import users_collection
 from app.email_templates import build_email_verification_html, build_password_reset_html
 
@@ -163,6 +175,17 @@ def _hash_token(token: str) -> str:
     return hashlib.sha256(token.encode("utf-8")).hexdigest()
 
 
+def _authenticated_response(user: dict) -> dict:
+    """Create a revocable session and issue its signed access token."""
+    user_id = str(user["_id"])
+    session_id = create_auth_session(user_id)
+    return {
+        "access_token": create_access_token({"sub": user_id, "sid": session_id}),
+        "token_type": "bearer",
+        "user": serialize_user(user),
+    }
+
+
 async def _send_email(to_email, subject, html, from_value):
     if not RESEND_API_KEY:
         raise HTTPException(status_code=503, detail="Email delivery is not configured yet.")
@@ -278,7 +301,7 @@ def confirm_email_verification(payload: EmailVerificationConfirm):
         {"$set": {"email_verified_at": datetime.now(timezone.utc).isoformat(), "email_verification_required": False}, "$unset": {"email_verification_token_hash": "", "email_verification_expires_at": ""}},
     )
     updated = users_collection.find_one({"_id": user["_id"]})
-    return {"access_token": create_access_token({"sub": str(user["_id"])}), "token_type": "bearer", "user": serialize_user(updated)}
+    return _authenticated_response(updated)
 
 
 @router.post("/login")
@@ -289,7 +312,18 @@ def login_user(form_data: OAuth2PasswordRequestForm = Depends()):
         raise HTTPException(status_code=401, detail="Invalid email or password")
     if user.get("email_verification_required", False) and not user.get("email_verified_at"):
         raise HTTPException(status_code=403, detail="Please verify your email before signing in.")
-    return {"access_token": create_access_token({"sub": str(user["_id"])}), "token_type": "bearer", "user": serialize_user(user)}
+    return _authenticated_response(user)
+
+
+@router.post("/logout")
+def logout_user(
+    current_user: dict = Depends(get_current_user),
+    session_id: str = Depends(get_current_session_id),
+):
+    """Revoke the caller's active server-side session."""
+    del current_user
+    revoke_auth_session(session_id, "logout")
+    return {"message": "Signed out."}
 
 
 @router.post("/password-reset/request")
@@ -321,7 +355,8 @@ def confirm_password_reset(payload: PasswordResetConfirm):
     if expires < datetime.now(timezone.utc):
         raise HTTPException(status_code=400, detail="This reset link is invalid or expired.")
     users_collection.update_one({"_id": user["_id"]}, {"$set": {"hashed_password": hash_password(payload.password)}, "$unset": {"password_reset_token_hash": "", "password_reset_expires_at": ""}})
-    return {"message": "Password updated. You can now sign in."}
+    revoke_all_auth_sessions(str(user["_id"]), "password_reset")
+    return {"message": "Password updated. All existing sessions were signed out. You can now sign in."}
 
 
 @router.get("/me")

--- a/backend/app/auth_sessions.py
+++ b/backend/app/auth_sessions.py
@@ -1,0 +1,125 @@
+"""Server-managed authentication sessions for Boasted.
+
+JWTs prove that a request was signed by Boasted. Session records add the
+server-side controls a stateless JWT cannot provide on its own: inactivity
+expiry, absolute expiry, logout revocation, and account-wide revocation after a
+password reset or other security event.
+"""
+
+from datetime import datetime, timedelta, timezone
+import os
+import secrets
+
+from app.database import auth_sessions_collection
+
+AUTH_SESSION_IDLE_MINUTES = int(os.getenv("AUTH_SESSION_IDLE_MINUTES", "60"))
+AUTH_SESSION_ABSOLUTE_DAYS = int(os.getenv("AUTH_SESSION_ABSOLUTE_DAYS", "7"))
+AUTH_SESSION_TOUCH_SECONDS = int(os.getenv("AUTH_SESSION_TOUCH_SECONDS", "60"))
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _as_utc(value) -> datetime | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            return value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc)
+    if isinstance(value, str):
+        try:
+            parsed = datetime.fromisoformat(value)
+        except ValueError:
+            return None
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc)
+    return None
+
+
+def create_auth_session(user_id: str) -> str:
+    """Create and persist a revocable session for one authenticated user."""
+    now = _utcnow()
+    session_id = secrets.token_urlsafe(32)
+    auth_sessions_collection.insert_one(
+        {
+            "_id": session_id,
+            "user_id": str(user_id),
+            "created_at": now,
+            "last_seen_at": now,
+            "expires_at": now + timedelta(days=AUTH_SESSION_ABSOLUTE_DAYS),
+            "revoked_at": None,
+            "revoked_reason": None,
+        }
+    )
+    return session_id
+
+
+def validate_and_touch_auth_session(session_id: str, user_id: str) -> bool:
+    """Validate idle/absolute expiry and touch recent activity.
+
+    Returns False for unknown, revoked, idle-expired, or absolute-expired
+    sessions. Expired sessions are marked revoked so subsequent checks are
+    cheap and auditable.
+    """
+    if not session_id:
+        return False
+
+    session = auth_sessions_collection.find_one(
+        {"_id": session_id, "user_id": str(user_id)}
+    )
+    if not session or session.get("revoked_at"):
+        return False
+
+    now = _utcnow()
+    expires_at = _as_utc(session.get("expires_at"))
+    last_seen_at = _as_utc(session.get("last_seen_at"))
+    if not expires_at or not last_seen_at:
+        revoke_auth_session(session_id, "invalid_session_record")
+        return False
+
+    if expires_at <= now:
+        revoke_auth_session(session_id, "absolute_timeout")
+        return False
+
+    if last_seen_at + timedelta(minutes=AUTH_SESSION_IDLE_MINUTES) <= now:
+        revoke_auth_session(session_id, "idle_timeout")
+        return False
+
+    if (now - last_seen_at).total_seconds() >= AUTH_SESSION_TOUCH_SECONDS:
+        auth_sessions_collection.update_one(
+            {"_id": session_id, "revoked_at": None},
+            {"$set": {"last_seen_at": now}},
+        )
+    return True
+
+
+def revoke_auth_session(session_id: str, reason: str = "logout") -> None:
+    """Revoke one session without deleting its audit trail."""
+    if not session_id:
+        return
+    auth_sessions_collection.update_one(
+        {"_id": session_id, "revoked_at": None},
+        {
+            "$set": {
+                "revoked_at": _utcnow(),
+                "revoked_reason": reason,
+            }
+        },
+    )
+
+
+def revoke_all_auth_sessions(user_id: str, reason: str) -> int:
+    """Revoke every active session for a user and return the affected count."""
+    result = auth_sessions_collection.update_many(
+        {"user_id": str(user_id), "revoked_at": None},
+        {
+            "$set": {
+                "revoked_at": _utcnow(),
+                "revoked_reason": reason,
+            }
+        },
+    )
+    return int(result.modified_count)

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -9,6 +9,7 @@ db = client["bragstack"]
 
 entries_collection = db["entries"]
 users_collection = db["users"]
+auth_sessions_collection = db["auth_sessions"]
 impact_receipts_collection = db["impact_receipts"]
 receipt_verification_requests_collection = db["receipt_verification_requests"]
 packet_export_audit_collection = db["packet_export_audit"]

--- a/backend/app/oauth_routes.py
+++ b/backend/app/oauth_routes.py
@@ -11,6 +11,7 @@ from fastapi.responses import RedirectResponse
 
 from app.auth import create_access_token
 from app.auth_routes import PRIVACY_VERSION, TERMS_VERSION
+from app.auth_sessions import create_auth_session
 from app.database import users_collection
 
 router = APIRouter(prefix="/auth", tags=["auth"])
@@ -174,7 +175,9 @@ def _find_or_create_oauth_user(
 
 
 def _frontend_success_redirect(user: dict) -> RedirectResponse:
-    token = create_access_token({"sub": str(user["_id"])})
+    user_id = str(user["_id"])
+    session_id = create_auth_session(user_id)
+    token = create_access_token({"sub": user_id, "sid": session_id})
     return RedirectResponse(
         url=f"{FRONTEND_URL}/login#oauth_token={token}",
         status_code=status.HTTP_302_FOUND,

--- a/backend/tests/test_auth_sessions.py
+++ b/backend/tests/test_auth_sessions.py
@@ -1,0 +1,146 @@
+"""Server-managed authentication session tests."""
+
+from datetime import datetime, timedelta, timezone
+
+import mongomock
+from bson import ObjectId
+from fastapi.testclient import TestClient
+from jose import jwt
+
+import app.auth as auth
+import app.auth_routes as auth_routes
+import app.auth_sessions as auth_sessions
+from app.main import app
+
+
+client = TestClient(app)
+
+
+def _mock_auth_store(monkeypatch):
+    mock_client = mongomock.MongoClient()
+    database = mock_client["boasted_auth_test"]
+    users = database["users"]
+    sessions = database["auth_sessions"]
+    monkeypatch.setattr(auth_routes, "users_collection", users)
+    monkeypatch.setattr(auth, "users_collection", users)
+    monkeypatch.setattr(auth_sessions, "auth_sessions_collection", sessions)
+    return users, sessions
+
+
+def _insert_verified_user(users, email="person@example.com", password="secure-pass-123"):
+    user_id = ObjectId()
+    users.insert_one(
+        {
+            "_id": user_id,
+            "name": "Session Person",
+            "email": email,
+            "hashed_password": auth.hash_password(password),
+            "email_verification_required": False,
+            "email_verified_at": datetime.now(timezone.utc).isoformat(),
+            "public_slug": "session-person-test",
+        }
+    )
+    return user_id
+
+
+def _login(email="person@example.com", password="secure-pass-123"):
+    response = client.post(
+        "/auth/login",
+        data={"username": email, "password": password},
+    )
+    assert response.status_code == 200
+    return response.json()["access_token"]
+
+
+def _auth_headers(token):
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_login_issues_session_bound_token(monkeypatch):
+    users, sessions = _mock_auth_store(monkeypatch)
+    user_id = _insert_verified_user(users)
+
+    token = _login()
+    payload = jwt.decode(token, auth.SECRET_KEY, algorithms=[auth.ALGORITHM])
+
+    assert payload["sub"] == str(user_id)
+    assert payload["sid"]
+    stored = sessions.find_one({"_id": payload["sid"]})
+    assert stored is not None
+    assert stored["user_id"] == str(user_id)
+    assert stored["revoked_at"] is None
+
+    current = client.get("/auth/me", headers=_auth_headers(token))
+    assert current.status_code == 200
+    assert current.json()["email"] == "person@example.com"
+
+
+def test_idle_session_is_rejected_after_sixty_minutes(monkeypatch):
+    users, sessions = _mock_auth_store(monkeypatch)
+    _insert_verified_user(users)
+    token = _login()
+    payload = jwt.decode(token, auth.SECRET_KEY, algorithms=[auth.ALGORITHM])
+
+    sessions.update_one(
+        {"_id": payload["sid"]},
+        {"$set": {"last_seen_at": datetime.now(timezone.utc) - timedelta(minutes=61)}},
+    )
+
+    response = client.get("/auth/me", headers=_auth_headers(token))
+    assert response.status_code == 401
+    assert "Session expired" in response.json()["detail"]
+    stored = sessions.find_one({"_id": payload["sid"]})
+    assert stored["revoked_reason"] == "idle_timeout"
+
+
+def test_logout_revokes_current_session_server_side(monkeypatch):
+    users, sessions = _mock_auth_store(monkeypatch)
+    _insert_verified_user(users)
+    token = _login()
+    payload = jwt.decode(token, auth.SECRET_KEY, algorithms=[auth.ALGORITHM])
+
+    logout = client.post("/auth/logout", headers=_auth_headers(token))
+    assert logout.status_code == 200
+    assert sessions.find_one({"_id": payload["sid"]})["revoked_reason"] == "logout"
+
+    after_logout = client.get("/auth/me", headers=_auth_headers(token))
+    assert after_logout.status_code == 401
+
+
+def test_password_reset_revokes_all_existing_sessions(monkeypatch):
+    users, sessions = _mock_auth_store(monkeypatch)
+    user_id = _insert_verified_user(users)
+    first = _login()
+    second = _login()
+    assert sessions.count_documents({"user_id": str(user_id), "revoked_at": None}) == 2
+
+    raw_reset_token = "reset-token-with-enough-characters-123456789"
+    users.update_one(
+        {"_id": user_id},
+        {
+            "$set": {
+                "password_reset_token_hash": auth_routes._hash_token(raw_reset_token),
+                "password_reset_expires_at": (datetime.now(timezone.utc) + timedelta(minutes=10)).isoformat(),
+            }
+        },
+    )
+
+    response = client.post(
+        "/auth/password-reset/confirm",
+        json={"token": raw_reset_token, "password": "new-secure-pass-456"},
+    )
+    assert response.status_code == 200
+    assert sessions.count_documents({"user_id": str(user_id), "revoked_at": None}) == 0
+    assert sessions.count_documents({"user_id": str(user_id), "revoked_reason": "password_reset"}) == 2
+
+    assert client.get("/auth/me", headers=_auth_headers(first)).status_code == 401
+    assert client.get("/auth/me", headers=_auth_headers(second)).status_code == 401
+
+
+def test_legacy_token_without_session_id_is_rejected(monkeypatch):
+    users, _ = _mock_auth_store(monkeypatch)
+    user_id = _insert_verified_user(users)
+    legacy_token = auth.create_access_token({"sub": str(user_id)})
+
+    response = client.get("/auth/me", headers=_auth_headers(legacy_token))
+    assert response.status_code == 401

--- a/backend/tests/test_boasted_staged_domain_migration.py
+++ b/backend/tests/test_boasted_staged_domain_migration.py
@@ -54,6 +54,7 @@ def test_boasted_frontend_keeps_legacy_github_callback(monkeypatch):
 
 def test_oauth_success_returns_existing_user_to_boasted(monkeypatch):
     monkeypatch.setattr(oauth_routes, "FRONTEND_URL", "https://boasted.io")
+    monkeypatch.setattr(oauth_routes, "create_auth_session", lambda _user_id: "test-session")
     monkeypatch.setattr(oauth_routes, "create_access_token", lambda _payload: "test-token")
 
     response = oauth_routes._frontend_success_redirect({"_id": "existing-user-id"})

--- a/frontend/src/AppSidebar.jsx
+++ b/frontend/src/AppSidebar.jsx
@@ -1,7 +1,9 @@
 import { useEffect, useState } from "react";
 import { BarChart3, BrainCircuit, Building2, ChevronDown, FileCheck2, FileText, GraduationCap, Home, LifeBuoy, ListChecks, LogOut, Menu, ReceiptText, Settings, ShieldCheck, UserRound, Users, Video, X } from "lucide-react";
 import { getCurrentUser } from "./api";
+import { signOutAndRedirect } from "./authSessionApi.js";
 import { getOpsAccess } from "./opsApi";
+import { installAuthIdleGuard } from "./sessionIdleGuard.js";
 import "./AppShell.css";
 import "./SidebarCollapsible.css";
 
@@ -24,8 +26,9 @@ function AppSidebar() {
   const path = window.location.pathname; const search = window.location.search; const hash = window.location.hash;
   const careerToolsActive = path === "/app/resume-builder" || path === "/app/interview-practice" || path === "/app/reports";
   const [careerToolsOpen, setCareerToolsOpen] = useState(() => careerToolsActive || localStorage.getItem("bragstack_career_tools_nav") !== "closed");
+  useEffect(() => installAuthIdleGuard(), []);
   useEffect(() => { let mounted = true; (async () => { try { const data = await getCurrentUser(); if (!mounted) return; setUser(data); try { const access = await getOpsAccess(); if (mounted) setInternalAccess(access?.authorized ? access : null); } catch { if (mounted) setInternalAccess(null); } } catch (error) { if (error.response?.status === 401) { localStorage.removeItem("bragstack_token"); window.location.assign("/login"); } } })(); return () => { mounted = false; }; }, []);
-  function logout() { localStorage.removeItem("bragstack_token"); window.location.assign("/login"); }
+  async function logout() { await signOutAndRedirect(); }
   function toolIsActive(href) { const target = new URL(href, window.location.origin); return path === target.pathname && search === target.search && hash === target.hash; }
   function toggleCareerTools(event) { const open = event.currentTarget.open; setCareerToolsOpen(open); localStorage.setItem("bragstack_career_tools_nav", open ? "open" : "closed"); }
   const isPro = Boolean(user?.entitlements?.advanced_reports);

--- a/frontend/src/authSessionApi.js
+++ b/frontend/src/authSessionApi.js
@@ -1,0 +1,29 @@
+import axios from "axios";
+
+function getApiBaseUrl() {
+  if (window.location.hostname.endsWith(".app.github.dev")) return "/api";
+  return import.meta.env.VITE_API_BASE_URL || import.meta.env.VITE_API_URL || "http://localhost:8000";
+}
+
+export async function revokeCurrentSession() {
+  const token = localStorage.getItem("bragstack_token");
+  if (!token) return;
+  await axios.post(
+    `${getApiBaseUrl()}/auth/logout`,
+    null,
+    { headers: { Authorization: `Bearer ${token}` } },
+  );
+}
+
+export async function signOutAndRedirect() {
+  try {
+    await revokeCurrentSession();
+  } catch {
+    // The local credential is removed even if the API is temporarily
+    // unreachable. A valid server response revokes the session immediately;
+    // otherwise the server-side inactivity/absolute timeout still applies.
+  } finally {
+    localStorage.removeItem("bragstack_token");
+    window.location.assign("/login");
+  }
+}

--- a/frontend/src/sessionIdleGuard.js
+++ b/frontend/src/sessionIdleGuard.js
@@ -1,0 +1,90 @@
+import { signOutAndRedirect } from "./authSessionApi.js";
+
+const DEFAULT_IDLE_MINUTES = 60;
+const LAST_ACTIVITY_KEY = "boasted_last_user_activity_v1";
+const ACTIVITY_TOKEN_KEY = "boasted_activity_token_id_v1";
+const ACTIVITY_WRITE_THROTTLE_MS = 15_000;
+const CHECK_INTERVAL_MS = 30_000;
+
+function idleTimeoutMs() {
+  const configured = Number(import.meta.env.VITE_AUTH_IDLE_MINUTES || DEFAULT_IDLE_MINUTES);
+  const minutes = Number.isFinite(configured) && configured > 0 ? configured : DEFAULT_IDLE_MINUTES;
+  return minutes * 60_000;
+}
+
+function tokenMarker(token) {
+  const signature = String(token || "").split(".")[2] || String(token || "");
+  return signature.slice(-24);
+}
+
+function readLastActivity() {
+  const value = Number(localStorage.getItem(LAST_ACTIVITY_KEY));
+  return Number.isFinite(value) && value > 0 ? value : null;
+}
+
+function writeLastActivity(timestamp = Date.now()) {
+  localStorage.setItem(LAST_ACTIVITY_KEY, String(timestamp));
+}
+
+export function clearAuthActivityTimestamp() {
+  localStorage.removeItem(LAST_ACTIVITY_KEY);
+  localStorage.removeItem(ACTIVITY_TOKEN_KEY);
+}
+
+export function installAuthIdleGuard() {
+  const token = localStorage.getItem("bragstack_token");
+  if (!token) return () => {};
+
+  const marker = tokenMarker(token);
+  const previousMarker = localStorage.getItem(ACTIVITY_TOKEN_KEY);
+  if (!previousMarker || previousMarker !== marker) {
+    localStorage.setItem(ACTIVITY_TOKEN_KEY, marker);
+    writeLastActivity();
+  }
+
+  const timeoutMs = idleTimeoutMs();
+  let lastWrite = readLastActivity();
+  if (!lastWrite) {
+    lastWrite = Date.now();
+    writeLastActivity(lastWrite);
+  }
+  let signingOut = false;
+
+  const expireIfIdle = () => {
+    if (signingOut) return true;
+    const lastActivity = readLastActivity() || lastWrite || Date.now();
+    if (Date.now() - lastActivity < timeoutMs) return false;
+    signingOut = true;
+    void signOutAndRedirect();
+    return true;
+  };
+
+  const markActivity = () => {
+    if (expireIfIdle()) return;
+    const now = Date.now();
+    if (now - (lastWrite || 0) < ACTIVITY_WRITE_THROTTLE_MS) return;
+    lastWrite = now;
+    writeLastActivity(now);
+  };
+
+  const checkOnFocus = () => { expireIfIdle(); };
+  const checkOnVisibility = () => {
+    if (document.visibilityState === "visible") expireIfIdle();
+  };
+
+  const activityEvents = ["pointerdown", "keydown", "touchstart", "scroll"];
+  activityEvents.forEach((eventName) => window.addEventListener(eventName, markActivity, { passive: true }));
+  window.addEventListener("focus", checkOnFocus);
+  document.addEventListener("visibilitychange", checkOnVisibility);
+  const intervalId = window.setInterval(expireIfIdle, CHECK_INTERVAL_MS);
+
+  // Catch a tab restored after sleeping before treating the restore as activity.
+  expireIfIdle();
+
+  return () => {
+    activityEvents.forEach((eventName) => window.removeEventListener(eventName, markActivity));
+    window.removeEventListener("focus", checkOnFocus);
+    document.removeEventListener("visibilitychange", checkOnVisibility);
+    window.clearInterval(intervalId);
+  };
+}


### PR DESCRIPTION
## Why
Boasted currently stores a bearer JWT in `localStorage` and allows it to remain valid for up to 24 hours. That means a user can leave an authenticated tab for an hour and resume it without a server-side inactivity decision, and client-side sign-out cannot revoke an already-issued JWT.

## What this PR adds
- server-managed auth sessions stored in MongoDB;
- **60-minute inactivity timeout** enforced server-side;
- **7-day absolute session lifetime** as a hard ceiling;
- session IDs (`sid`) embedded in newly issued JWTs;
- every protected request validates the JWT *and* its active session record;
- a real `POST /auth/logout` endpoint that revokes the current session;
- password reset revokes **all existing sessions** for the account;
- Google/GitHub OAuth sign-ins now create revocable sessions too;
- legacy pre-session JWTs are intentionally rejected once this deploy lands, forcing a one-time fresh sign-in;
- authenticated UI installs a one-hour idle guard so an already-open Settings/App tab is redirected after inactivity instead of leaving stale private UI visible;
- sign-out attempts server revocation before clearing the browser token;
- regression tests cover session-bound login, idle expiry, server logout, password-reset revocation, and rejection of legacy tokens;
- environment defaults document the 60-minute idle and 7-day absolute session policy.

## Security model
This is the safe first production step. It fixes the immediate inactivity/revocation gap without making Boasted depend on cross-site refresh cookies while the API still lives on the legacy `api.usebragstack.com` hostname.

A follow-up should move the API to a same-site Boasted hostname (for example `api.boasted.io`) and then migrate bearer-token storage out of `localStorage` to short-lived access tokens + Secure/HttpOnly refresh cookies. Doing that *before* the API is same-site would risk browser third-party-cookie failures.

## Expected user-visible behavior
- An authenticated tab left unused for ~60 minutes signs out.
- Returning to a stale `/app/settings` tab no longer silently resumes a valid session.
- Clicking Sign out revokes that session on the server.
- Resetting a password signs out every existing session.
- Existing users will need to sign in once after deployment because old JWTs have no server session ID.

## Rollout note
No new production environment variables are required for the secure defaults: `AUTH_SESSION_IDLE_MINUTES=60`, `AUTH_SESSION_ABSOLUTE_DAYS=7`, and `AUTH_SESSION_TOUCH_SECONDS=60` are built in. They are also documented in `.env.example`.