### PR TITLE
SEO MAXX: strengthen Boasted search identity and entity signals

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -16,9 +16,8 @@
     <link rel="manifest" href="/site.webmanifest?v=4" />
     <link rel="stylesheet" href="/bragstack-polish.css" />
 
-    <title>Boasted: Save It. Prove It. Use It.</title>
-    <meta name="description" content="Boasted helps you save your work, wins, projects, skills, and proof in one place, then reuse them for jobs, reviews, promotions, interviews, scholarships, and more." />
-    <meta name="keywords" content="career proof, work accomplishments, resume builder, resume accomplishments, career portfolio, professional portfolio, job search, interview preparation, performance review, promotion packet, certification evidence, achievement tracker, brag document, career evidence, hiring, portfolio" />
+    <title>Boasted | Work Accomplishment Tracker & Career Proof</title>
+    <meta name="description" content="Boasted is a work accomplishment tracker and career proof platform. Capture wins, results, skills, and evidence, then reuse them for resumes, performance reviews, promotions, interviews, portfolios, and opportunities." />
     <meta name="author" content="Boasted" />
     <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1" />
     <meta name="googlebot" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1" />
@@ -27,8 +26,8 @@
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="Boasted" />
     <meta property="og:locale" content="en_US" />
-    <meta property="og:title" content="Boasted — Save it. Prove it. Use it." />
-    <meta property="og:description" content="Save accomplishments, projects, skills, wins, results, and proof in one place — then use them for jobs, reviews, promotions, interviews, scholarships, and more." />
+    <meta property="og:title" content="Boasted — Work Accomplishment Tracker & Career Proof" />
+    <meta property="og:description" content="Capture work accomplishments, results, skills, and evidence in one place — then reuse your career proof for resumes, reviews, promotions, interviews, portfolios, and opportunities." />
     <meta property="og:url" content="https://boasted.io/" />
     <meta property="og:image" content="https://boasted.io/boasted-social-share-card.jpg?v=1" />
     <meta property="og:image:secure_url" content="https://boasted.io/boasted-social-share-card.jpg?v=1" />
@@ -38,8 +37,8 @@
     <meta property="og:image:alt" content="Boasted — Save it. Prove it. Use it. Turn meaningful work into reusable career proof." />
 
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Boasted — Save it. Prove it. Use it." />
-    <meta name="twitter:description" content="Save accomplishments, projects, skills, wins, results, and proof in one place — then use them when opportunity shows up." />
+    <meta name="twitter:title" content="Boasted — Work Accomplishment Tracker & Career Proof" />
+    <meta name="twitter:description" content="Capture work accomplishments, results, skills, and evidence, then reuse your career proof when opportunity shows up." />
     <meta name="twitter:image" content="https://boasted.io/boasted-social-share-card.jpg?v=1" />
     <meta name="twitter:image:alt" content="Boasted — Save it. Prove it. Use it." />
 
@@ -63,9 +62,12 @@
             "alternateName": ["Boasted.io", "Boasted Career Proof"],
             "url": "https://boasted.io/",
             "email": "mailto:Tobias.scott@boasted.io",
-            "description": "Boasted is career evidence software for capturing accomplishments, outcomes, skills, and proof so people can reuse them when opportunities arrive.",
+            "description": "Boasted is a work accomplishment tracker and career proof platform for capturing accomplishments, outcomes, skills, and evidence so people can reuse them when opportunities arrive.",
             "founder": { "@id": "https://boasted.io/#founder" },
-            "logo": { "@id": "https://boasted.io/#logo" }
+            "logo": { "@id": "https://boasted.io/#logo" },
+            "sameAs": [
+              "https://github.com/mergemaven11/Boasted.io"
+            ]
           },
           {
             "@type": "Person",
@@ -85,7 +87,7 @@
             "name": "Boasted",
             "alternateName": ["Boasted.io", "Boasted Career Proof"],
             "publisher": { "@id": "https://boasted.io/#organization" },
-            "description": "Boasted helps people save meaningful work and turn it into reusable career proof for resumes, portfolios, interviews, reviews, promotions, certifications, scholarships, and career transitions.",
+            "description": "Boasted helps people track work accomplishments and turn meaningful work into reusable career proof for resumes, portfolios, interviews, reviews, promotions, certifications, scholarships, and career transitions.",
             "inLanguage": "en-US"
           },
           {
@@ -98,10 +100,10 @@
             "url": "https://boasted.io/",
             "image": "https://boasted.io/boasted-social-share-card.jpg?v=1",
             "publisher": { "@id": "https://boasted.io/#organization" },
-            "description": "Capture meaningful work and safe evidence across professions, then turn it into resume material, portfolios, interview stories, performance-review packets, promotion proof, certification evidence, and other career assets.",
+            "description": "A work accomplishment tracker and career proof platform for capturing meaningful work and safe evidence, then turning it into resume material, portfolios, interview stories, performance-review packets, promotion proof, certification evidence, and other career assets.",
             "offers": [
               { "@type": "Offer", "name": "Free", "price": "0", "priceCurrency": "USD" },
-              { "@type": "Offer", "name": "Pro", "price": "9", "priceCurrency": "USD" }
+              { "@type": "Offer", "name": "Pro early access", "price": "0", "priceCurrency": "USD" }
             ]
           }
         ]

