### PR TITLE
Quiet CI noise without weakening required checks

### DIFF
--- a/.github/workflows/ci-fast.yml
+++ b/.github/workflows/ci-fast.yml
@@ -1,50 +1,29 @@
 name: CI Fast
 
 on:
-  push:
-    branches-ignore:
-      - main
-    paths:
-      - "backend/**"
-      - "frontend/**"
-      - ".github/workflows/ci-*.yml"
-      - "docs/CI_BUDGET_POLICY.md"
+  workflow_dispatch:
+    inputs:
+      scope:
+        description: "Area to validate"
+        required: true
+        default: "all"
+        type: choice
+        options:
+          - all
+          - backend
+          - frontend
 
 concurrency:
-  group: ci-fast-${{ github.ref }}
+  group: ci-fast-${{ github.ref }}-${{ inputs.scope }}
   cancel-in-progress: true
 
 permissions:
   contents: read
 
 jobs:
-  changes:
-    name: Detect changed areas
-    runs-on: ubuntu-latest
-    timeout-minutes: 2
-    outputs:
-      backend: ${{ steps.filter.outputs.backend }}
-      frontend: ${{ steps.filter.outputs.frontend }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 2
-      - id: filter
-        shell: bash
-        run: |
-          if git rev-parse HEAD^ >/dev/null 2>&1; then
-            changed_files="$(git diff --name-only HEAD^ HEAD)"
-          else
-            changed_files="$(git show --pretty='' --name-only HEAD)"
-          fi
-          printf '%s\n' "$changed_files"
-          if printf '%s\n' "$changed_files" | grep -Eq '^(backend/|\.github/workflows/ci-)'; then echo "backend=true" >> "$GITHUB_OUTPUT"; else echo "backend=false" >> "$GITHUB_OUTPUT"; fi
-          if printf '%s\n' "$changed_files" | grep -Eq '^(frontend/|\.github/workflows/ci-)'; then echo "frontend=true" >> "$GITHUB_OUTPUT"; else echo "frontend=false" >> "$GITHUB_OUTPUT"; fi
-
   backend-fast:
     name: Fast backend checks
-    needs: changes
-    if: needs.changes.outputs.backend == 'true'
+    if: inputs.scope == 'all' || inputs.scope == 'backend'
     runs-on: ubuntu-latest
     timeout-minutes: 8
     defaults:
@@ -74,8 +53,7 @@ jobs:
 
   frontend-fast:
     name: Fast frontend checks
-    needs: changes
-    if: needs.changes.outputs.frontend == 'true'
+    if: inputs.scope == 'all' || inputs.scope == 'frontend'
     runs-on: ubuntu-latest
     timeout-minutes: 8
     defaults:

--- a/.github/workflows/production-smoke.yml
+++ b/.github/workflows/production-smoke.yml
@@ -8,6 +8,10 @@ on:
     - cron: "23 */6 * * *"
   workflow_dispatch:
 
+concurrency:
+  group: production-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -17,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Check canonical and Render origins
+      - name: Check canonical production and observe Render origins
         shell: bash
         run: |
           set -uo pipefail
@@ -29,6 +33,7 @@ jobs:
           check_200() {
             local label="$1"
             local url="$2"
+            local required="${3:-true}"
             local code
 
             code="$(curl \
@@ -47,12 +52,16 @@ jobs:
 
             printf '%-24s %s %s\n' "$label" "$code" "$url"
             if [[ "$code" != "200" ]]; then
-              echo "::error title=Production smoke failed::$label returned HTTP ${code:-curl_error} for $url"
-              failures=$((failures + 1))
+              if [[ "$required" == "true" ]]; then
+                echo "::error title=Production smoke failed::$label returned HTTP ${code:-curl_error} for $url"
+                failures=$((failures + 1))
+              else
+                echo "::warning title=Origin probe failed::$label returned HTTP ${code:-curl_error} for $url"
+              fi
             fi
           }
 
-          echo "=== Canonical frontend ==="
+          echo "=== Canonical frontend (required) ==="
           check_200 "home" "https://boasted.io/"
           check_200 "resume" "https://boasted.io/resume-accomplishments"
           check_200 "interview" "https://boasted.io/interview-preparation"
@@ -65,22 +74,20 @@ jobs:
           check_200 "privacy" "https://boasted.io/privacy"
           check_200 "terms" "https://boasted.io/terms"
 
-          echo "=== Render frontend origin ==="
-          check_200 "render home" "https://bragstack.onrender.com/"
-          check_200 "render resume" "https://bragstack.onrender.com/resume-accomplishments"
-          check_200 "render receipts" "https://bragstack.onrender.com/impact-receipts"
-
-          echo "=== Canonical API ==="
+          echo "=== Canonical API (required) ==="
           check_200 "api health" "https://api.usebragstack.com/health"
           check_200 "api ready" "https://api.usebragstack.com/ready"
 
-          echo "=== Render API origin ==="
-          check_200 "render api health" "https://bragstack-api-bxf3.onrender.com/health"
-          check_200 "render api ready" "https://bragstack-api-bxf3.onrender.com/ready"
+          echo "=== Render origins (diagnostic only) ==="
+          check_200 "render home" "https://bragstack.onrender.com/" false
+          check_200 "render resume" "https://bragstack.onrender.com/resume-accomplishments" false
+          check_200 "render receipts" "https://bragstack.onrender.com/impact-receipts" false
+          check_200 "render api health" "https://bragstack-api-bxf3.onrender.com/health" false
+          check_200 "render api ready" "https://bragstack-api-bxf3.onrender.com/ready" false
 
           if (( failures > 0 )); then
-            echo "::error::$failures production smoke check(s) failed. Compare canonical vs Render-origin rows to isolate edge/domain failures from origin failures."
+            echo "::error::$failures required production smoke check(s) failed."
             exit 1
           fi
 
-          echo "All production smoke checks returned HTTP 200."
+          echo "All required production smoke checks returned HTTP 200."

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -9,6 +9,10 @@ on:
   schedule:
     - cron: "17 4 * * *"
 
+concurrency:
+  group: secret-scan-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/docs/CI_BUDGET_POLICY.md
+++ b/docs/CI_BUDGET_POLICY.md
@@ -14,7 +14,7 @@ GitHub does not expose the account billing counter directly inside ordinary repo
 
 Both repositories use the same four-tier model:
 
-1. **CI Fast** — feature-branch commits. Compile/lint and a small safety-critical deterministic test set. Superseded runs cancel automatically.
+1. **CI Fast** — manual pre-PR validation. Run backend, frontend, or both when you want a quick local-equivalent confidence check without paying for an automatic branch-push workflow. Superseded manual runs cancel automatically.
 2. **CI PR** — pull requests. Medium regression coverage. Expensive browser/container/docs work is excluded. Dependency audits run only when dependency manifests change.
 3. **CI Nightly** — scheduled heavy integration/browser/security coverage, but only when `main` changed during the prior 24 hours. A manual dispatch can force it when needed.
 4. **CI Full Validation** — manual launch-grade validation. Run this before a major production launch, store release, or other high-risk cut. Do not run it for routine commits.
@@ -23,11 +23,12 @@ Both repositories use the same four-tier model:
 
 - Never intentionally rerun a successful job just because another job failed.
 - Retry only the failed job or failed workflow jobs when GitHub supports it.
-- New commits must cancel obsolete in-progress Fast/PR runs.
+- New commits must cancel obsolete in-progress PR and secret-scan runs.
 - Use dependency caches and strict `timeout-minutes` on every paid runner job.
 - Do not run container image builds, exhaustive docs, multi-browser device QA, or full release evidence on routine commits.
 - Prefer path-aware jobs so backend-only changes do not pay for frontend work and vice versa.
 - Keep one workflow architecture in both repositories; repo-specific commands may differ, but trigger tiers and budget rules should not.
+- Production smoke tests should fail only for required canonical production endpoints. Legacy or origin probes may remain diagnostic-only so they do not create false production incidents.
 
 ## Release rule
 


### PR DESCRIPTION
## Summary
- make `CI Fast` manual-only with selectable backend/frontend/all scope, removing duplicate automatic branch-push validation when a PR already runs `CI PR`
- add concurrency cancellation to Secret Scan so superseded PR scans do not pile up
- keep canonical production routes blocking in Production Smoke, while making legacy Render-origin probes diagnostic warnings only
- add Production Smoke concurrency cancellation
- update the shared CI budget policy to match the quieter workflow architecture

## Why
Recent Boasted workflow activity is producing repeated failure notifications from overlapping branch/PR checks and scheduled diagnostics. This keeps the important PR, secret, nightly, and canonical production checks intact while reducing duplicate or legacy-origin noise.

## Intentionally unchanged
- `CI PR` remains the required pull-request regression workflow.
- `CI Nightly` is unchanged because the recent failure occurred before any job steps executed, which points away from the test commands themselves.
- Scholarship maintenance is unchanged. It already fails explicitly when `MONGO_URL` is unavailable; repository Actions secrets cannot be inspected through the current GitHub connection, so this PR does not weaken that safeguard.

## Validation notes
- CI Fast still supports the same backend deterministic suite and frontend resume/interview/safety/lint checks when manually dispatched.
- Secret Scan still runs for pull requests, pushes to main, manual dispatches, and its daily schedule.
- Production Smoke still fails for any non-200 canonical Boasted frontend route or canonical API health/readiness route. Only Render-origin probes are non-blocking.