### PR TITLE
Harden public-repo secret protections

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,58 @@
+name: Secret Scan
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+  schedule:
+    - cron: "17 4 * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  gitleaks:
+    name: Scan all refs for secrets
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout full history
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Fetch every branch and tag
+        run: git fetch --force --prune --tags origin '+refs/heads/*:refs/remotes/origin/*'
+
+      - name: Run full-history Gitleaks scan
+        run: |
+          docker run --rm \
+            -e GIT_CONFIG_COUNT=1 \
+            -e GIT_CONFIG_KEY_0=safe.directory \
+            -e GIT_CONFIG_VALUE_0=/repo \
+            -v "$PWD:/repo" \
+            ghcr.io/gitleaks/gitleaks:v8.30.1 \
+            git --redact --no-banner --exit-code 0 \
+            --config /repo/.gitleaks.toml \
+            --report-format json --report-path /repo/gitleaks-report.json /repo
+
+      - name: Report sanitized findings
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          report_path = Path("gitleaks-report.json")
+          findings = json.loads(report_path.read_text()) if report_path.exists() else []
+          print(f"Gitleaks findings: {len(findings)}")
+          for index, finding in enumerate(findings, 1):
+              rule = finding.get("RuleID") or finding.get("rule_id") or "unknown-rule"
+              file_name = finding.get("File") or finding.get("file") or "unknown-file"
+              commit = finding.get("Commit") or finding.get("commit") or "unknown-commit"
+              line = finding.get("StartLine") or finding.get("start_line") or "?"
+              print(f"{index}. rule={rule} file={file_name} commit={commit} line={line}")
+          if findings:
+              raise SystemExit(1)
+          PY

--- a/.gitignore
+++ b/.gitignore
@@ -1,34 +1,62 @@
+# Python
 __pycache__/
 *.pyc
-.env
 .venv/
-.idea/
-.vscode/
-.DS_Store
 
+# Environment files and secrets
+.env
+.env.*
+!.env.example
+!.env.*.example
+.envrc
+.direnv/
+*.pem
+*.key
+*.p8
+*.p12
+*.pfx
+*.jks
+*.keystore
+*.kdbx
+*.mobileprovision
+*.provisionprofile
+id_rsa*
+id_ed25519*
+credentials.json
+service-account*.json
+service_account*.json
+firebase-adminsdk*.json
+client_secret*.json
+secrets.json
+*.tfvars
+*.tfvars.json
+terraform.tfstate
+terraform.tfstate.*
+kubeconfig*
+*.kubeconfig
+.npmrc
+.pypirc
+.netrc
 
+# Node / frontend
 node_modules/
 dist/
-npm-debug.log*
-
-# Logs
-logs
-*.log
+dist-ssr/
+*.local
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
 lerna-debug.log*
 
-node_modules
-dist
-dist-ssr
-*.local
+# Logs
+logs/
+*.log
 
-# Editor directories and files
+# Editors / OS
 .vscode/*
 !.vscode/extensions.json
-.idea
+.idea/
 .DS_Store
 *.suo
 *.ntvs*

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,17 @@
+title = "Boasted Gitleaks configuration"
+
+[extend]
+useDefault = true
+
+[[allowlists]]
+description = "Synthetic secret fixtures used by NDA safety tests"
+condition = "AND"
+regexTarget = "line"
+paths = ['''^frontend/src/ndaSafety\.test\.js$''']
+regexes = [
+  '''-----BEGIN (?:RSA |OPENSSH )?PRIVATE KEY-----''',
+  '''AKIAABCDEFGHIJKLMNOP''',
+  '''ghp_12345678901234567890''',
+  '''xoxb-1234567890-abcdefghij''',
+  '''sk-123456789012345678901234'''
+]


### PR DESCRIPTION
## What this does
- expands `.gitignore` to block common environment, credential, private-key, package-registry, and service-account secret files
- adds a dedicated Secret Scan workflow
- fetches every branch and tag before scanning
- runs Gitleaks v8.30.1 across full reachable git history with redaction enabled
- runs on PRs, pushes to `main`, manual dispatch, and daily schedule

## Why
This is the final guardrail before making Boasted.io public. The existing repository did not show a committed `.env`, PEM key, private key, `id_rsa`, or `credentials.json` in the historical path checks performed, and high-risk OAuth/staging branches inspected so far use environment variables/placeholders rather than embedded credentials. This PR prevents the common accidental-secret paths and adds repeatable all-ref history scanning.

## CI note
The repository currently has the separate GitHub Actions runner-provisioning issue where jobs can fail before runner assignment. If this PR shows the same `runner_id=0` / no-steps pattern, that is the known infrastructure blocker rather than a Gitleaks finding.