--- a/frontend/public/sitemap.xml
+++ b/frontend/public/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://boasted.io/</loc>
-    <lastmod>2026-09-09</lastmod>
+    <lastmod>2026-09-11</lastmod>
   </url>
   <url>
     <loc>https://boasted.io/resume-accomplishments</loc>

--- a/frontend/scripts/generate-static-route-shells.mjs
+++ b/frontend/scripts/generate-static-route-shells.mjs
@@ -1,6 +1,7 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { SEO_GUIDE_LINKS, SEO_LANDING_CONTENT } from "../src/seoLandingContent.js";
 
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const FRONTEND_DIR = path.resolve(SCRIPT_DIR, "..");
@@ -199,6 +200,77 @@ function escapeHtmlAttribute(value) {
     .replaceAll(">", "&gt;");
 }
 
+function guideSchema(route, meta) {
+  const content = SEO_LANDING_CONTENT[route];
+  if (!content || (content.kind !== "guide" && content.kind !== "hub")) return null;
+
+  const canonicalUrl = `${SITE_ORIGIN}${route}`;
+  const organization = { "@id": `${SITE_ORIGIN}/#organization` };
+  const breadcrumbItems = [
+    { "@type": "ListItem", position: 1, name: "Boasted", item: `${SITE_ORIGIN}/` },
+    { "@type": "ListItem", position: 2, name: "Career Guides", item: `${SITE_ORIGIN}/guides` },
+  ];
+
+  if (content.kind === "guide") {
+    breadcrumbItems.push({ "@type": "ListItem", position: 3, name: content.eyebrow, item: canonicalUrl });
+  }
+
+  const primaryNode = content.kind === "guide"
+    ? {
+        "@type": "Article",
+        "@id": `${canonicalUrl}#article`,
+        headline: content.title,
+        description: content.description,
+        mainEntityOfPage: { "@type": "WebPage", "@id": canonicalUrl },
+        author: organization,
+        publisher: organization,
+        about: content.keywords || [],
+        isPartOf: { "@id": `${SITE_ORIGIN}/#website` },
+      }
+    : {
+        "@type": "CollectionPage",
+        "@id": canonicalUrl,
+        name: meta.title,
+        description: content.description,
+        isPartOf: { "@id": `${SITE_ORIGIN}/#website` },
+        mainEntity: {
+          "@type": "ItemList",
+          itemListElement: SEO_GUIDE_LINKS.map((guide, index) => ({
+            "@type": "ListItem",
+            position: index + 1,
+            name: guide.label,
+            url: `${SITE_ORIGIN}${guide.href}`,
+          })),
+        },
+      };
+
+  const graph = [
+    primaryNode,
+    {
+      "@type": "BreadcrumbList",
+      "@id": `${canonicalUrl}#breadcrumbs`,
+      itemListElement: breadcrumbItems,
+    },
+  ];
+
+  if (content.kind === "guide" && content.faq?.length) {
+    graph.push({
+      "@type": "FAQPage",
+      "@id": `${canonicalUrl}#faq`,
+      mainEntity: content.faq.map((item) => ({
+        "@type": "Question",
+        name: item.question,
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: item.answer,
+        },
+      })),
+    });
+  }
+
+  return JSON.stringify({ "@context": "https://schema.org", "@graph": graph }).replaceAll("</", "<\\/");
+}
+
 function routeShell(indexHtml, route) {
   const canonicalUrl = `${SITE_ORIGIN}${route}`;
   const meta = ROUTE_META[route];
@@ -241,6 +313,14 @@ function routeShell(indexHtml, route) {
     html = html.replace(
       /<meta name="robots" content="[^"]*"\s*\/>/,
       '<meta name="robots" content="noindex,nofollow" />',
+    );
+  }
+
+  const staticSchema = guideSchema(route, meta);
+  if (staticSchema) {
+    html = html.replace(
+      "</head>",
+      `    <script id="boasted-static-content-schema" type="application/ld+json">${staticSchema}</script>\n  </head>`,
     );
   }
 

--- a/frontend/scripts/verify-search-appearance.mjs
+++ b/frontend/scripts/verify-search-appearance.mjs
@@ -87,6 +87,7 @@ assert.match(seoLandingPages, /meta\[name="twitter:description"\]/);
 assert.match(seoLandingPages, /"@type": "Article"/);
 assert.match(seoLandingPages, /"@type": "CollectionPage"/);
 assert.match(seoLandingPages, /"@type": "BreadcrumbList"/);
+assert.match(seoLandingPages, /"@type": "FAQPage"/);
 assert.match(seoLandingPages, /seo-guide-faq/);
 assert.match(seoLandingPages, /seo-guide-section/);
 assert.match(seoLandingContent, /brag document/i);
@@ -125,6 +126,10 @@ assert.doesNotMatch(staticRouteShells, /copyFile\(INDEX_FILE, path\.join\(routeD
 assert.match(staticRouteShells, /NOINDEX_ROUTES = new Set\(\["\/login", "\/register", "\/upgrade", "\/verify-receipt"\]\)/);
 assert.match(staticRouteShells, /noindex,nofollow/);
 assert.ok(staticRouteShells.includes('"/support"'), "the public Support Hub needs a generated static shell");
+assert.match(staticRouteShells, /SEO_LANDING_CONTENT/);
+assert.match(staticRouteShells, /function guideSchema\(route, meta\)/);
+assert.match(staticRouteShells, /boasted-static-content-schema/);
+assert.match(staticRouteShells, /"@type": "FAQPage"/);
 
 for (const path of sitemapPaths) {
   assert.ok(staticRouteShells.includes(`"${path}"`), `${path} must have explicit static title/description metadata`);

--- a/frontend/scripts/verify-search-appearance.mjs
+++ b/frontend/scripts/verify-search-appearance.mjs
@@ -3,6 +3,7 @@ import { readFileSync } from "node:fs";
 
 const read = (path) => readFileSync(new URL(`../${path}`, import.meta.url), "utf8");
 
+const indexHtml = read("index.html");
 const robots = read("public/robots.txt");
 const sitemap = read("public/sitemap.xml");
 const searchMeta = read("src/useSearchAppearanceMeta.js");
@@ -48,6 +49,15 @@ assert.match(robots, /Sitemap:\s+https:\/\/boasted\.io\/sitemap\.xml/);
 assert.match(robots, /Disallow:\s+\/app\//);
 assert.doesNotMatch(robots, /Disallow:\s+\/login/);
 assert.doesNotMatch(robots, /Disallow:\s+\/register/);
+
+// Homepage search identity must stay explicit about the product category and brand.
+assert.match(indexHtml, /<title>Boasted \| Work Accomplishment Tracker & Career Proof<\/title>/);
+assert.match(indexHtml, /work accomplishment tracker and career proof platform/i);
+assert.match(indexHtml, /https:\/\/github\.com\/mergemaven11\/Boasted\.io/);
+assert.doesNotMatch(indexHtml, /<meta\s+name="keywords"/i);
+assert.match(searchMeta, /Boasted \| Work Accomplishment Tracker & Career Proof/);
+assert.match(searchMeta, /work accomplishment tracker and career proof platform/i);
+assert.match(searchMeta, /https:\/\/github\.com\/mergemaven11\/Boasted\.io/);
 
 for (const path of publicSitelinks) {
   const canonicalUrl = `https://boasted.io${path}`;

--- a/frontend/src/SeoLandingPages.jsx
+++ b/frontend/src/SeoLandingPages.jsx
@@ -14,8 +14,10 @@ function setMetaContent(selector, value) {
 
 function installContentSchema({ canonicalUrl, title, content }) {
   const scriptId = "boasted-seo-content-schema";
+  const staticScriptId = "boasted-static-content-schema";
   document.getElementById(scriptId)?.remove();
 
+  if (document.getElementById(staticScriptId)) return () => {};
   if (content.kind !== "guide" && content.kind !== "hub") return () => {};
 
   const organization = { "@id": "https://boasted.io/#organization" };
@@ -57,16 +59,33 @@ function installContentSchema({ canonicalUrl, title, content }) {
         },
       };
 
+  const graph = [
+    primaryNode,
+    {
+      "@type": "BreadcrumbList",
+      "@id": `${canonicalUrl}#breadcrumbs`,
+      itemListElement: breadcrumbItems,
+    },
+  ];
+
+  if (content.kind === "guide" && content.faq?.length) {
+    graph.push({
+      "@type": "FAQPage",
+      "@id": `${canonicalUrl}#faq`,
+      mainEntity: content.faq.map((item) => ({
+        "@type": "Question",
+        name: item.question,
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: item.answer,
+        },
+      })),
+    });
+  }
+
   const schema = {
     "@context": "https://schema.org",
-    "@graph": [
-      primaryNode,
-      {
-        "@type": "BreadcrumbList",
-        "@id": `${canonicalUrl}#breadcrumbs`,
-        itemListElement: breadcrumbItems,
-      },
-    ],
+    "@graph": graph,
   };
 
   const script = document.createElement("script");

--- a/frontend/src/useSearchAppearanceMeta.js
+++ b/frontend/src/useSearchAppearanceMeta.js
@@ -3,8 +3,8 @@ import { PRIMARY_SITELINKS } from "./primarySitelinks.js";
 
 const PUBLIC_META = {
   "/": {
-    title: "Boasted: Save It. Prove It. Use It.",
-    description: "Boasted helps you save your work, wins, projects, skills, and proof in one place, then reuse them for jobs, reviews, promotions, interviews, scholarships, and more.",
+    title: "Boasted | Work Accomplishment Tracker & Career Proof",
+    description: "Boasted is a work accomplishment tracker and career proof platform. Capture wins, results, skills, and evidence, then reuse them for resumes, performance reviews, promotions, interviews, portfolios, and opportunities.",
   },
   "/login": {
     title: "Sign In to Boasted | Career Proof",
@@ -160,7 +160,7 @@ export default function useSearchAppearanceMeta(path) {
           url: "https://boasted.io/",
           name: "Boasted",
           alternateName: ["Boasted.io", "Boasted Career Proof"],
-          description: "Boasted helps people save meaningful work and turn it into reusable career proof.",
+          description: "Boasted is a work accomplishment tracker and career proof platform that helps people capture wins, results, skills, and evidence and reuse them when opportunities arrive.",
           publisher: { "@id": "https://boasted.io/#organization" },
         },
         {
@@ -169,7 +169,7 @@ export default function useSearchAppearanceMeta(path) {
           name: "Boasted",
           alternateName: ["Boasted.io", "Boasted Career Proof"],
           url: "https://boasted.io/",
-          description: "Boasted is career evidence software for capturing accomplishments, outcomes, skills, and proof so people can reuse them when opportunities arrive.",
+          description: "Boasted is a work accomplishment tracker and career proof platform for capturing accomplishments, outcomes, skills, and evidence so people can reuse them when opportunities arrive.",
           founder: { "@id": "https://boasted.io/#founder" },
           logo: {
             "@type": "ImageObject",
@@ -178,6 +178,9 @@ export default function useSearchAppearanceMeta(path) {
             height: 192,
           },
           image: OFFICIAL_LOGO_URL,
+          sameAs: [
+            "https://github.com/mergemaven11/Boasted.io",
+          ],
         },
         {
           "@type": "Person",


### PR DESCRIPTION
## What this changes
- Repositions the homepage title/description around high-intent category language: work accomplishment tracker + career proof
- Strengthens Organization/WebSite/SoftwareApplication structured data for the Boasted entity
- Adds an official GitHub brand reference via `sameAs`
- Removes the obsolete `meta keywords` tag
- Aligns Pro structured pricing with the current complimentary early-access UI
- Refreshes the homepage sitemap `lastmod`
- Adds SEO regression checks so these signals do not silently regress

## Why
Boasted is a recent rebrand from BragStack. The immediate goal is to make the new brand/entity and product category unmistakable to search engines while preserving the existing technical SEO foundation and avoiding keyword stuffing or doorway-page tactics.

## Follow-up
A separate migration/content phase should verify permanent redirects from the former BragStack frontend domain and expand topic-cluster/AEO content after this low-risk foundation ships.